### PR TITLE
fix: menu icon component showing up twice [closes #531]

### DIFF
--- a/header-footer-grid/Core/Components/MenuIcon.php
+++ b/header-footer-grid/Core/Components/MenuIcon.php
@@ -75,6 +75,7 @@ class MenuIcon extends Abstract_Component {
 	public function init() {
 		$this->set_property( 'label', __( 'Menu Icon', 'neve' ) );
 		$this->set_property( 'id', $this->get_class_const( 'COMPONENT_SLUG' ) );
+		$this->set_property( 'component_slug', self::COMPONENT_SLUG );
 		$this->set_property( 'width', 1 );
 		$this->set_property( 'icon', 'menu' );
 		$this->set_property( 'section', self::COMPONENT_ID );


### PR DESCRIPTION
### Summary
Adds component slug, to make sure it doesn't appear twice inside the add-component window.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check that the menu icon component doesn't appear twice inside the add component window

<!-- Issues that this pull request closes. -->
Closes #531.
<!-- Should look like this: `Closes #1, #2, #3.` . -->