### PR TITLE
fix: adapt global colors for whitelabel [closes Codeinwp/neve-pro-addon#1096]

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -85,7 +85,7 @@ class Elementor extends Page_Builder_Base {
 		$response = new \WP_REST_Response(
 			[
 				'id'    => esc_attr( $rest_id ),
-				'title' => 'Neve - ' . esc_html( $rest_to_slugs[ $rest_id ] ),
+				'title' => $this->get_global_color_prefix() . esc_html( $rest_to_slugs[ $rest_id ] ),
 				'value' => neve_sanitize_colors( $colors[ $rest_to_slugs[ $rest_id ] ] ),
 			]
 		);
@@ -126,7 +126,7 @@ class Elementor extends Page_Builder_Base {
 			$no_hyphens                    = str_replace( '-', '', $slug );
 			$data['colors'][ $no_hyphens ] = [
 				'id'    => esc_attr( $no_hyphens ),
-				'title' => 'Neve - ' . esc_html( $label_map[ $slug ] ),
+				'title' => $this->get_global_color_prefix() . esc_html( $label_map[ $slug ] ),
 				'value' => neve_sanitize_colors( $color_value ),
 			];
 		}
@@ -280,5 +280,14 @@ class Elementor extends Page_Builder_Base {
 		$palette    = $palettes[ $active ];
 
 		return $palette['colors'];
+	}
+
+	/**
+	 * Get the global colors prefix.
+	 *
+	 * @return string
+	 */
+	private function get_global_color_prefix() {
+		return ( apply_filters( 'ti_wl_theme_is_localized', false ) ? __( 'Theme', 'neve' ) : 'Neve' ) . ' - ';
 	}
 }

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -86,43 +86,44 @@ class Front_End {
 	 * Get the color palette in Gutenberg from Customizer colors.
 	 */
 	private function get_gutenberg_color_palette() {
+		$prefix                  = ( apply_filters( 'ti_wl_theme_is_localized', false ) ? __( 'Theme', 'neve' ) : 'Neve' ) . ' - ';
 		$gutenberg_color_palette = array();
 		$from_global_colors      = [
 			'neve-link-color'       => array(
 				'val'   => 'var(--nv-primary-accent)',
-				'label' => __( 'Neve - Primary Accent', 'neve' ),
+				'label' => $prefix . __( 'Primary Accent', 'neve' ),
 			),
 			'neve-link-hover-color' => array(
 				'val'   => 'var(--nv-secondary-accent)',
-				'label' => __( 'Neve - Secondary Accent', 'neve' ),
+				'label' => $prefix . __( 'Secondary Accent', 'neve' ),
 			),
 			'nv-site-bg'            => array(
 				'val'   => 'var(--nv-site-bg)',
-				'label' => __( 'Neve - Site Background', 'neve' ),
+				'label' => $prefix . __( 'Site Background', 'neve' ),
 			),
 			'nv-light-bg'           => array(
 				'val'   => 'var(--nv-light-bg)',
-				'label' => __( 'Neve - Light Background', 'neve' ),
+				'label' => $prefix . __( 'Light Background', 'neve' ),
 			),
 			'nv-dark-bg'            => array(
 				'val'   => 'var(--nv-dark-bg)',
-				'label' => __( 'Neve - Dark Background', 'neve' ),
+				'label' => $prefix . __( 'Dark Background', 'neve' ),
 			),
 			'neve-text-color'       => array(
 				'val'   => 'var(--nv-text-color)',
-				'label' => __( 'Neve - Text Color', 'neve' ),
+				'label' => $prefix . __( 'Text Color', 'neve' ),
 			),
 			'nv-text-dark-bg'       => array(
 				'val'   => 'var(--nv-text-dark-bg)',
-				'label' => __( 'Neve - Text Dark Background', 'neve' ),
+				'label' => $prefix . __( 'Text Dark Background', 'neve' ),
 			),
 			'nv-c-1'                => array(
 				'val'   => 'var(--nv-c-1)',
-				'label' => __( 'Neve - Extra Color 1', 'neve' ),
+				'label' => $prefix . __( 'Extra Color 1', 'neve' ),
 			),
 			'nv-c-2'                => array(
 				'val'   => 'var(--nv-c-2)',
-				'label' => __( 'Neve - Extra Color 2', 'neve' ),
+				'label' => $prefix . __( 'Extra Color 2', 'neve' ),
 			),
 		];
 


### PR DESCRIPTION
### Summary
- Makes sure global colors theme name is adapted to White Label settings
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Enable WhiteLabel and check the global colors names in the Elementor / Gutenberg Palettes;
- They should not include "Neve" but have the "Theme" prefix, as opposed to the free version.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1096.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
