### PR TITLE
fix: headings not inheriting customizer colors inside editor

### DIFF
--- a/inc/core/styles/gutenberg.php
+++ b/inc/core/styles/gutenberg.php
@@ -29,12 +29,12 @@ class Gutenberg extends Generator {
 			Dynamic_Selector::KEY_SELECTOR => '
 				 .wp-block ,
 				 .editor-post-title__block .editor-post-title__input,
-				 h1,
-				 h2,
-				 h3,
-				 h4,
-				 h5,
-				 h6',
+				 h1.wp-block,
+				 h2.wp-block,
+				 h3.wp-block,
+				 h4.wp-block,
+				 h5.wp-block,
+				 h6.wp-block',
 			Dynamic_Selector::KEY_CONTEXT  => [
 				Dynamic_Selector::CONTEXT_GUTENBERG => true,
 			],


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Headings should inherit customizer set colors 

<!-- Issues that this pull request closes. -->
Closes #2010.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
