### PR TITLE
chore: drop last menu item if it's disabled or not in use

### DIFF
--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -51,8 +51,6 @@ class Nav extends Abstract_Component {
 				'filter_neve_last_menu_setting_slug',
 			)
 		);
-
-		add_action( 'init', array( $this, 'map_last_menu_item' ) );
 	}
 
 	/**
@@ -285,31 +283,4 @@ class Nav extends Abstract_Component {
 
 		return parent::add_style( $css_array );
 	}
-
-	/**
-	 * Map last menu item from select type control to ordering control.
-	 */
-	public function map_last_menu_item() {
-		$map_items = get_option( 'neve_map_menu_items' );
-		if ( $map_items === 'yes' ) {
-			return;
-		}
-		$default_last = 'search';
-		if ( class_exists( 'WooCommerce', false ) ) {
-			$default_last = 'search-cart';
-		}
-
-		$last_menu_item       = get_theme_mod( 'neve_last_menu_item', $default_last );
-		$last_menu_item_value = array();
-		if ( $last_menu_item === 'search-cart' ) {
-			$last_menu_item_value = array( 'search', 'cart' );
-		}
-		if ( $last_menu_item === 'search' || $last_menu_item === 'cart' ) {
-			$last_menu_item_value = array( $last_menu_item );
-		}
-
-		set_theme_mod( 'neve_last_menu_item', json_encode( $last_menu_item_value ) );
-		update_option( 'neve_map_menu_items', 'yes' );
-	}
-
 }

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -171,23 +171,31 @@ class Nav extends Abstract_Component {
 
 		$components = apply_filters( 'neve_last_menu_item_components', $components );
 
-		SettingsManager::get_instance()->add(
-			[
-				'id'                => $this->get_class_const( 'LAST_ITEM_ID' ),
-				'group'             => $this->get_class_const( 'COMPONENT_ID' ),
-				'tab'               => SettingsManager::TAB_GENERAL,
-				'noformat'          => true,
-				'transport'         => 'post' . $this->get_class_const( 'COMPONENT_ID' ),
-				'sanitize_callback' => array( $this, 'sanitize_last_menu_item' ),
-				'default'           => json_encode( $order_default_components ),
-				'label'             => __( 'Last Menu Item', 'neve' ),
-				'type'              => 'Neve\Customizer\Controls\Ordering',
-				'options'           => [
-					'components' => $components,
-				],
-				'section'           => $this->section,
-			]
-		);
+		/**
+		 * Last menu item removed for new users and users who didn't have it set.
+		 *
+		 * @since 2.5.3
+		 */
+		$old_last_menu_item = json_decode( get_theme_mod( 'neve_last_menu_item' ) );
+		if ( $old_last_menu_item !== false && ! empty( $old_last_menu_item ) ) {
+			SettingsManager::get_instance()->add(
+				[
+					'id'                => $this->get_class_const( 'LAST_ITEM_ID' ),
+					'group'             => $this->get_class_const( 'COMPONENT_ID' ),
+					'tab'               => SettingsManager::TAB_GENERAL,
+					'noformat'          => true,
+					'transport'         => 'post' . $this->get_class_const( 'COMPONENT_ID' ),
+					'sanitize_callback' => array( $this, 'sanitize_last_menu_item' ),
+					'default'           => json_encode( $order_default_components ),
+					'label'             => __( 'Last Menu Item', 'neve' ),
+					'type'              => 'Neve\Customizer\Controls\Ordering',
+					'options'           => [
+						'components' => $components,
+					],
+					'section'           => $this->section,
+				]
+			);
+		}
 		SettingsManager::get_instance()->add(
 			[
 				'id'                => 'shortcut',

--- a/inc/views/header.php
+++ b/inc/views/header.php
@@ -77,13 +77,7 @@ class Header extends Base_View {
 	 * @return string
 	 */
 	private function get_last_menu_item_setting() {
-		$default = array(
-			'search',
-		);
-		if ( class_exists( 'WooCommerce', false ) ) {
-			array_push( $default, 'cart' );
-		}
-
+		$default           = array();
 		$current_component = 'default';
 		if ( isset( Nav::$current_component ) ) {
 			$current_component = Nav::$current_component;


### PR DESCRIPTION
### Summary
Removes last menu item if it was never changed or it's empty.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- By default, the setting should not appear.
- If you migrate from an older version with it set up to something, it should be there.
- If you migrate from an older version with it empty or with the default value, it shouldn't appear.

<!-- Issues that this pull request closes. -->
Closes #993.
<!-- Should look like this: `Closes #1, #2, #3.` . -->