### PR TITLE
fix: global colors overridden by old colors in editor

### DIFF
--- a/inc/core/settings/config.php
+++ b/inc/core/settings/config.php
@@ -13,22 +13,36 @@ namespace Neve\Core\Settings;
  * @package Neve\Core\Settings
  */
 class Config {
-
-	const MODS_LINK_COLOR                  = 'neve_link_color';
-	const MODS_LINK_HOVER_COLOR            = 'neve_link_hover_color';
-	const MODS_GLOBAL_COLORS               = 'neve_global_colors';
-	const MODS_TEXT_COLOR                  = 'neve_text_color';
-	const MODS_CONTAINER_WIDTH             = 'neve_container_width';
-	const MODS_SITEWIDE_CONTENT_WIDTH      = 'neve_sitewide_content_width';
-	const MODS_OTHERS_CONTENT_WIDTH        = 'neve_other_pages_content_width';
-	const MODS_ARCHIVE_CONTENT_WIDTH       = 'neve_blog_archive_content_width';
-	const MODS_SINGLE_CONTENT_WIDTH        = 'neve_single_post_content_width';
-	const MODS_SHOP_ARCHIVE_CONTENT_WIDTH  = 'neve_shop_archive_content_width';
-	const MODS_SHOP_SINGLE_CONTENT_WIDTH   = 'neve_single_product_content_width';
-	const MODS_ADVANCED_LAYOUT_OPTIONS     = 'neve_advanced_layout_options';
-	const MODS_BUTTON_PRIMARY_STYLE        = 'neve_button_appearance';
-	const MODS_BUTTON_SECONDARY_STYLE      = 'neve_secondary_button_appearance';
-	const MODS_BUTTON_PRIMARY_PADDING      = 'neve_button_padding';
+	/**
+	 * Link color - deprecated.
+	 *
+	 * @deprecated
+	 */
+	const MODS_LINK_COLOR = 'neve_link_color';
+	/**
+	 * Link hover color - deprecated.
+	 *
+	 * @deprecated
+	 */
+	const MODS_LINK_HOVER_COLOR           = 'neve_link_hover_color';
+	const MODS_GLOBAL_COLORS              = 'neve_global_colors';
+	const MODS_TEXT_COLOR                 = 'neve_text_color';
+	const MODS_CONTAINER_WIDTH            = 'neve_container_width';
+	const MODS_SITEWIDE_CONTENT_WIDTH     = 'neve_sitewide_content_width';
+	const MODS_OTHERS_CONTENT_WIDTH       = 'neve_other_pages_content_width';
+	const MODS_ARCHIVE_CONTENT_WIDTH      = 'neve_blog_archive_content_width';
+	const MODS_SINGLE_CONTENT_WIDTH       = 'neve_single_post_content_width';
+	const MODS_SHOP_ARCHIVE_CONTENT_WIDTH = 'neve_shop_archive_content_width';
+	const MODS_SHOP_SINGLE_CONTENT_WIDTH  = 'neve_single_product_content_width';
+	const MODS_ADVANCED_LAYOUT_OPTIONS    = 'neve_advanced_layout_options';
+	const MODS_BUTTON_PRIMARY_STYLE       = 'neve_button_appearance';
+	const MODS_BUTTON_SECONDARY_STYLE     = 'neve_secondary_button_appearance';
+	const MODS_BUTTON_PRIMARY_PADDING     = 'neve_button_padding';
+	/**
+	 * Background color - deprecated.
+	 *
+	 * @deprecated
+	 */
 	const MODS_BACKGROUND_COLOR            = 'background_color';
 	const MODS_BUTTON_SECONDARY_PADDING    = 'neve_secondary_button_padding';
 	const MODS_TYPEFACE_GENERAL            = 'neve_typeface_general';

--- a/inc/core/styles/gutenberg.php
+++ b/inc/core/styles/gutenberg.php
@@ -21,51 +21,7 @@ class Gutenberg extends Generator {
 	 * Generator constructor.
 	 */
 	public function __construct() {
-		$this->context        = Dynamic_Selector::CONTEXT_GUTENBERG;
-		$this->_subscribers[] = [
-			Dynamic_Selector::KEY_RULES    => [
-				Config::CSS_PROP_COLOR => Config::MODS_TEXT_COLOR,
-			],
-			Dynamic_Selector::KEY_SELECTOR => '
-				 .wp-block ,
-				 .editor-post-title__block .editor-post-title__input,
-				 h1.wp-block,
-				 h2.wp-block,
-				 h3.wp-block,
-				 h4.wp-block,
-				 h5.wp-block,
-				 h6.wp-block',
-			Dynamic_Selector::KEY_CONTEXT  => [
-				Dynamic_Selector::CONTEXT_GUTENBERG => true,
-			],
-		];
-		$this->_subscribers[] = [
-			Dynamic_Selector::KEY_RULES    => [
-				Config::CSS_PROP_BACKGROUND_COLOR => Config::MODS_BACKGROUND_COLOR,
-			],
-			Dynamic_Selector::KEY_SELECTOR => ' > *',
-			Dynamic_Selector::KEY_CONTEXT  => [
-				Dynamic_Selector::CONTEXT_GUTENBERG => true,
-			],
-		];
-		$this->_subscribers[] = [
-			Dynamic_Selector::KEY_RULES    => [
-				Config::CSS_PROP_COLOR => Config::MODS_LINK_COLOR,
-			],
-			Dynamic_Selector::KEY_SELECTOR => 'a, .wp-block a',
-			Dynamic_Selector::KEY_CONTEXT  => [
-				Dynamic_Selector::CONTEXT_GUTENBERG => true,
-			],
-		];
-		$this->_subscribers[] = [
-			Dynamic_Selector::KEY_RULES    => [
-				Config::CSS_PROP_COLOR => Config::MODS_LINK_HOVER_COLOR,
-			],
-			Dynamic_Selector::KEY_SELECTOR => 'a:hover, .wp-block a:hover',
-			Dynamic_Selector::KEY_CONTEXT  => [
-				Dynamic_Selector::CONTEXT_GUTENBERG => true,
-			],
-		];
+		$this->context = Dynamic_Selector::CONTEXT_GUTENBERG;
 		$this->setup_buttons();
 		$this->setup_typography();
 		$this->add_editor_color_palette_styles();
@@ -310,7 +266,7 @@ class Gutenberg extends Generator {
 			Config::CSS_PROP_COLOR => [
 				Dynamic_Selector::META_KEY       => Config::MODS_BUTTON_PRIMARY_STYLE . '.background',
 				Dynamic_Selector::META_IMPORTANT => true,
-				Dynamic_Selector::META_DEFAULT   => '#0366d6',
+				Dynamic_Selector::META_DEFAULT   => 'var(--nv-primary-accent)',
 				Dynamic_Selector::KEY_CONTEXT    => [
 					Dynamic_Selector::CONTEXT_GUTENBERG => true,
 				],
@@ -320,7 +276,7 @@ class Gutenberg extends Generator {
 			Config::CSS_PROP_BACKGROUND_COLOR => [
 				Dynamic_Selector::META_KEY       => Config::MODS_BUTTON_PRIMARY_STYLE . '.background',
 				Dynamic_Selector::META_IMPORTANT => true,
-				Dynamic_Selector::META_DEFAULT   => '#0366d6',
+				Dynamic_Selector::META_DEFAULT   => 'var(--nv-primary-accent)',
 				Dynamic_Selector::KEY_CONTEXT    => [
 					Dynamic_Selector::CONTEXT_GUTENBERG => true,
 				],


### PR DESCRIPTION
### Summary
When you had previously set colors for:

```
link-color
text-color
background-color
```

The old colors were still applied inside the editor. 