### PR TITLE
Add support for themer parts

### DIFF
--- a/globals/hooks.php
+++ b/globals/hooks.php
@@ -21,20 +21,6 @@ function neve_before_header_wrapper_trigger() {
 }
 
 /**
- * Hook just before the responsive navbar-toggle.
- */
-function neve_before_navbar_toggle_trigger() {
-	do_action( 'neve_before_navbar_toggle_hook' );
-}
-
-/**
- * Hook just after the responsive navbar-toggle.
- */
-function neve_after_navbar_toggle_trigger() {
-	do_action( 'neve_after_navbar_toggle_hook' );
-}
-
-/**
  * Hook just after the header ( navigation ) area
  */
 function neve_after_header_trigger() {

--- a/inc/compatibility/beaver.php
+++ b/inc/compatibility/beaver.php
@@ -25,6 +25,7 @@ class Beaver extends Page_Builder_Base {
 		}
 
 		add_action( 'wp', array( $this, 'add_theme_builder_hooks' ) );
+		add_filter( 'fl_theme_builder_part_hooks', array( $this, 'register_part_hooks' ) );
 	}
 
 	/**
@@ -77,5 +78,69 @@ class Beaver extends Page_Builder_Base {
 			add_action( 'neve_do_footer', 'FLThemeBuilderLayoutRenderer::render_footer' );
 		}
 
+	}
+
+	/**
+	 * Register part hooks for Beaver Themer.
+	 *
+	 * @return array
+	 */
+	public function register_part_hooks() {
+		return array(
+			array(
+				'label' => __( 'Header', 'neve' ),
+				'hooks' => array(
+					'neve_before_header_wrapper_hook' => __( 'Before header wrapper', 'neve' ),
+					'neve_before_header_hook'         => __( 'Before header', 'neve' ),
+					'neve_after_header_hook'          => __( 'After header', 'neve' ),
+					'neve_after_header_wrapper_hook'  => __( 'After header wrapper', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Footer', 'neve' ),
+				'hooks' => array(
+					'neve_before_footer_hook' => __( 'Before footer', 'neve' ),
+					'neve_after_footer_hook'  => __( 'After footer', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Single Page', 'neve' ),
+				'hooks' => array(
+					'neve_before_page_header'   => __( 'Before page header', 'neve' ),
+					'neve_before_content'       => __( 'Before content', 'neve' ),
+					'neve_after_content'        => __( 'After content', 'neve' ),
+					'neve_before_page_comments' => __( 'Before comments', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Single Post', 'neve' ),
+				'hooks' => array(
+					'neve_before_post_content' => __( 'Before content', 'neve' ),
+					'neve_after_post_content'  => __( 'After content', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Cart Popup', 'neve' ),
+				'hooks' => array(
+					'neve_before_cart_popup'          => __( 'Before cart popup', 'neve' ),
+					'neve_after_cart_popup'           => __( 'After cart popup', 'neve' ),
+					'neve_cart_icon_after_cart_total' => __( 'After cart total', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Blog', 'neve' ),
+				'hooks' => array(
+					'neve_before_posts_loop' => __( 'Before posts loop', 'neve' ),
+					'neve_after_posts_loop'  => __( 'After posts loop', 'neve' ),
+				),
+			),
+			array(
+				'label' => __( 'Sideber', 'neve' ),
+				'hooks' => array(
+					'neve_before_sidebar_content' => __( 'Before sidebar content', 'neve' ),
+					'neve_after_sidebar_content'  => __( 'After sidebar content', 'neve' ),
+				),
+			),
+		);
 	}
 }

--- a/inc/compatibility/beaver.php
+++ b/inc/compatibility/beaver.php
@@ -81,66 +81,45 @@ class Beaver extends Page_Builder_Base {
 	}
 
 	/**
+	 * Beautify hook names.
+	 *
+	 * @param string $hook Hook name.
+	 *
+	 * @return string
+	 */
+	private function beautify_hook( $hook ) {
+		$hook_label = str_replace( '_', ' ', $hook );
+		$hook_label = str_replace( 'neve', ' ', $hook_label );
+		$hook_label = str_replace( 'woocommerce', ' ', $hook_label );
+		$hook_label = ucwords( $hook_label );
+		return $hook_label;
+	}
+
+	/**
+	 * Mapping function to move from neve_hooks format to the format required by Beaver Builder.
+	 *
+	 * @param string $location Current location, the key of neve_hooks array.
+	 * @param array  $hooks Hooks from that location.
+	 *
+	 * @return array
+	 */
+	private function hook_to_part( $location, $hooks ) {
+		$part = array(
+			'label' => ucfirst( $location ),
+		);
+		foreach ( $hooks as $hook ) {
+			$part['hooks'][ $hook ] = $this->beautify_hook( $hook );
+		}
+		return $part;
+	}
+
+	/**
 	 * Register part hooks for Beaver Themer.
 	 *
 	 * @return array
 	 */
 	public function register_part_hooks() {
-		return array(
-			array(
-				'label' => __( 'Header', 'neve' ),
-				'hooks' => array(
-					'neve_before_header_wrapper_hook' => __( 'Before header wrapper', 'neve' ),
-					'neve_before_header_hook'         => __( 'Before header', 'neve' ),
-					'neve_after_header_hook'          => __( 'After header', 'neve' ),
-					'neve_after_header_wrapper_hook'  => __( 'After header wrapper', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Footer', 'neve' ),
-				'hooks' => array(
-					'neve_before_footer_hook' => __( 'Before footer', 'neve' ),
-					'neve_after_footer_hook'  => __( 'After footer', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Single Page', 'neve' ),
-				'hooks' => array(
-					'neve_before_page_header'   => __( 'Before page header', 'neve' ),
-					'neve_before_content'       => __( 'Before content', 'neve' ),
-					'neve_after_content'        => __( 'After content', 'neve' ),
-					'neve_before_page_comments' => __( 'Before comments', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Single Post', 'neve' ),
-				'hooks' => array(
-					'neve_before_post_content' => __( 'Before content', 'neve' ),
-					'neve_after_post_content'  => __( 'After content', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Cart Popup', 'neve' ),
-				'hooks' => array(
-					'neve_before_cart_popup'          => __( 'Before cart popup', 'neve' ),
-					'neve_after_cart_popup'           => __( 'After cart popup', 'neve' ),
-					'neve_cart_icon_after_cart_total' => __( 'After cart total', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Blog', 'neve' ),
-				'hooks' => array(
-					'neve_before_posts_loop' => __( 'Before posts loop', 'neve' ),
-					'neve_after_posts_loop'  => __( 'After posts loop', 'neve' ),
-				),
-			),
-			array(
-				'label' => __( 'Sideber', 'neve' ),
-				'hooks' => array(
-					'neve_before_sidebar_content' => __( 'Before sidebar content', 'neve' ),
-					'neve_after_sidebar_content'  => __( 'After sidebar content', 'neve' ),
-				),
-			),
-		);
+		$hooks = neve_hooks();
+		return array_map( array( $this, 'hook_to_part' ), array_keys( $hooks ), $hooks );
 	}
 }

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -54,6 +54,7 @@ class Front_End {
 		add_theme_support( 'editor-color-palette', $this->get_gutenberg_color_palette() );
 		add_theme_support( 'fl-theme-builder-headers' );
 		add_theme_support( 'fl-theme-builder-footers' );
+		add_theme_support( 'fl-theme-builder-parts' );
 		add_theme_support( 'header-footer-elementor' );
 		add_theme_support( 'lifterlms-sidebars' );
 		add_theme_support( 'lifterlms' );


### PR DESCRIPTION
### Summary
Add support for beaver themer parts, following [this](https://docs.wpbeaverbuilder.com/beaver-themer/developer/add-header-footer-and-parts-support-to-your-theme-themer/) documentation.

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->
1. https://prnt.sc/xt6lu1
2. https://prnt.sc/xt6nt8
3. https://prnt.sc/xt6qw6

### Test instructions
1. Install Beaver Builder Pro and Beaver Themer form handbook
2. Follow the steps described in the Screenshots section.


Closes #2329.
