### PR TITLE
chore: changes to make compatible with Codeinwp/neve-pro-addon#530

### DIFF
--- a/inc/customizer/base_customizer.php
+++ b/inc/customizer/base_customizer.php
@@ -183,6 +183,17 @@ abstract class Base_Customizer {
 					}
 				);
 			}
+			if ( isset( $control->control_args['conditional_header'] ) && $control->control_args['conditional_header'] ) {
+				$id = $control->id;
+				add_filter(
+					'neve_pro_react_controls_localization',
+					function ( $array ) use ( $id ) {
+						$array['headerControls'][] = $id;
+
+						return $array;
+					} 
+				);
+			}
 			if ( isset( $control->partial ) ) {
 				$this->add_partial( new Partial( $control->id, $control->partial ) );
 			}


### PR DESCRIPTION
### Summary
Adapt abstract class `base_customizer.php` to work with conditional headers from Neve Pro.
Related to Codeinwp/neve-pro-addon#530.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Test with this PR: https://github.com/Codeinwp/neve-pro-addon/pull/538
- Should work fine with older versions of Neve Pro. 

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#530.
<!-- Should look like this: `Closes #1, #2, #3.` . -->