### PR TITLE
Fix style for metabox range input in Firefox [closes #1098]

### DIFF
--- a/header-footer-grid/templates/components/component-footer-sidebar.php
+++ b/header-footer-grid/templates/components/component-footer-sidebar.php
@@ -28,7 +28,7 @@ if ( is_active_sidebar( $_id ) ) {
 					'<p>%s</p>',
 					sprintf(
 						/* translators: %s - customizer link */
-							esc_html( 'Replace this widget content by going to %s and add widgets into this widget area.', 'neve' ),
+						esc_html( 'Replace this widget content by going to %s and add widgets into this widget area.', 'neve' ),
 						sprintf(
 							/* translators: %1$s - link %2$s - name %3$s - label */
 							'<a href="%1$s"><strong>%2$s  %3$s</strong></a>',

--- a/inc/admin/metabox/controls/range.php
+++ b/inc/admin/metabox/controls/range.php
@@ -37,22 +37,28 @@ class Range extends Control_Base {
 			$class      .= ' neve-dependent';
 		}
 
-		$markup = '<style>.neve-range-input{display: flex; align-items: center; justify-content: space-between;}.neve-range-input.neve-hidden{display: none;}</style>';
+		$markup = '
+<style>
+.neve-range-input{display: flex; align-items: center;}
+.neve-range-input .nv-range{flex-grow: 1; margin-right: 5px;}
+.neve-range-input .nv-number{min-width: 0; margin-left: auto;}
+.neve-range-input.neve-hidden{display: none;}
+</style>';
 
 		$markup .= '<p class="' . esc_attr( $class ) . '" ' . esc_attr( $dependency ) . ' >';
-		$markup .= '<input type="range" 
-		value="' . esc_attr( $value ) . '" 
+		$markup .= '<input type="range"
+		value="' . esc_attr( $value ) . '"
 		id="' . esc_attr( $this->id ) . '-range' . '"
-		class="nv-range" 
-		name="' . esc_attr( $this->id ) . '" 
-		min="' . esc_attr( $this->settings['min'] ) . '" 
+		class="nv-range"
+		name="' . esc_attr( $this->id ) . '"
+		min="' . esc_attr( $this->settings['min'] ) . '"
 		max="' . esc_attr( $this->settings['max'] ) . '" >';
-		$markup .= '<input type="number" 
-		value="' . esc_attr( $value ) . '" 
-		id="' . esc_attr( $this->id ) . '" 
-		class="nv-number" 
-		name="' . esc_attr( $this->id ) . '" 
-		min="' . esc_attr( $this->settings['min'] ) . '" 
+		$markup .= '<input type="number"
+		value="' . esc_attr( $value ) . '"
+		id="' . esc_attr( $this->id ) . '"
+		class="nv-number"
+		name="' . esc_attr( $this->id ) . '"
+		min="' . esc_attr( $this->settings['min'] ) . '"
 		max="' . esc_attr( $this->settings['max'] ) . '" >';
 		$markup .= '</p>';
 


### PR DESCRIPTION
### Summary
Fixes style for metabox range input in Firefox.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Screenshots <!-- if applicable -->
Tested with _Chrome / Safari / Firefox_
![image](https://user-images.githubusercontent.com/15010186/72902363-01710800-3d34-11ea-9875-2afd6fedc1a6.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go inside the editor
- Check the metabox options
- Individual content width should look fine in Firefox / Safari / Chrome (like the screenshot above)

<!-- Issues that this pull request closes. -->
Closes #1098.
<!-- Should look like this: `Closes #1, #2, #3.` . -->