### PR TITLE
chore: enable vertical alignment for all footer components [#1368]

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -300,13 +300,6 @@ abstract class Abstract_Component implements Component {
 	public $has_typeface_control = false;
 
 	/**
-	 * Should have vertical alignment control.
-	 *
-	 * @var bool
-	 */
-	public $has_vertical_alignment = false;
-
-	/**
 	 * Abstract_Component constructor.
 	 *
 	 * @param string $panel Builder panel.
@@ -857,7 +850,7 @@ abstract class Abstract_Component implements Component {
 	 * Add verical alignment control.
 	 */
 	private function add_vertical_alignment_control() {
-		if ( ! $this->has_vertical_alignment ) {
+		if ( $this->builder_id !== 'footer' ) {
 			return;
 		}
 		$align_choices = [
@@ -867,7 +860,7 @@ abstract class Abstract_Component implements Component {
 			],
 			'middle' => [
 				'tooltip' => __( 'Middle', 'neve' ),
-				'icon'    => 'leftright',
+				'icon'    => 'sort',
 			],
 			'bottom' => [
 				'tooltip' => __( 'Bottom', 'neve' ),

--- a/header-footer-grid/Core/Components/Abstract_FooterWidget.php
+++ b/header-footer-grid/Core/Components/Abstract_FooterWidget.php
@@ -22,13 +22,6 @@ use WP_Customize_Manager;
 abstract class Abstract_FooterWidget extends Abstract_Component {
 
 	/**
-	 * Has vertical alignment.
-	 *
-	 * @var bool
-	 */
-	public $has_vertical_alignment = true;
-
-	/**
 	 * Method to show footer widget
 	 *
 	 * @param bool   $active Is active.


### PR DESCRIPTION
### Summary
Enables vertical alignment on ALL footer components as it made much more sense.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- All footer components - including pro ones - should have vertical alignment controls. 
- None of the other builder components should have vertical alignment controls.
- Vertical alignment should work, obviously :see_no_evil: . 

<!-- Issues that this pull request closes. -->
Closes #1368.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
