### PR TITLE
feat: add color controls to components

### DIFF
--- a/header-footer-grid/Core/Components/Copyright.php
+++ b/header-footer-grid/Core/Components/Copyright.php
@@ -86,7 +86,7 @@ class Copyright extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					[
-						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *',
+						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *:not(a)',
 						'prop'     => 'color',
 						'fallback' => 'inherit',
 					],

--- a/header-footer-grid/Core/Components/Copyright.php
+++ b/header-footer-grid/Core/Components/Copyright.php
@@ -23,6 +23,7 @@ use WP_Customize_Manager;
 class Copyright extends Abstract_Component {
 	const COMPONENT_ID = 'footer_copyright';
 	const CONTENT_ID   = 'content';
+	const COLOR_ID     = 'color';
 
 	/**
 	 * Copyright constructor.
@@ -58,7 +59,7 @@ class Copyright extends Abstract_Component {
 					apply_filters(
 						'ti_wl_copyright',
 						sprintf(
-							/* translators: %1$s is Theme Name ( Neve ), %2$s is WordPress */
+						/* translators: %1$s is Theme Name ( Neve ), %2$s is WordPress */
 							esc_html__( '%1$s | Powered by %2$s', 'neve' ),
 							wp_kses_post( '<p><a href="https://themeisle.com/themes/neve/" rel="nofollow">Neve</a>' ),
 							wp_kses_post( '<a href="http://wordpress.org" rel="nofollow">WordPress</a></p>' )
@@ -72,6 +73,46 @@ class Copyright extends Abstract_Component {
 			]
 		);
 
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::COLOR_ID,
+				'group'                 => $this->get_class_const( 'COMPONENT_ID' ),
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => 'sanitize_hex_color',
+				'label'                 => __( 'Text Color', 'neve' ),
+				'type'                  => 'neve_color_control',
+				'section'               => $this->section,
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					[
+						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *',
+						'prop'     => 'color',
+						'fallback' => 'inherit',
+					],
+				],
+			]
+		);
+	}
+
+
+	/**
+	 * Method to add Component css styles.
+	 *
+	 * @param array $css_array An array containing css rules.
+	 *
+	 * @return array
+	 * @since   1.0.0
+	 * @access  public
+	 */
+	public function add_style( array $css_array = array() ) {
+		$color = SettingsManager::get_instance()->get( $this->get_id() . '_' . self::COLOR_ID );
+		if ( ! empty( $color ) ) {
+			$css_array[ $this->default_typography_selector ]        = [ 'color' => sanitize_hex_color( $color ) ];
+			$css_array[ $this->default_typography_selector . ' *' ] = [ 'color' => sanitize_hex_color( $color ) ];
+		}
+
+		return parent::add_style( $css_array );
 	}
 
 	/**

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -20,10 +20,9 @@ use HFG\Main;
  * @package HFG\Core\Components
  */
 class CustomHtml extends Abstract_Component {
-
-	const CONTENT_ID = 'content';
-
+	const CONTENT_ID   = 'content';
 	const COMPONENT_ID = 'custom_html';
+	const COLOR_ID     = 'color';
 
 	/**
 	 * CustomHtml constructor.
@@ -38,7 +37,7 @@ class CustomHtml extends Abstract_Component {
 		$this->set_property( 'component_slug', 'hfg-html' );
 		$this->set_property( 'icon', 'welcome-write-blog' );
 		$this->set_property( 'has_typeface_control', true );
-		$this->set_property( 'default_typography_selector', $this->default_typography_selector . '.builder-item--' . $this->get_id() );
+		$this->set_property( 'default_typography_selector', $this->default_typography_selector . '.builder-item--' . $this->get_id() . ' .nv-html-content' );
 		add_filter( 'wp_kses_allowed_html', array( $this, 'allow_input_form_tags' ), 10, 2 );
 	}
 
@@ -130,7 +129,6 @@ class CustomHtml extends Abstract_Component {
 	 * @access  public
 	 */
 	public function add_settings() {
-
 		SettingsManager::get_instance()->add(
 			[
 				'id'                 => self::CONTENT_ID,
@@ -149,6 +147,46 @@ class CustomHtml extends Abstract_Component {
 			]
 		);
 
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::COLOR_ID,
+				'group'                 => $this->get_class_const( 'COMPONENT_ID' ),
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => 'sanitize_hex_color',
+				'label'                 => __( 'Text Color', 'neve' ),
+				'type'                  => 'neve_color_control',
+				'section'               => $this->section,
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					[
+						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *',
+						'prop'     => 'color',
+						'fallback' => 'inherit',
+					],
+				],
+				'conditional_header'    => $this->get_builder_id() === 'header',
+			]
+		);
+	}
+
+	/**
+	 * Method to add Component css styles.
+	 *
+	 * @param array $css_array An array containing css rules.
+	 *
+	 * @return array
+	 * @since   1.0.0
+	 * @access  public
+	 */
+	public function add_style( array $css_array = array() ) {
+		$color = SettingsManager::get_instance()->get( $this->get_id() . '_' . self::COLOR_ID );
+		if ( ! empty( $color ) ) {
+			$css_array[ $this->default_typography_selector ]        = [ 'color' => sanitize_hex_color( $color ) ];
+			$css_array[ $this->default_typography_selector . ' *' ] = [ 'color' => sanitize_hex_color( $color ) ];
+		}
+
+		return parent::add_style( $css_array );
 	}
 
 	/**

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -160,7 +160,7 @@ class CustomHtml extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					[
-						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *',
+						'selector' => $this->default_typography_selector . ', ' . $this->default_typography_selector . ' *:not(a)',
 						'prop'     => 'color',
 						'fallback' => 'inherit',
 					],

--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -28,6 +28,7 @@ class Logo extends Abstract_Component {
 	const MAX_WIDTH    = 'max_width';
 	const SHOW_TITLE   = 'show_title';
 	const SHOW_TAGLINE = 'show_tagline';
+	const COLOR_ID     = 'color';
 
 	/**
 	 * Default spacing value
@@ -108,7 +109,7 @@ class Logo extends Abstract_Component {
 				'label'              => __( 'Display', 'neve' ),
 				'type'               => '\Neve\Customizer\Controls\React\Radio_Buttons',
 				'options'            => [
-					'priority'      => -1,
+					'priority'      => - 1,
 					'is_for'        => 'logo',
 					'large_buttons' => true,
 				],
@@ -191,6 +192,27 @@ class Logo extends Abstract_Component {
 			]
 		);
 
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::COLOR_ID,
+				'group'                 => $this->get_class_const( 'COMPONENT_ID' ),
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => 'sanitize_hex_color',
+				'label'                 => __( 'Text Color', 'neve' ),
+				'type'                  => 'neve_color_control',
+				'section'               => $this->section,
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					[
+						'selector' => $this->default_selector . ' .brand .nv-title-tagline-wrap',
+						'prop'     => 'color',
+						'fallback' => 'inherit',
+					],
+				],
+				'conditional_header'    => true,
+			]
+		);
 	}
 
 	/**
@@ -229,6 +251,11 @@ class Logo extends Abstract_Component {
 			$css_array[' @media (min-width: 961px)'][ $selector ] = array(
 				'max-width' => $logo_max_width['desktop'],
 			);
+		}
+
+		$color = SettingsManager::get_instance()->get( $this->get_id() . '_' . self::COLOR_ID );
+		if ( ! empty( $color ) ) {
+			$css_array[ $this->default_selector . ' .brand .nv-title-tagline-wrap' ] = [ 'color' => sanitize_hex_color( $color ) ];
 		}
 
 		return parent::add_style( $css_array );


### PR DESCRIPTION
### Summary
Adds color controls for HTML / Copyright / Page Header HTML / Logo components under the Style tab.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Test that the style controls apply color properly
- Should not affect `<a>` tags as those are handled by the skin mode.

<!-- Issues that this pull request closes. -->
Closes #1317.
<!-- Should look like this: `Closes #1, #2, #3.` . -->