### PR TITLE
fix: link colors inside the editor

### DIFF
--- a/inc/core/styles/gutenberg.php
+++ b/inc/core/styles/gutenberg.php
@@ -52,7 +52,7 @@ class Gutenberg extends Generator {
 			Dynamic_Selector::KEY_RULES    => [
 				Config::CSS_PROP_COLOR => Config::MODS_LINK_COLOR,
 			],
-			Dynamic_Selector::KEY_SELECTOR => 'a',
+			Dynamic_Selector::KEY_SELECTOR => 'a, .wp-block a',
 			Dynamic_Selector::KEY_CONTEXT  => [
 				Dynamic_Selector::CONTEXT_GUTENBERG => true,
 			],
@@ -61,7 +61,7 @@ class Gutenberg extends Generator {
 			Dynamic_Selector::KEY_RULES    => [
 				Config::CSS_PROP_COLOR => Config::MODS_LINK_HOVER_COLOR,
 			],
-			Dynamic_Selector::KEY_SELECTOR => 'a:hover',
+			Dynamic_Selector::KEY_SELECTOR => 'a:hover, .wp-block a:hover',
 			Dynamic_Selector::KEY_CONTEXT  => [
 				Dynamic_Selector::CONTEXT_GUTENBERG => true,
 			],


### PR DESCRIPTION
### Summary
Link colors were not applying inside the editor. Should be in working order now.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

<!-- Issues that this pull request closes. -->
Closes #2009.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
