### PR TITLE
chore: do not parse html tags inside search heading

### DIFF
--- a/views/page-header.php
+++ b/views/page-header.php
@@ -8,7 +8,7 @@
 <div class="nv-page-title-wrap <?php echo esc_attr( $args['wrap-class'] ); ?>">
 	<div class="nv-page-title <?php echo esc_attr( $args['class'] ); ?>">
 		<?php do_action( 'neve_before_page_title' ); ?>
-		<h1><?php echo wp_kses_post( html_entity_decode( $args['string'] ) ); ?></h1>
+		<h1><?php echo wp_kses_post( is_search() ? $args['string'] : html_entity_decode( $args['string'] ) ); ?></h1>
 		<?php if ( ! empty( $args['category_description'] ) ) { ?>
 			<?php echo wp_kses_post( $args['category_description'] ); ?>
 		<?php } ?>


### PR DESCRIPTION
### Summary
Page Header was parsing HTML tags from search.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- If you search for any HTML code in the site, the tags should not be parsed.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#902.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
