### PR TITLE
fix: canvas search on amp mobile [#1743]

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -162,7 +162,7 @@ function neve_search_icon( $is_link = false, $echo = false, $size = 15, $amp_rea
 
 	$amp_state = '';
 	if ( $amp_ready ) {
-		$amp_state = ' on="tap:nv-search-icon-responsive.toggleClass(class=\'active\')" role="button" tabindex="0" ';
+		$amp_state = 'on="tap:AMP.setState({visible: !visible})" role="button" tabindex="0" ';
 	}
 	$start_tag = $is_link ? 'a href="#"' : 'div';
 	$end_tag   = $is_link ? 'a' : 'div';

--- a/header-footer-grid/templates/components/component-search-responsive.php
+++ b/header-footer-grid/templates/components/component-search-responsive.php
@@ -24,11 +24,11 @@ if ( ! empty( $component_styles_array ) ) {
 }
 $amp_state = '';
 if ( neve_is_amp() ) {
-	$amp_state = ' on="tap:nv-search-icon-responsive.toggleClass(class=\'active\')" ';
+	$amp_state = ' on="tap:AMP.setState({visible: !visible})" ';
 }
 ?>
 <div class="nv-search-icon-component" <?php echo wp_kses_post( $component_styles ); ?>>
-	<div class="menu-item-nav-search <?php echo esc_attr( $open ); ?>" id="nv-search-icon-responsive" tabindex="0">
+	<div [class]="visible ? 'menu-item-nav-search active <?php echo esc_attr( $open ); ?>' : 'menu-item-nav-search <?php echo esc_attr( $open ); ?>'" class="menu-item-nav-search <?php echo esc_attr( $open ); ?>" id="nv-search-icon-responsive" tabindex="0">
 		<?php neve_search_icon( true, true, 15, ! empty( $amp_state ) ); ?>
 		<div class="nv-nav-search" aria-label="search">
 			<div class="form-wrap <?php echo $open === 'canvas' ? 'container' : ''; ?>">


### PR DESCRIPTION
### Summary
I have no idea why the old implementation wasn't working on mobile.

How it was and wasn't working on mobile:
```on="tap:nv-search-icon-responsive.toggleClass(class='active')"```

How it is now and this way it's working:
```on="tap:AMP.setState({visible: !visible})"```
and on the `.nv-search-icon-responsive`
``` [class]="visible ? 'menu-item-nav-search active <?php echo esc_attr( $open ); ?>' : 'menu-item-nav-search <?php echo esc_attr( $open ); ?>'" ```

The implementation is similar but it's written differently.

### Will affect the visual aspect of the product
NO

### Test instructions
- Activate AMP
- Go to the AMP version on mobile and click on the search icon component in the header.

Closes #1743.
