### PR TITLE
chore: add filter to hide dashboard notice [Codeinwp/neve pro addon#706]

### DIFF
--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -85,6 +85,9 @@ class Admin {
 	 * Add notice.
 	 */
 	public function admin_notice() {
+		if ( apply_filters( 'neve_disable_starter_sites_admin_notice', false ) === true ) {
+			return;
+		}
 		if ( defined( 'TI_ONBOARDING_DISABLED' ) && TI_ONBOARDING_DISABLED === true ) {
 			return;
 		}


### PR DESCRIPTION
### Summary
Adds filter to hide starter sites dashboard notice.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Must work with [this PR](https://github.com/Codeinwp/neve-pro-addon/pull/773)

<!-- Issues that this pull request closes. -->
Ref: Codeinwp/neve pro addon#706.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
