### PR TITLE
fix: notice placement [Codeinwp/neve-pro-addon/#886]

### DIFF
--- a/inc/customizer/options/layout_sidebar.php
+++ b/inc/customizer/options/layout_sidebar.php
@@ -273,7 +273,7 @@ class Layout_Sidebar extends Base_Customizer {
 		}
 
 		/* translators: %s is Notice text */
-		$template = '<div class="notice notice-info"><p>%s</p></div>';
+		$template = '<p class="notice notice-info">%s</p>';
 
 		return sprintf(
 			$template,


### PR DESCRIPTION
### Summary
Fix notice placement. Don't know why but if it's wrapped in a div, the position of it changes. I removed the wrapper and it looks ok.

### Will affect the visual aspect of the product
NO

Closes Codeinwp/neve-pro-addon#886