### PR TITLE
Fix current_single_url magic tag when added as link [#931]

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -94,6 +94,11 @@ class Magic_Tags {
 			return $input;
 		}
 
+		if ( strpos( $input, 'http://{current_single_url}' ) !== false || strpos( $input, 'https://{current_single_url}' ) !== false ) {
+			$input = str_replace( 'http://{current_single_url}', '{current_single_url}', $input );
+			$input = str_replace( 'https://{current_single_url}', '{current_single_url}', $input );
+		}
+
 		return preg_replace_callback(
 			'/\\{\s?\b(?:' . self::$magic_tag_regex . ')\b\s?\\}/',
 			[


### PR DESCRIPTION
### Summary
When adding a link, it already comes with the protocol for the link in the markup. The input in which we replaced the §
`{current_single_url}` was `<a href="http://{current_single_url}">` and then we were replacing the `{current_single_url}` with `http://neve.local/p=13` and the result was `<a href="http://http://neve.local/p=13">`

### Will affect the visual aspect of the product
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Create a custom layout that applies on a single post or page
- Add `{current_single_url}`as a link



Closes Codeinwp/neve-pro-addon#931.
