### PR TITLE
chore: hide responsive switches for HFG components [closes #701]

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -165,6 +165,7 @@ abstract class Abstract_Component implements Component {
 	 *
 	 * @since   1.0.0
 	 * @access  protected
+	 *
 	 * @param string $const Name of the constant.
 	 *
 	 * @return mixed
@@ -173,6 +174,7 @@ abstract class Abstract_Component implements Component {
 		if ( defined( 'static::' . $const ) ) {
 			return constant( 'static::' . $const );
 		}
+
 		return '';
 	}
 
@@ -180,7 +182,7 @@ abstract class Abstract_Component implements Component {
 	 * Method to filter component loading if needed.
 	 *
 	 * @since   1.0.1
-	 * @access public
+	 * @access  public
 	 * @return bool
 	 */
 	public function is_active() {
@@ -324,9 +326,10 @@ abstract class Abstract_Component implements Component {
 				'label'             => __( 'Padding', 'neve' ),
 				'type'              => '\HFG\Core\Customizer\SpacingControl',
 				'options'           => [
-					'linked_choices' => true,
-					'unit_choices'   => array( 'px', 'em', '%' ),
-					'choices'        => array(
+					'hide_responsive_switches' => true,
+					'linked_choices'           => true,
+					'unit_choices'             => array( 'px', 'em', '%' ),
+					'choices'                  => array(
 						'top'    => __( 'Top', 'neve' ),
 						'right'  => __( 'Right', 'neve' ),
 						'bottom' => __( 'Bottom', 'neve' ),
@@ -370,9 +373,10 @@ abstract class Abstract_Component implements Component {
 				'label'             => __( 'Margin', 'neve' ),
 				'type'              => '\HFG\Core\Customizer\SpacingControl',
 				'options'           => [
-					'linked_choices' => true,
-					'unit_choices'   => array( 'px', 'em', '%' ),
-					'choices'        => array(
+					'hide_responsive_switches' => true,
+					'linked_choices'           => true,
+					'unit_choices'             => array( 'px', 'em', '%' ),
+					'choices'                  => array(
 						'top'    => __( 'Top', 'neve' ),
 						'right'  => __( 'Right', 'neve' ),
 						'bottom' => __( 'Bottom', 'neve' ),
@@ -457,12 +461,13 @@ abstract class Abstract_Component implements Component {
 	 *
 	 * @since   1.0.1
 	 * @access  protected
+	 *
 	 * @param string $target CSS target property ( margin | padding ).
-	 * @param string $top Top value.
-	 * @param string $right Right value.
+	 * @param string $top    Top value.
+	 * @param string $right  Right value.
 	 * @param string $bottom Bottom value.
-	 * @param string $left Left value.
-	 * @param string $unit Unit to use ( px | em | % ).
+	 * @param string $left   Left value.
+	 * @param string $unit   Unit to use ( px | em | % ).
 	 *
 	 * @return array
 	 */
@@ -478,6 +483,7 @@ abstract class Abstract_Component implements Component {
 				$result[ $target . '-' . $pos ] = $value . $unit;
 			}
 		}
+
 		return $result;
 	}
 
@@ -486,10 +492,11 @@ abstract class Abstract_Component implements Component {
 	 *
 	 * @since   1.0.1
 	 * @access  protected
-	 * @param array  $css_array The css array.
+	 *
+	 * @param array  $css_array       The css array.
 	 * @param array  $position_values The position values array.
-	 * @param string $selector The item selector.
-	 * @param string $type The type to generate ( margin | padding ).
+	 * @param string $selector        The item selector.
+	 * @param string $type            The type to generate ( margin | padding ).
 	 *
 	 * @return mixed
 	 */
@@ -507,6 +514,7 @@ abstract class Abstract_Component implements Component {
 				$css_array[ $media_selector ][ $selector ] = array_merge( $css_array[ $media_selector ][ $selector ], $position_filter );
 			}
 		}
+
 		return $css_array;
 	}
 

--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -106,10 +106,11 @@ class Logo extends Abstract_Component {
 				'label'             => __( 'Logo max width (px)', 'neve' ),
 				'type'              => '\Neve\Customizer\Controls\Range',
 				'options'           => [
-					'type'        => 'range-value',
-					'media_query' => true,
-					'step'        => 1,
-					'input_attr'  => [
+					'type'                     => 'range-value',
+					'hide_responsive_switches' => true,
+					'media_query'              => true,
+					'step'                     => 1,
+					'input_attr'               => [
 						'mobile'  => [
 							'min'     => 0,
 							'max'     => 350,

--- a/header-footer-grid/Core/Customizer/SpacingControl.php
+++ b/header-footer-grid/Core/Customizer/SpacingControl.php
@@ -41,6 +41,14 @@ class SpacingControl extends WP_Customize_Control {
 	 * @var array
 	 */
 	public $unit_choices = array( 'px' => 'px' );
+
+	/**
+	 * Hide the responsive switches.
+	 *
+	 * @var bool
+	 */
+	public $hide_responsive_switches = false;
+
 	/**
 	 * Enqueue control related scripts/styles.
 	 *
@@ -48,9 +56,19 @@ class SpacingControl extends WP_Customize_Control {
 	 */
 	public function enqueue() {
 		$base = Config::get_url() . '/Core/Customizer/';
-		wp_enqueue_script( 'hfg-responsive-spacing', $base . 'responsive-spacing.js', array( 'jquery', 'customize-base' ), NEVE_VERSION, true );
+		wp_enqueue_script(
+			'hfg-responsive-spacing',
+			$base . 'responsive-spacing.js',
+			array(
+				'jquery',
+				'customize-base',
+			),
+			NEVE_VERSION,
+			true 
+		);
 		wp_enqueue_style( 'hfg-responsive-spacing', $base . 'responsive-spacing.css', null, NEVE_VERSION );
 	}
+
 	/**
 	 * Refresh the parameters passed to the JavaScript via JSON.
 	 *
@@ -99,14 +117,15 @@ class SpacingControl extends WP_Customize_Control {
 				$val[ $unit_key ] = $unit_value;
 			}
 		}
-		$json['value']          = $val;
-		$json['choices']        = $this->choices;
-		$json['link']           = $this->get_link();
-		$json['id']             = $this->id;
-		$json['label']          = esc_html( $this->label );
-		$json['linked_choices'] = $this->linked_choices;
-		$json['unit_choices']   = $this->unit_choices;
-		$json['inputAttrs']     = '';
+		$json['value']                    = $val;
+		$json['choices']                  = $this->choices;
+		$json['link']                     = $this->get_link();
+		$json['id']                       = $this->id;
+		$json['label']                    = esc_html( $this->label );
+		$json['linked_choices']           = $this->linked_choices;
+		$json['unit_choices']             = $this->unit_choices;
+		$json['inputAttrs']               = '';
+		$json['hide_responsive_switches'] = $this->hide_responsive_switches;
 		foreach ( $this->input_attrs as $attr => $value ) {
 			$json['inputAttrs'] .= $attr . '="' . esc_attr( $value ) . '" ';
 		}
@@ -114,13 +133,14 @@ class SpacingControl extends WP_Customize_Control {
 
 		return $json;
 	}
+
 	/**
 	 * An Underscore (JS) template for this control's content (but not its container).
 	 *
 	 * Class variables for this control class are available in the `data` JS object;
 	 * export custom variables by overriding {@see WP_Customize_Control::to_json()}.
 	 *
-	 * @see WP_Customize_Control::print_template()
+	 * @see    WP_Customize_Control::print_template()
 	 *
 	 * @access protected
 	 */
@@ -143,11 +163,12 @@ class SpacingControl extends WP_Customize_Control {
 		mobile_unit_val = data.value['mobile-unit'];
 		}
 		#>
-		<label class='hfg-spacing-responsive' for="" >
+		<label class='hfg-spacing-responsive' for="">
 			<div class="hfg-spacing-header">
 				<# if ( data.label ) { #>
 				<span class="customize-control-title">{{{ data.label }}}</span>
 				<# } #>
+				<# if( data.hide_responsive_switches === false ) { #>
 				<ul class="hfg-spacing-responsive-btns">
 					<li class="desktop active">
 						<button type="button" class="preview-desktop active" data-device="desktop">
@@ -165,12 +186,15 @@ class SpacingControl extends WP_Customize_Control {
 						</button>
 					</li>
 				</ul>
-
+				<# } #>
 				<div class="hfg-spacing-responsive-units-screen-wrap">
 					<div class="unit-input-wrapper hfg-spacing-unit-wrapper">
-						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-desktop-unit' data-device='desktop' value='{{desktop_unit_val}}'>
-						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-tablet-unit' data-device='tablet' value='{{tablet_unit_val}}'>
-						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-mobile-unit' data-device='mobile' value='{{mobile_unit_val}}'>
+						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-desktop-unit'
+								data-device='desktop' value='{{desktop_unit_val}}'>
+						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-tablet-unit' data-device='tablet'
+								value='{{tablet_unit_val}}'>
+						<input type='hidden' class='hfg-spacing-unit-input hfg-spacing-mobile-unit' data-device='mobile'
+								value='{{mobile_unit_val}}'>
 					</div>
 				</div>
 
@@ -181,9 +205,11 @@ class SpacingControl extends WP_Customize_Control {
 						if ( desktop_unit_val === unit_key ) {
 						unit_class = 'active';
 						}
-						#><li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}' >
+						#>
+						<li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}'>
 							<span class="unit-text">{{{ unit_key }}}</span>
-						</li><#
+						</li>
+						<#
 						});#>
 					</ul>
 					<ul class="hfg-spacing-responsive-units hfg-spacing-tablet-responsive-units">
@@ -192,9 +218,11 @@ class SpacingControl extends WP_Customize_Control {
 						if ( tablet_unit_val === unit_key ) {
 						unit_class = 'active';
 						}
-						#><li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}' >
+						#>
+						<li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}'>
 							<span class="unit-text">{{{ unit_key }}}</span>
-						</li><#
+						</li>
+						<#
 						});#>
 					</ul>
 					<ul class="hfg-spacing-responsive-units hfg-spacing-mobile-responsive-units">
@@ -203,9 +231,11 @@ class SpacingControl extends WP_Customize_Control {
 						if ( mobile_unit_val === unit_key ) {
 						unit_class = 'active';
 						}
-						#><li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}' >
+						#>
+						<li class='single-unit {{ unit_class }}' data-unit='{{ unit_key }}'>
 							<span class="unit-text">{{{ unit_key }}}</span>
-						</li><#
+						</li>
+						<#
 						});#>
 					</ul>
 				</div>
@@ -217,8 +247,8 @@ class SpacingControl extends WP_Customize_Control {
 			<div class="hfg-spacing-responsive-outer-wrapper">
 				<#
 				value_desktop = '';
-				value_tablet  = '';
-				value_mobile  = '';
+				value_tablet = '';
+				value_mobile = '';
 
 				if ( data.value['desktop'] ) {
 				value_desktop = data.value['desktop'];
@@ -236,15 +266,21 @@ class SpacingControl extends WP_Customize_Control {
 					<ul class="hfg-spacing-wrapper desktop active"><#
 						if ( data.linked_choices ) { #>
 						<li class="hfg-spacing-input-item-link">
-							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-						</li><#
+							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+						</li>
+						<#
 						}
 						_.each( data.choices, function( choiceLabel, choiceID ) {
-						#><li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
-							<input type='number' class='hfg-spacing-input hfg-spacing-desktop' data-id= '{{ choiceID }}' value='{{ value_desktop[ choiceID ] }}'>
+						#>
+						<li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
+							<input type='number' class='hfg-spacing-input hfg-spacing-desktop' data-id='{{ choiceID }}'
+									value='{{ value_desktop[ choiceID ] }}'>
 							<span class="hfg-spacing-title">{{{ data.choices[ choiceID ] }}}</span>
-						</li><#
+						</li>
+						<#
 						}); #>
 						<li class="hfg-spacing-input-item-reset">
 							<span class="dashicons dashicons-image-rotate" data-device='desktop'></span>
@@ -256,15 +292,21 @@ class SpacingControl extends WP_Customize_Control {
 
 						if ( data.linked_choices ) { #>
 						<li class="hfg-spacing-input-item-link">
-							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-						</li><#
+							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+						</li>
+						<#
 						}
 						_.each( data.choices, function( choiceLabel, choiceID ) {
-						#><li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
-							<input type='number' class='hfg-spacing-input hfg-spacing-tablet' data-id='{{ choiceID }}' value='{{ value_tablet[ choiceID ] }}'>
+						#>
+						<li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
+							<input type='number' class='hfg-spacing-input hfg-spacing-tablet' data-id='{{ choiceID }}'
+									value='{{ value_tablet[ choiceID ] }}'>
 							<span class="hfg-spacing-title">{{{ data.choices[ choiceID ] }}}</span>
-						</li><#
+						</li>
+						<#
 						}); #>
 						<li class="hfg-spacing-input-item-reset">
 							<span class="dashicons dashicons-image-rotate" data-device='tablet'></span>
@@ -275,15 +317,21 @@ class SpacingControl extends WP_Customize_Control {
 					<ul class="hfg-spacing-wrapper mobile"><#
 						if ( data.linked_choices ) { #>
 						<li class="hfg-spacing-input-item-link">
-							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected" data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
-						</li><#
+							<span class="dashicons dashicons-admin-links hfg-spacing-connected wp-ui-highlight"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+							<span class="dashicons dashicons-editor-unlink hfg-spacing-disconnected"
+									data-element-connect="{{ data.id }}" title="{{ data.title }}"></span>
+						</li>
+						<#
 						}
 						_.each( data.choices, function( choiceLabel, choiceID ) {
-						#><li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
-							<input type='number' class='hfg-spacing-input hfg-spacing-mobile' data-id='{{ choiceID }}' value='{{ value_mobile[ choiceID ] }}'>
+						#>
+						<li {{{ data.inputAttrs }}} class='hfg-spacing-input-item'>
+							<input type='number' class='hfg-spacing-input hfg-spacing-mobile' data-id='{{ choiceID }}'
+									value='{{ value_mobile[ choiceID ] }}'>
 							<span class="hfg-spacing-title">{{{ data.choices[ choiceID ] }}}</span>
-						</li><#
+						</li>
+						<#
 						}); #>
 						<li class="hfg-spacing-input-item-reset">
 							<span class="dashicons dashicons-image-rotate" data-device='mobile'></span>
@@ -296,10 +344,12 @@ class SpacingControl extends WP_Customize_Control {
 
 		<?php
 	}
+
 	/**
 	 * Render the control's content.
 	 *
 	 * @see WP_Customize_Control::render_content()
 	 */
-	protected function render_content() {}
+	protected function render_content() {
+	}
 }

--- a/inc/customizer/controls/range.php
+++ b/inc/customizer/controls/range.php
@@ -51,6 +51,13 @@ class Range extends \WP_Customize_Control {
 	public $sum_type = false;
 
 	/**
+	 * Hide the responsive switches
+	 *
+	 * @var bool
+	 */
+	public $hide_responsive_switches = false;
+
+	/**
 	 * Range constructor.
 	 *
 	 * @param \WP_Customize_Manager $manager Customize manager.
@@ -70,12 +77,13 @@ class Range extends \WP_Customize_Control {
 	public function json() {
 		$json = parent::json();
 
-		$json['value']       = json_decode( $this->value(), true );
-		$json['link']        = $this->get_link();
-		$json['media_query'] = $this->media_query;
-		$json['step']        = $this->step;
-		$json['sum_type']    = $this->sum_type;
-		$json['inputAttr']   = $this->input_attr;
+		$json['value']                    = json_decode( $this->value(), true );
+		$json['link']                     = $this->get_link();
+		$json['media_query']              = $this->media_query;
+		$json['step']                     = $this->step;
+		$json['sum_type']                 = $this->sum_type;
+		$json['inputAttr']                = $this->input_attr;
+		$json['hide_responsive_switches'] = $this->hide_responsive_switches;
 
 		return $json;
 	}
@@ -93,7 +101,7 @@ class Range extends \WP_Customize_Control {
 							title="{{{ data.description }}}"></i>
 				<# } #>
 		</span>
-		<# if( data.media_query === true ) { #>
+		<# if( data.media_query === true && data.hide_responsive_switches === false ) { #>
 		<?php $this->render_responsive_switches(); ?>
 		<# } #>
 		<# } #>
@@ -153,15 +161,15 @@ class Range extends \WP_Customize_Control {
 			>
 			<input
 			<# if( data.sum_type ) { #>
-					readonly
+			readonly
 			<# } #>
-					class="range-slider-value"
-					type="{{type}}"
-					title="{{{data.label}}}"
-					min="{{attr.min}}"
-					max="{{attr.max}}"
-					step="{{data.step}}"
-					value="{{ value }}"
+			class="range-slider-value"
+			type="{{type}}"
+			title="{{{data.label}}}"
+			min="{{attr.min}}"
+			max="{{attr.max}}"
+			step="{{data.step}}"
+			value="{{ value }}"
 			>
 			<span class="range-reset-slider"><span class="dashicons dashicons-image-rotate"></span></span>
 		</div>


### PR DESCRIPTION
### Summary
Hides responsive switchers for HFG components.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- See if responsive switches are properly hidden.
- See that everything still works by switching from the customizer sidebar
- See that the rows still work.
- Check with the pro components from this PR: Codeinwp/neve-pro-addon#268

<!-- Issues that this pull request closes. -->
Closes #701.
<!-- Should look like this: `Closes #1, #2, #3.` . -->