### PR TITLE
chore: move logo component Display setting first in section [#1324]

### DIFF
--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -108,7 +108,7 @@ class Logo extends Abstract_Component {
 				'label'              => __( 'Display', 'neve' ),
 				'type'               => '\Neve\Customizer\Controls\React\Radio_Buttons',
 				'options'            => [
-					'priority'      => 11,
+					'priority'      => -1,
 					'is_for'        => 'logo',
 					'large_buttons' => true,
 				],


### PR DESCRIPTION
### Summary
Moves logo component Display setting as first in the section.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/15010186/73841964-5a589a00-4824-11ea-9536-0bb059159b5b.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Section should look like in the screenshot

<!-- Issues that this pull request closes. -->
Closes #1324.
<!-- Should look like this: `Closes #1, #2, #3.` . -->