### PR TITLE
fix: components in page_header were taken into account for conditional headers

### DIFF
--- a/header-footer-grid/Core/Components/Button.php
+++ b/header-footer-grid/Core/Components/Button.php
@@ -102,7 +102,7 @@ class Button extends Abstract_Component {
 				'type'               => 'text',
 				'section'            => $this->section,
 				'use_dynamic_fields' => array( 'url' ),
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 		SettingsManager::get_instance()->add(
@@ -117,7 +117,7 @@ class Button extends Abstract_Component {
 				'type'               => 'text',
 				'section'            => $this->section,
 				'use_dynamic_fields' => array( 'string' ),
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 
@@ -142,7 +142,7 @@ class Button extends Abstract_Component {
 				'label'              => __( 'Appearance', 'neve' ),
 				'type'               => 'neve_button_appearance',
 				'section'            => $this->section,
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 	}

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -149,7 +149,7 @@ class CustomHtml extends Abstract_Component {
 				'type'               => 'textarea',
 				'section'            => $this->section,
 				'use_dynamic_fields' => array( 'string', 'url' ),
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 

--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -64,7 +64,7 @@ class SecondNav extends Abstract_Component {
 				'transport'          => 'post' . $this->get_class_const( 'COMPONENT_ID' ),
 				'sanitize_callback'  => 'wp_filter_nohtml_kses',
 				'default'            => 'style-plain',
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 				'label'              => __( 'Hover Skin Mode', 'neve' ),
 				'type'               => '\Neve\Customizer\Controls\React\Radio_Buttons',
 				'section'            => $this->section,
@@ -86,7 +86,7 @@ class SecondNav extends Abstract_Component {
 				'label'                 => __( 'Items Color', 'neve' ),
 				'type'                  => 'neve_color_control',
 				'section'               => $this->section,
-				'conditional_header'    => true,
+				'conditional_header'    => $this->get_builder_id() === 'header',
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					[
@@ -109,7 +109,7 @@ class SecondNav extends Abstract_Component {
 				'label'                 => __( 'Items Hover Color', 'neve' ),
 				'type'                  => 'neve_color_control',
 				'section'               => $this->section,
-				'conditional_header'    => true,
+				'conditional_header'    => $this->get_builder_id() === 'header',
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					[
@@ -168,7 +168,7 @@ class SecondNav extends Abstract_Component {
 						],
 					],
 				],
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 
@@ -195,7 +195,7 @@ class SecondNav extends Abstract_Component {
 					],
 				],
 				'section'            => $this->section,
-				'conditional_header' => true,
+				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);
 	}


### PR DESCRIPTION
### Summary

Related to [this PR](https://github.com/Codeinwp/neve-pro-addon/pull/942).

Components in Page Header were taken into account for conditional headers.

---
Modifies the following: 

- Button Component
- Custom HTML Component
- Secondary Nav Component

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The page header components mentioned above should not be taken into account by the functionality of the conditional headers. 

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/927
<!-- Should look like this: `Closes #1, #2, #3.` . -->
