### PR TITLE
fix: breadcrumbs for SEOPress and RankMath [ref Codeinwp/neve-pro-addon#996]

### DIFF
--- a/inc/views/breadcrumbs.php
+++ b/inc/views/breadcrumbs.php
@@ -108,12 +108,25 @@ class Breadcrumbs extends Base_View {
 
 		// SEOPress breadcrumbs
 		if ( function_exists( 'seopress_display_breadcrumbs' ) ) {
-			return '<small class="neve-breadcrumbs-wrapper">' . seopress_display_breadcrumbs() . '</small>';
+			echo '<' . esc_html( $html_tag ) . ' class="neve-breadcrumbs-wrapper">';
+			seopress_display_breadcrumbs();
+			echo '</' . esc_html( $html_tag ) . '>';
+
+			return true;
 		}
 
 		// Rank Math breadcrumbs
 		if ( function_exists( 'rank_math_the_breadcrumbs' ) ) {
-			return '<small class="neve-breadcrumbs-wrapper">' . rank_math_the_breadcrumbs() . '</small>';
+			echo '<' . esc_html( $html_tag ) . ' class="neve-breadcrumbs-wrapper">';
+			rank_math_the_breadcrumbs(
+				[
+					'wrap_before' => '<nav aria-label="breadcrumbs" class="rank-math-breadcrumb">',
+					'wrap_after'  => '</nav>',
+				]
+			);
+			echo '</' . esc_html( $html_tag ) . '>';
+
+			return true;
 		}
 
 		if ( function_exists( 'bcn_display' ) ) {


### PR DESCRIPTION
### Summary
Breadcrumbs were not displayed for SEOPress and RankMath
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

Using the following plugins: 

- Yoast
- SeoPress (pro needed - you'll have to believe me that it works as I can't give you the API key (it's not mine :joy:)
- RankMath -> [enable breadcrumbs](https://successpixel.com/how-to-enable-breadcrumbs-with-rank-math-wordpress-seo-plugin/#:~:text=Before%20that%2C%20you%20must%20enable,Breadcrumbs%20%3E%3E%20Enable%20breadcrumbs%20function.)
- NavXT

---

- Breadcrumbs HFG Component should work with all of them;
- Should work with [this PR](https://github.com/Codeinwp/neve-pro-addon/pull/1077) just fine;

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#996.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
