### PR TITLE
Fix no sidebar on checkout

### DIFF
--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -436,10 +436,14 @@ final class Manager {
 			return;
 		}
 
-		if ( Main::is_new_page() || Main::is_checkout() ) {
+		$checkout_was_updated = get_post_meta( $post_id, 'neve_checkout_updated', 'no' );
+		if ( Main::is_new_page() || ( Main::is_checkout() && $checkout_was_updated === 'no' ) ) {
 			update_post_meta( $post_id, 'neve_meta_sidebar', 'full-width' );
 			update_post_meta( $post_id, 'neve_meta_enable_content_width', 'on' );
 			update_post_meta( $post_id, 'neve_meta_content_width', 100 );
+			if ( Main::is_checkout() ) {
+				update_post_meta( $post_id, 'neve_checkout_updated', 'yes' );
+			}
 		}
 	}
 }

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -117,9 +117,7 @@ class Metabox_Settings {
 			return false;
 		}
 
-		$meta_value = get_post_meta( $post_id, 'neve_meta_content_width', true );
-
-		return empty( $meta_value ) ? $this->get_content_width_default() : $meta_value;
+		return get_post_meta( $post_id, 'neve_meta_content_width', true );
 
 	}
 
@@ -320,7 +318,6 @@ class Metabox_Settings {
 		}
 
 		$meta_value = get_post_meta( $post_id, 'neve_meta_sidebar', true );
-		$meta_value = empty( $meta_value ) ? $this->get_sidebar_default() : $meta_value;
 		if ( empty( $meta_value ) || $meta_value === 'default' ) {
 			return $position;
 		}
@@ -428,19 +425,6 @@ class Metabox_Settings {
 		}
 
 		return 70;
-	}
-
-	/**
-	 * Get sidebar default.
-	 *
-	 * @return string
-	 */
-	private function get_sidebar_default() {
-		if ( (int) $this->get_post_id() === (int) get_option( 'woocommerce_checkout_page_id' ) ) {
-			return 'full-width';
-		}
-
-		return '';
 	}
 
 	/**


### PR DESCRIPTION
### Summary
There was no way to add the sidebar on checkout. It resets to no sidebar every time you've updated the checkout page.

### Will affect the visual aspect of the product
NO

### Test instructions
- Go to the checkout page and try to change the sidebar position, then press publish.
- Refresh the page and see if the sidebar position is still no-sidebar

