### PR TITLE
fix: button component selector specificity

### DIFF
--- a/header-footer-grid/Core/Components/Button.php
+++ b/header-footer-grid/Core/Components/Button.php
@@ -64,7 +64,7 @@ class Button extends Abstract_Component {
 	 */
 	public function __construct( $panel ) {
 		parent::__construct( $panel );
-		$this->default_selector = '.builder-item--' . $this->get_id() . ' > .component-wrap > a.button';
+		$this->default_selector = '.builder-item > .item--inner.builder-item--' . $this->get_id() . ' > .component-wrap > a.button.button-primary';
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Increases button component default CSS selector specificity to override WooCommerce rules.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES - but fixes some issues

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Button component style settings should apply on all pages, including woocommerce ones where they were overridden by the Button styles previously.

<!-- Issues that this pull request closes. -->
Closes #2036.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
