### PR TITLE
fix: syntax error [ref #2375]

### DIFF
--- a/inc/compatibility/amp.php
+++ b/inc/compatibility/amp.php
@@ -41,7 +41,7 @@ class Amp {
 			10,
 			2
 		);
-		add_filter( 'walker_nav_menu_start_el', array( $this, 'wrap_content' ), 10, 4 );\
+		add_filter( 'walker_nav_menu_start_el', array( $this, 'wrap_content' ), 10, 4 );
 		add_filter( 'neve_sidebar_data_attrs', array( $this, 'add_woo_sidebar_attrs' ), 10, 2 );
 		add_filter( 'neve_search_menu_item_filter', array( $this, 'add_search_menu_item_attrs' ), 10, 2 );
 		add_action( 'neve_after_header_hook', array( $this, 'render_amp_states' ) );


### PR DESCRIPTION
### Summary
Fixes syntax oversight.

This was treated as a namespace separator so it did not affect the code.

ref: #2375