### PR TITLE
Remove time to read magic tag from lite

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -515,10 +515,6 @@ class Magic_Tags {
 						'label' => __( 'Comments meta', 'neve' ),
 						'type'  => 'string',
 					],
-					'meta_time_to_read'      => [
-						'label' => __( 'Time to read meta', 'neve' ),
-						'type'  => 'string',
-					],
 				],
 			],
 			[
@@ -639,6 +635,8 @@ class Magic_Tags {
 				],
 			];
 		}
+
+		$this->options = apply_filters( 'neve_magic_tags_config', $this->options );
 
 		foreach ( $this->options as $magic_tag_group => $args ) {
 			foreach ( $args['controls'] as $tag => $tag_args ) {

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -97,8 +97,12 @@ class Post_Meta extends Base_View {
 					if ( $post_type !== 'post' ) {
 						break;
 					}
+					$reading_time = apply_filters( 'neve_do_read_time', '' );
+					if ( empty( $reading_time ) ) {
+						break;
+					}
 					$markup .= '<' . $tag . ' class="meta reading-time">';
-					$markup .= apply_filters( 'neve_do_read_time', '' );
+					$markup .= $reading_time;
 					$markup .= '</' . $tag . '>';
 					break;
 				case 'default':


### PR DESCRIPTION
### Summary
Remove the meta_time_to_read magic tag in lite and add it in PRO via filters.

### Will affect the visual aspect of the product
NO

Need to also merge https://github.com/Codeinwp/neve-pro-addon/pull/938

Closes #2065.

