### PR TITLE
fix: migration not being registered without TPC plugin

### DIFF
--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -65,6 +65,7 @@ class Admin {
 		}
 
 		add_action( 'admin_menu', [ $this, 'remove_background_submenu' ], 110 );
+		add_action( 'after_switch_theme', [ $this, 'get_previous_theme' ] );
 	}
 
 	/**
@@ -421,6 +422,14 @@ class Admin {
 			})
 		</script>
 		<?php
+	}
+
+	/**
+	 * Memorize the previous theme to later display the import template for it.
+	 */
+	public function get_previous_theme() {
+		$previous_theme = strtolower( get_option( 'theme_switched' ) );
+		set_theme_mod( 'ti_prev_theme', $previous_theme );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Migration needed theme mod was set only inside the TPC plugin instead of setting it inside the theme. That meant that when you changed the theme without the TPC plugin active, the change would not be saved for the migration purposes.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use zerif-lite/zerif-pro and set some basic front page options inside the customizer.
- Switch to neve
- Follow the normal user flow installing the TPC plugin for starter sites.
- The migration from the old theme should work fine inside the starter sites page/tab

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-patterns-collection#10.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
