### PR TITLE
Missing image and thumbnail width in WooCommerce

### DIFF
--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -2905,10 +2905,7 @@ class Front_End {
 		$woocommerce_settings = apply_filters(
 			'neves_woocommerce_args',
 			array(
-				'single_image_width'            => 600,
-				'thumbnail_image_width'         => 230,
-				'gallery_thumbnail_image_width' => 160,
-				'product_grid'                  => array(
+				'product_grid' => array(
 					'default_columns' => 3,
 					'default_rows'    => 4,
 					'min_columns'     => 1,


### PR DESCRIPTION
### Summary
Add back image and thumbnail width in WooCommerce for free users.

### Will affect the visual aspect of the product
NO

We should remove the function that removes that parameter in pro. I've made a PR for this: https://github.com/Codeinwp/neve-pro-addon/pull/720

Closes #1614.

