### PR TITLE
Fix/selective non header

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -11,6 +11,7 @@
 
 namespace HFG\Core\Components;
 
+use HFG\Core\Builder\Abstract_Builder;
 use HFG\Core\Interfaces\Component;
 use HFG\Core\Settings;
 use HFG\Core\Settings\Manager as SettingsManager;
@@ -570,8 +571,8 @@ abstract class Abstract_Component implements Component {
 	 * Render component markup.
 	 */
 	public function render() {
-		self::$current_component = $this->get_id();
-
+		self::$current_component           = $this->get_id();
+		Abstract_Builder::$current_builder = $this->get_builder_id();
 		if ( is_customize_preview() ) {
 			$style = $this->css_array_to_css( $this->add_style() );
 			echo '<style type="text/css">' . $style . '</style>';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
### Summary
Selective refresh is not working on the non-header builders

### Will affect visual aspect of the product
No

### Screenshots <!-- if applicable -->

### Test instructions

- Try to edit a component with a selective refresh setting, i.e copyright or HTML in the page header
- the setting should change without a full refresh.

<!-- Issues that this pull request closes. -->
Closes #1315 