### PR TITLE
chore: fix dropdown color issue with imported demos using dark skin on hfg rows [ref #1550]

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -841,10 +841,12 @@ abstract class Abstract_Builder implements Builder {
 				Dynamic_Selector::KEY_SELECTOR => $selector . ' .primary-menu-ul .sub-menu li,' . $selector . ' .primary-menu-ul .sub-menu',
 				Dynamic_Selector::KEY_RULES    => [
 					Config::CSS_PROP_BACKGROUND_COLOR => [
-						Dynamic_Selector::META_KEY => $this->control_id . '_' . $row_index . '_background' . '.colorValue',
+						Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_background' . '.colorValue',
+						Dynamic_Selector::META_DEFAULT => $default_color,
 					],
 					Config::CSS_PROP_BORDER_COLOR     => [
-						Dynamic_Selector::META_KEY => $this->control_id . '_' . $row_index . '_background' . '.colorValue',
+						Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_background' . '.colorValue',
+						Dynamic_Selector::META_DEFAULT => $default_color,
 					],
 				],
 			];
@@ -853,7 +855,7 @@ abstract class Abstract_Builder implements Builder {
 				Dynamic_Selector::KEY_RULES    => [
 					Config::CSS_PROP_BACKGROUND_COLOR => [
 						Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_background' . '.colorValue',
-						Dynamic_Selector::META_DEFAULT => $defaults['background'],
+						Dynamic_Selector::META_DEFAULT => $default_color,
 					],
 				],
 			];


### PR DESCRIPTION
### Summary
Imported demos with dark skins on header rows that had dropdowns were not properly set.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Clean wp (`wp theme mod remove --all && wp site empty --yes`)
- Import the `Shop` demo. 
- Primary menu dropdowns should have the proper background color

cc @rodica-andronache 