### PR TITLE
chore: fix issue with old core background color applying to body

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -1330,6 +1330,8 @@ function neve_get_global_colors_default( $migrated = false ) {
 	$old_text_color       = get_theme_mod( 'neve_text_color', '#393939' );
 	$old_bg_color         = '#' . get_theme_mod( 'background_color', 'ffffff' );
 
+	add_filter( 'theme_mod_background_color', '__return_empty_string' );
+
 	return [
 		'activePalette' => 'base',
 		'palettes'      => [

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -41,17 +41,13 @@ class Front_End {
 			'width'       => 200,
 		);
 
-		$custom_background_settings = array(
-			'default-color' => apply_filters( 'neve_default_background_color', 'ffffff' ),
-		);
-
 		add_theme_support( 'title-tag' );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'automatic-feed-links' );
 		add_theme_support( 'custom-logo', $logo_settings );
 		add_theme_support( 'html5', array( 'search-form' ) );
 		add_theme_support( 'customize-selective-refresh-widgets' );
-		add_theme_support( 'custom-background', $custom_background_settings );
+		add_theme_support( 'custom-background', [] );
 		add_theme_support( 'align-wide' );
 		add_theme_support( 'editor-color-palette', $this->get_gutenberg_color_palette() );
 		add_theme_support( 'fl-theme-builder-headers' );
@@ -65,6 +61,8 @@ class Front_End {
 		add_filter( 'embed_oembed_html', array( $this, 'wrap_oembeds' ), 10, 3 );
 		add_filter( 'video_embed_html', array( $this, 'wrap_jetpack_oembeds' ), 10, 1 );
 		add_filter( 'themeisle_gutenberg_templates', array( $this, 'add_gutenberg_templates' ) );
+		add_filter( 'theme_mod_background_color', '__return_empty_string' );
+
 		$this->add_amp_support();
 		$nav_menus_to_register = apply_filters(
 			'neve_register_nav_menus',

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -61,7 +61,6 @@ class Front_End {
 		add_filter( 'embed_oembed_html', array( $this, 'wrap_oembeds' ), 10, 3 );
 		add_filter( 'video_embed_html', array( $this, 'wrap_jetpack_oembeds' ), 10, 1 );
 		add_filter( 'themeisle_gutenberg_templates', array( $this, 'add_gutenberg_templates' ) );
-		add_filter( 'theme_mod_background_color', '__return_empty_string' );
 
 		$this->add_amp_support();
 		$nav_menus_to_register = apply_filters(


### PR DESCRIPTION
### Summary
Old background color control value was applying to `body.custom-background` selector.
<!-- Please describe the changes you made. -->

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- use an old version of the theme, make sure you change the background color from the core background color control;
- migrate to this version, the background color should not apply;
- on the dev version, the background color will apply;
