### PR TITLE
chore: fix typography control on WP 5.3

### DIFF
--- a/inc/customizer/controls/react/bundle/controls.css
+++ b/inc/customizer/controls/react/bundle/controls.css
@@ -206,6 +206,7 @@
     overflow: hidden;
     text-overflow: ellipsis; }
   .neve-typeface-control .font-family-selector-toggle .ff-preview {
+    line-height: initial;
     align-self: flex-end;
     margin-left: auto;
     font-size: 21px; }

--- a/inc/customizer/controls/react/src/style.scss
+++ b/inc/customizer/controls/react/src/style.scss
@@ -330,6 +330,7 @@
 		}
 
 		.ff-preview {
+			line-height: initial;
 			align-self: flex-end;
 			margin-left: auto;
 			font-size: 21px;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fix line height in font-family control.

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

<!-- Issues that this pull request closes. -->
Closes #936.
<!-- Should look like this: `Closes #1, #2, #3.` . -->