### PR TITLE
chore: move after/before content hooks in hook list to Single

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -42,9 +42,11 @@ function neve_hooks() {
 		),
 		'page'       => array(
 			'neve_before_page_header',
+			'neve_before_page_comments',
+		),
+		'single'     => array(
 			'neve_before_content',
 			'neve_after_content',
-			'neve_before_page_comments',
 		),
 		'sidebar'    => array(
 			'neve_before_sidebar_content',
@@ -84,7 +86,7 @@ function neve_cart_icon( $echo = false ) {
 /**
  * Search Icon
  *
- * @param bool $echo should be echoed.
+ * @param bool $echo      should be echoed.
  * @param bool $amp_ready Should we add the AMP binding.
  *
  * @return string


### PR DESCRIPTION
### Summary
move after/before content hooks in hook list to Single
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Test with custom layouts from Neve Pro

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#322
<!-- Should look like this: `Closes #1, #2, #3.` . -->