### PR TITLE
fix: selective refresh for components [closes #1370]

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -315,6 +315,21 @@ abstract class Abstract_Component implements Component {
 	}
 
 	/**
+	 * Render CSS code for component.
+	 */
+	public function render_css() {
+		if ( ! self::$should_show_css ) {
+			return;
+		}
+		if ( ! is_customize_preview() ) {
+			return;
+		}
+		$style = $this->css_array_to_css( $this->add_style() );
+		echo '<style type="text/css" id="' . esc_attr( $this->get_id() ) . '-style">' . $style . '</style>';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		self::$should_show_css = false;
+	}
+
+	/**
 	 * Allow for constant changes in pro.
 	 *
 	 * @param string $const Name of the constant.
@@ -573,9 +588,10 @@ abstract class Abstract_Component implements Component {
 		$wp_customize->selective_refresh->add_partial(
 			$this->get_id() . '_partial',
 			array(
-				'selector'        => '.builder-item--' . $this->get_id(),
-				'settings'        => Settings\Manager::get_instance()->get_transport_group( $this->get_id() ),
-				'render_callback' => [ $this, 'render' ],
+				'selector'            => '.builder-item--' . $this->get_id() . ':parent',
+				'settings'            => Settings\Manager::get_instance()->get_transport_group( $this->get_id() ),
+				'render_callback'     => [ $this, 'render' ],
+				'container_inclusive' => true,
 			)
 		);
 
@@ -588,12 +604,6 @@ abstract class Abstract_Component implements Component {
 	public function render() {
 		self::$current_component           = $this->get_id();
 		Abstract_Builder::$current_builder = $this->get_builder_id();
-		if ( self::$should_show_css && is_customize_preview() ) {
-			$style = $this->css_array_to_css( $this->add_style() );
-			echo '<style type="text/css" id="' . esc_attr( $this->get_id() ) . '-style">' . $style . '</style>';  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			self::$should_show_css = false;
-		}
-
 		Main::get_instance()->load( 'component-wrapper' );
 	}
 

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -47,7 +47,6 @@ class Nav extends Abstract_Component {
 		$this->set_property( 'has_font_family_control', true );
 		$this->set_property( 'has_typeface_control', true );
 		$this->set_property( 'default_typography_selector', $this->default_typography_selector . '.builder-item--' . $this->get_id() . ' li > a' );
-		$this->set_property( 'default_selector', $this->default_typography_selector . '.builder-item--' . $this->get_id() . ' li > a' );
 		$this->default_align = 'right';
 		add_filter(
 			'neve_last_menu_setting_slug_' . $this->get_class_const( 'COMPONENT_ID' ),

--- a/header-footer-grid/templates/component-wrapper.php
+++ b/header-footer-grid/templates/component-wrapper.php
@@ -30,6 +30,7 @@ $item_classes = join( ' ', $item_classes );
 		data-section="<?php echo esc_attr( current_component()->get_section_id() ); ?>"
 		data-item-id="<?php echo esc_attr( current_component()->get_id() ); ?>">
 	<?php
+	current_component()->render_css();
 	current_component()->render_component();
 	?>
 	<?php if ( is_customize_preview() ) { ?>


### PR DESCRIPTION
### Summary
Fixes issue with the selective refresh for components. Previously, the inner content was rendered twice upon selective refresh. Now it should render fine.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- Will eyepatch be affected? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Test if selective refresh renders the inner content of the component twice - it shouldn't.

<!-- Issues that this pull request closes. -->
Closes #1370.
<!-- Should look like this: `Closes #1, #2, #3.` . -->