### PR TITLE
fix: useless escaping for the archive post inner content [fix #733]

### DIFF
--- a/views/archive-post.php
+++ b/views/archive-post.php
@@ -8,18 +8,7 @@
 <article id="<?php echo esc_attr( $args['post_id'] ); ?>" class="<?php echo esc_attr( $args['post_class'] ); ?>">
 	<div class="article-content-col">
 		<div class="content">
-			<?php
-			echo neve_custom_kses_escape( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-				$args['content'],
-				array(
-					'time' => array(
-						'class'    => true,
-						'datetime' => true,
-						'content'  => true,
-					),
-				)
-			);
-			?>
+			<?php echo $args['content'];  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		</div>
 	</div>
 </article>


### PR DESCRIPTION
### Summary
Remove escaping from article inner-content.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

<!-- Issues that this pull request closes. -->
Closes #733.
<!-- Should look like this: `Closes #1, #2, #3.` . -->