### PR TITLE
fix: getting post meta value for single meta-box

### DIFF
--- a/inc/admin/metabox/controls/control_base.php
+++ b/inc/admin/metabox/controls/control_base.php
@@ -149,6 +149,7 @@ abstract class Control_Base {
 		if ( isset( $_POST[ $this->id ] ) ) {
 			$value = wp_unslash( $_POST[ $this->id ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			update_post_meta( $post_id, $this->id, $this->sanitize_value( $value ) );
+
 			return;
 		} else {
 			if ( $this->type === 'checkbox' ) {
@@ -186,25 +187,29 @@ abstract class Control_Base {
 				return sanitize_text_field( $value );
 				break;
 			case 'range':
-				return absint( $value );
+				return sanitize_text_field( $value );
 				break;
 			case 'input':
-				return esc_url( $value );
+				return sanitize_text_field( $value );
 				break;
 			case 'separator':
 			default:
 				break;
 		}
+
+		return sanitize_text_field( $value );
 	}
 
 	/**
 	 * Get the value.
 	 *
+	 * @param int $post_id the post id.
+	 *
 	 * @return mixed
 	 */
 	final protected function get_value( $post_id ) {
-		$values = get_post_meta( $post_id );
+		$value = get_post_meta( $post_id, $this->id, true );
 
-		return isset( $values[ $this->id ] ) ? esc_attr( $values[ $this->id ][0] ) : $this->settings['default'];
+		return ! empty( $value ) ? $value : $this->settings['default'];
 	}
 }


### PR DESCRIPTION
### Summary
Changed the meta getting method for meta-box settings to pull only single meta values.

The data inconsistencies were coming from the checks, as meta might've been set but it was `''`. I previously made it verify if the value was set with `isset` in the meta array. 

That yielded that on the next save the value becomes `0`. 

The range and number input have a `min=50`, so the browser couldn't validate the value for that input, hence the error. 

cc @stefan-cotitosu this is going to fix #1026.

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

<!-- Issues that this pull request closes. -->
Closes #1026.
<!-- Should look like this: `Closes #1, #2, #3.` . -->