### PR TITLE
Add missing role=button and tabindex=0 for search icon button to fix AMP validity

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -131,7 +131,7 @@ function neve_search_icon( $echo = false, $size = 15, $amp_ready = false ) {
 
 	$amp_state = '';
 	if ( $amp_ready ) {
-		$amp_state = ' on="tap:nv-search-icon-responsive.toggleClass(class=\'active\')" ';
+		$amp_state = ' on="tap:nv-search-icon-responsive.toggleClass(class=\'active\')" role="button" tabindex="0" ';
 	}
 
 	$svg = '<span class="nv-icon nv-search" ' . $amp_state . '>


### PR DESCRIPTION
### Summary

AMP requires `role` and `tabindex` attributes for elements that have an `on="tap:..."` attribute, unless they are buttons or links (i.e. elements that aren't normally tappable/tabbable).

Originally reported on the AMP plugin support forum: https://wordpress.org/support/topic/the-attribute-tabindex-in-tag-span-is-missing-or-incorrect/

Note the changes where should be done automatically by the AMP plugin in the future (via https://github.com/ampproject/amp-wp/issues/4528) but it is best if the changes are done up-front.

As an alternative to adding these attributes, the icon could instead be represented by a `button` instead of a `span`.

### Will affect visual aspect of the product

YES (when tabbing there may be an outline on the element)

### Test instructions

* No validation error should be reported for the page.
* The search icon should be tabbable with the keyboard. 