### PR TITLE
Fix archive_title magic tag

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -155,6 +155,10 @@ class Magic_Tags {
 	 * @return string
 	 */
 	public function archive_title() {
+		if ( get_option( 'show_on_front' ) === 'page' && is_home() ) {
+			$blog_page_id = get_option( 'page_for_posts' );
+			return get_the_title( $blog_page_id );
+		}
 		return html_entity_decode( get_the_archive_title() );
 	}
 


### PR DESCRIPTION
### Summary
I've changed the {archive_title} tag a bit because when you had a blog page in customizer it returned "Archives" instead of the page title

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->
https://prnt.sc/salwbv
