### PR TITLE
chore: do not create useless meta for posts / pages in DB [fixes #821]

### DIFF
--- a/inc/admin/metabox/controls/control_base.php
+++ b/inc/admin/metabox/controls/control_base.php
@@ -147,18 +147,23 @@ abstract class Control_Base {
 			return;
 		}
 		if ( isset( $_POST[ $this->id ] ) ) {
-			$value = wp_unslash( $_POST[ $this->id ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			update_post_meta( $post_id, $this->id, $this->sanitize_value( $value ) );
-
-			return;
-		} else {
-			if ( $this->type === 'checkbox' ) {
-				update_post_meta( $post_id, $this->id, $this->sanitize_value( 'off' ) );
+			$value = $this->sanitize_value( wp_unslash( $_POST[ $this->id ] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			// Remove post meta on default.
+			if ( $value === $this->settings['default'] ) {
+				delete_post_meta( $post_id, $this->id );
 
 				return;
 			}
+			// Update post meta on other values.
+			update_post_meta( $post_id, $this->id, $value );
+
+			return;
+		} else {
+			// Delete on unset.
+			delete_post_meta( $post_id, $this->id );
+
+			return;
 		}
-		delete_post_meta( $post_id, $this->id );
 	}
 
 	/**
@@ -187,7 +192,7 @@ abstract class Control_Base {
 				return sanitize_text_field( $value );
 				break;
 			case 'range':
-				return sanitize_text_field( $value );
+				return absint( $value );
 				break;
 			case 'input':
 				return sanitize_text_field( $value );

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -297,7 +297,7 @@ class Metabox_Settings {
 			return 100;
 		}
 
-		return '';
+		return 70;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Make sure we don't insert useless meta in the database.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO (at least shouldn't be)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if everything works properly with the meta box.
- Should still work with Pro [we have an additional field for product video there]
- New posts should not insert any meta from the meta box in the DB
- New pages insert content width `100` and Sidebar `full-width`

<!-- Issues that this pull request closes. -->
Closes #821.
<!-- Should look like this: `Closes #1, #2, #3.` . -->