### PR TITLE
chore: add filter to display comment form first [ref #2481]

### DIFF
--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -28,6 +28,12 @@ class Comments extends Base_View {
 	 * Render the comments form.
 	 */
 	public function render_comment_form() {
+		$display_form_first = apply_filters( 'neve_show_comment_form_first', false );
+
+		if ( $display_form_first ) {
+			comment_form();
+		}
+
 		if ( have_comments() ) { ?>
 			<div class="nv-comments-title-wrap">
 				<h2 class="comments-title">
@@ -57,8 +63,9 @@ class Comments extends Base_View {
 			<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'neve' ); ?></p>
 			<?php
 		}
-
-		comment_form();
+		if ( ! $display_form_first ) {
+			comment_form();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Add a filter that will account for the functionality the doc tries the implement.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- add a PHP file inside of your mu-plugins folder and add the following code to it: `add_filter( 'neve_show_comment_form_first', '__return_true' );
`
- the comment form should be displayed before the comments instead of after;
- this should replace the functionality that the document was aiming to provide; 
- note that after this is released you should ping me to update the doc;

<!-- Issues that this pull request closes. -->
Ref #2481.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
