### PR TITLE
chore: disable woocommerce plugin for main demo by default

### DIFF
--- a/onboarding/neve-main/data.json
+++ b/onboarding/neve-main/data.json
@@ -1,1 +1,100 @@
-{"content_file":"https:\/\/demo.themeisle.com\/neve-onboarding\/wp-content\/uploads\/sites\/173\/ti-demo-data\/export.xml","theme_mods":{"neve_last_menu_item":"search-cart","neve_body_font_family":"","neve_body_font_size":"{\"suffix\":{\"mobile\":\"px\",\"tablet\":\"px\",\"desktop\":\"px\"},\"mobile\":16,\"tablet\":16,\"desktop\":15}","neve_navigation_layout":"left","neve_theme_color":"#00a4f7","neve_link_color":"#0366d6","neve_link_hover_color":"#005bf7","neve_top_bar_enable":"","neve_top_bar_layout":"menu-content","neve_default_sidebar_layout":"full-width","neve_blog_archive_sidebar_layout":"full-width","neve_single_post_sidebar_layout":"full-width","neve_footer_content_type":"text","neve_headings_font_family":"","neve_blog_archive_layout":"alternative","neve_sitewide_content_width":75,"neve_post_excerpt_length":70,"neve_advanced_layout_options":true,"neve_blog_archive_content_width":75,"neve_pagination_type":"number","neve_shop_archive_sidebar_layout":"left","neve_single_product_sidebar_layout":"full-width","neve_other_pages_sidebar_layout":"full-width","neve_footer_text":"Original | Powered by <a href=\"http:\/\/wordpress.org\" rel=\"nofollow\">WordPress<\/a>","neve_single_product_content_width":100,"neve_generated_style_version":1551965289,"__ti_import_menus_location":{"primary":"main-menu"}},"widgets":{"blog-sidebar":{"search-2":{"title":""},"recent-posts-2":{"title":"","number":5},"recent-comments-2":{"title":"","number":5},"archives-2":{"title":"","count":0,"dropdown":0},"categories-2":{"title":"","count":0,"hierarchical":0,"dropdown":0},"meta-2":{"title":""}},"shop-sidebar":{"woocommerce_top_rated_products-2":{"title":"Top rated products","number":5},"woocommerce_price_filter-2":{"title":"Filter by price"},"woocommerce_product_categories-2":{"title":"Product categories","orderby":"name","dropdown":0,"count":1,"hierarchical":1,"show_children_only":0,"hide_empty":0,"max_depth":""}}},"recommended_plugins":{"themeisle-companion":"Orbit Fox by ThemeIsle","woocommerce":"WooCommerce"},"mandatory_plugins":{"elementor":"Elementor Page Builder"},"front_page":{"front_page":"neve-home","blog_page":"neve-blog"},"shop_pages":{"woocommerce_shop_page_id":"shop","woocommerce_cart_page_id":"cart","woocommerce_checkout_page_id":"checkout","woocommerce_myaccount_page_id":"my-account"}}
+{
+  "content_file": "https:\/\/demo.themeisle.com\/neve-onboarding\/wp-content\/uploads\/sites\/173\/ti-demo-data\/export.xml",
+  "theme_mods": {
+    "neve_last_menu_item": "search-cart",
+    "neve_body_font_family": "",
+    "neve_body_font_size": "{\"suffix\":{\"mobile\":\"px\",\"tablet\":\"px\",\"desktop\":\"px\"},\"mobile\":16,\"tablet\":16,\"desktop\":15}",
+    "neve_navigation_layout": "left",
+    "neve_theme_color": "#00a4f7",
+    "neve_link_color": "#0366d6",
+    "neve_link_hover_color": "#005bf7",
+    "neve_top_bar_enable": "",
+    "neve_top_bar_layout": "menu-content",
+    "neve_default_sidebar_layout": "full-width",
+    "neve_blog_archive_sidebar_layout": "full-width",
+    "neve_single_post_sidebar_layout": "full-width",
+    "neve_footer_content_type": "text",
+    "neve_headings_font_family": "",
+    "neve_blog_archive_layout": "alternative",
+    "neve_sitewide_content_width": 75,
+    "neve_post_excerpt_length": 70,
+    "neve_advanced_layout_options": true,
+    "neve_blog_archive_content_width": 75,
+    "neve_pagination_type": "number",
+    "neve_shop_archive_sidebar_layout": "left",
+    "neve_single_product_sidebar_layout": "full-width",
+    "neve_other_pages_sidebar_layout": "full-width",
+    "neve_footer_text": "Original | Powered by <a href=\"http:\/\/wordpress.org\" rel=\"nofollow\">WordPress<\/a>",
+    "neve_single_product_content_width": 100,
+    "neve_generated_style_version": 1551965289,
+    "__ti_import_menus_location": {
+      "primary": "main-menu"
+    }
+  },
+  "widgets": {
+    "blog-sidebar": {
+      "search-2": {
+        "title": ""
+      },
+      "recent-posts-2": {
+        "title": "",
+        "number": 5
+      },
+      "recent-comments-2": {
+        "title": "",
+        "number": 5
+      },
+      "archives-2": {
+        "title": "",
+        "count": 0,
+        "dropdown": 0
+      },
+      "categories-2": {
+        "title": "",
+        "count": 0,
+        "hierarchical": 0,
+        "dropdown": 0
+      },
+      "meta-2": {
+        "title": ""
+      }
+    },
+    "shop-sidebar": {
+      "woocommerce_top_rated_products-2": {
+        "title": "Top rated products",
+        "number": 5
+      },
+      "woocommerce_price_filter-2": {
+        "title": "Filter by price"
+      },
+      "woocommerce_product_categories-2": {
+        "title": "Product categories",
+        "orderby": "name",
+        "dropdown": 0,
+        "count": 1,
+        "hierarchical": 1,
+        "show_children_only": 0,
+        "hide_empty": 0,
+        "max_depth": ""
+      }
+    }
+  },
+  "recommended_plugins": {
+    "themeisle-companion": "Orbit Fox by ThemeIsle",
+    "woocommerce": "WooCommerce"
+  },
+  "default_off_recommended_plugins": [ "woocommerce" ],
+  "mandatory_plugins": {
+    "elementor": "Elementor Page Builder"
+  },
+  "front_page": {
+    "front_page": "neve-home",
+    "blog_page": "neve-blog"
+  },
+  "shop_pages": {
+    "woocommerce_shop_page_id": "shop",
+    "woocommerce_cart_page_id": "cart",
+    "woocommerce_checkout_page_id": "checkout",
+    "woocommerce_myaccount_page_id": "my-account"
+  }
+}


### PR DESCRIPTION
@rodica-andronache I've added the functionality to the onboarding and disabled woo by default on the main demo in this commit. Right now, I didn't add anything to the demo export plugin so we have to be careful until then to not delete this line. :))