### PR TITLE
fix: hiding thumb hides title when hide title metabox option is enabled

### DIFF
--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -50,16 +50,14 @@ class Post_Layout extends Base_View {
 			$content_order = json_encode( $default_order );
 		}
 		$content_order = json_decode( $content_order, true );
-
 		if ( apply_filters( 'neve_filter_toggle_content_parts', true, 'title' ) !== true ) {
-			unset( $content_order[ array_search( 'title-meta', $content_order, true ) ] );
+			$title_key = array_search( 'title-meta', $content_order, true );
+			if ( $title_key !== false ) {
+				unset( $content_order[ $title_key ] );
+			}
 		}
 
-		if ( apply_filters( 'neve_filter_toggle_content_parts', true, 'featured-image' ) !== true ) {
-			unset( $content_order[ array_search( 'thumbnail', $content_order, true ) ] );
-		}
-
-		if ( ! has_post_thumbnail() ) {
+		if ( apply_filters( 'neve_filter_toggle_content_parts', true, 'featured-image' ) !== true || ! has_post_thumbnail() ) {
 			$thumb_index = array_search( 'thumbnail', $content_order, true );
 			if ( $thumb_index !== false ) {
 				unset( $content_order[ $thumb_index ] );


### PR DESCRIPTION
### Summary
Fixed conflict between metabox and content ordering (false was being used as `0` array key)
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Disable the post thumbnail from the metabox for a post
- Disable the thumbnail from single post content ordering
- The title should be there.

<!-- Issues that this pull request closes. -->
Closes #731.
<!-- Should look like this: `Closes #1, #2, #3.` . -->