### PR TITLE
Fix/issue letter spacing

### DIFF
--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -171,7 +171,10 @@ class Frontend extends Generator {
 		if ( ! empty( $extra_selectors_body ) ) {
 			$extra_selectors_body                        = ltrim( $extra_selectors_body, ', ' );
 			$this->_subscribers[ $extra_selectors_body ] = [
-				Config::CSS_PROP_LETTER_SPACING => Config::MODS_TYPEFACE_GENERAL . '.letterSpacing',
+				Config::CSS_PROP_LETTER_SPACING => [
+					Dynamic_Selector::META_KEY           => Config::MODS_TYPEFACE_GENERAL . '.letterSpacing',
+					Dynamic_Selector::META_IS_RESPONSIVE => true,
+				],
 				Config::CSS_PROP_FONT_WEIGHT    => [
 					Dynamic_Selector::META_KEY => Config::MODS_TYPEFACE_GENERAL . '.fontWeight',
 					'font'                     => 'mods_' . Config::MODS_FONT_GENERAL,


### PR DESCRIPTION
### Summary
On extra selectors for typefaces, letter-spacing was not defined as responsive. 

### Will affect the visual aspect of the product
No
### Screenshots  
### Test instructions

1. Activate Neve
2. Activate woo
3. Got to customizer.
4. It should show a notice related to css_prop.php file. Make sure that you have WP_DEBUG on. 
  
