### PR TITLE
style: adds Prettier to run together with ESLint

### DIFF
--- a/cypress/.eslintrc
+++ b/cypress/.eslintrc
@@ -1,5 +1,9 @@
 {
-	"extends": ["plugin:cypress/recommended", "plugin:chai-friendly/recommended"],
+	"extends": [
+		"plugin:cypress/recommended",
+		"plugin:chai-friendly/recommended",
+		"plugin:prettier/recommended"
+	],
 	"env": {
 		"cypress/globals": true,
 		"jest": false,
@@ -12,6 +16,13 @@
 		"jest/valid-expect": "off",
 		"jest/no-standalone-expect": "off",
 		// temporary disable no unnecessary wait rule
-		"cypress/no-unnecessary-waiting": "off"
+		"cypress/no-unnecessary-waiting": "off",
+		"prettier/prettier": [
+			"error",
+			{},
+			{
+				"usePrettierrc": false
+			}
+		]
 	}
 }

--- a/cypress/.prettierrc.json
+++ b/cypress/.prettierrc.json
@@ -3,5 +3,7 @@
 	"tabWidth": 2,
 	"semi": true,
 	"singleQuote": true,
-	"printWidth": 100
+	"printWidth": 100,
+	"bracketSpacing": true,
+	"arrowParens": "always"
 }

--- a/cypress/integration/amp/amp-test.spec.js
+++ b/cypress/integration/amp/amp-test.spec.js
@@ -1,122 +1,120 @@
-describe('AMP Check', () => {
-	before('Sets up search icon on menu top row', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
+describe("AMP Check", () => {
+  before("Sets up search icon on menu top row", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
 
-		cy.get('#accordion-panel-hfg_header').should('be.visible').click();
+    cy.get("#accordion-panel-hfg_header").should("be.visible").click();
 
-		cy.get(
-			'.hfg--builder-show .hfg--panel-desktop .hfg--row-top .row--grid > div:last-child'
-		).trigger('mouseover');
-		cy.get(
-			'.hfg--builder-show .hfg--panel-desktop .hfg--row-top .row--grid > div:last-child .add-button--grid'
-		)
-			.should('be.visible')
-			.click();
+    cy.get(
+      ".hfg--builder-show .hfg--panel-desktop .hfg--row-top .row--grid > div:last-child"
+    ).trigger("mouseover");
+    cy.get(
+      ".hfg--builder-show .hfg--panel-desktop .hfg--row-top .row--grid > div:last-child .add-button--grid"
+    )
+      .should("be.visible")
+      .click();
 
-		cy.get('.widgets-panel--visible').should('exist');
-		cy.get(
-			'.widgets-panel--visible .hfg--widgets-desktop  .grid-stack-item.for-s-header_search_responsive'
-		).click();
+    cy.get(".widgets-panel--visible").should("exist");
+    cy.get(
+      ".widgets-panel--visible .hfg--widgets-desktop  .grid-stack-item.for-s-header_search_responsive"
+    ).click();
 
-		cy.get('#save').should('be.visible').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-		cy.visit('/wp-admin');
-		cy.get('#wp-admin-bar-logout > a').click({
-			force: true,
-		});
-	});
+    cy.get("#save").should("be.visible").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+    cy.visit("/wp-admin");
+    cy.get("#wp-admin-bar-logout > a").click({
+      force: true,
+    });
+  });
 
-	it('Checks the search box from the menu', () => {
-		cy.visit('/?amp');
-		cy.get(
-			'.header--row.header-top[data-show-on=desktop] .builder-item--header_search_responsive .nv-search-icon-component .menu-item-nav-search'
-		)
-			.as('navSearchButton')
-			.should('be.visible')
-			.click();
+  it("Checks the search box from the menu", () => {
+    cy.visit("/?amp");
+    cy.get(
+      ".header--row.header-top[data-show-on=desktop] .builder-item--header_search_responsive .nv-search-icon-component .menu-item-nav-search"
+    )
+      .as("navSearchButton")
+      .should("be.visible")
+      .click();
 
-		cy.get('@navSearchButton').should('have.class', 'active');
+    cy.get("@navSearchButton").should("have.class", "active");
 
-		cy.get('@navSearchButton')
-			.find('> .nv-nav-search')
-			.as('navSearchForm')
-			.should('be.visible');
+    cy.get("@navSearchButton")
+      .find("> .nv-nav-search")
+      .as("navSearchForm")
+      .should("be.visible");
 
-		cy.get('@navSearchButton').find('.close-responsive-search').click();
-		cy.get('@navSearchButton').should('not.have.class', 'active');
-		cy.get('@navSearchForm').should('have.css', 'opacity', '0');
-		cy.get('@navSearchButton').click();
+    cy.get("@navSearchButton").find(".close-responsive-search").click();
+    cy.get("@navSearchButton").should("not.have.class", "active");
+    cy.get("@navSearchForm").should("have.css", "opacity", "0");
+    cy.get("@navSearchButton").click();
 
-		cy.get('@navSearchForm')
-			.find('form')
-			.invoke('removeAttr', 'target')
-			.invoke('removeAttr', 'action');
-		cy.get('@navSearchForm').find('.search-field').as('formField').click();
-		cy.get('@navSearchForm').find('.search-submit').as('submitButton');
-		cy.get('@formField').should('have.focus').type('Hello');
-		cy.get('@submitButton').click();
-		cy.url().should('include', '/?s=Hello');
-		cy.get('.nv-page-title')
-			.find('h1')
-			.should('have.text', 'Search Results for: Hello');
-	});
+    cy.get("@navSearchForm")
+      .find("form")
+      .invoke("removeAttr", "target")
+      .invoke("removeAttr", "action");
+    cy.get("@navSearchForm").find(".search-field").as("formField").click();
+    cy.get("@navSearchForm").find(".search-submit").as("submitButton");
+    cy.get("@formField").should("have.focus").type("Hello");
+    cy.get("@submitButton").click();
+    cy.url().should("include", "/?s=Hello");
+    cy.get(".nv-page-title")
+      .find("h1")
+      .should("have.text", "Search Results for: Hello");
+  });
 
-	it('Checks the sidebar menu on mobile', () => {
-		cy.visit('/?amp');
-		cy.viewport('iphone-x');
+  it("Checks the sidebar menu on mobile", () => {
+    cy.visit("/?amp");
+    cy.viewport("iphone-x");
 
-		cy.get('#header-menu-sidebar')
-			.as('navSidebar')
-			.should('not.be.visible');
+    cy.get("#header-menu-sidebar").as("navSidebar").should("not.be.visible");
 
-		cy.get('.menu-mobile-toggle .navbar-toggle')
-			.as('navToggle')
-			.should('be.visible')
-			.click();
+    cy.get(".menu-mobile-toggle .navbar-toggle")
+      .as("navToggle")
+      .should("be.visible")
+      .click();
 
-		cy.get('@navSidebar').should('be.visible');
-		cy.get('@navSidebar')
-			.find('.navbar-toggle')
-			.should('be.visible')
-			.should('have.class', 'active')
-			.click();
+    cy.get("@navSidebar").should("be.visible");
+    cy.get("@navSidebar")
+      .find(".navbar-toggle")
+      .should("be.visible")
+      .should("have.class", "active")
+      .click();
 
-		cy.get('@navSidebar').should('not.be.visible');
-	});
+    cy.get("@navSidebar").should("not.be.visible");
+  });
 
-	it('Checks the sidebar sub-menu', () => {
-		cy.visit('/?amp');
-		cy.viewport('iphone-x');
+  it("Checks the sidebar sub-menu", () => {
+    cy.visit("/?amp");
+    cy.viewport("iphone-x");
 
-		cy.get('.menu-mobile-toggle .navbar-toggle').click();
+    cy.get(".menu-mobile-toggle .navbar-toggle").click();
 
-		cy.get('#header-menu-sidebar').as('navSidebar').should('be.visible');
+    cy.get("#header-menu-sidebar").as("navSidebar").should("be.visible");
 
-		cy.get('@navSidebar').find('.amp-caret-wrap').first().click();
+    cy.get("@navSidebar").find(".amp-caret-wrap").first().click();
 
-		cy.get('@navSidebar')
-			.find('.has-caret')
-			.first()
-			.should('have.class', 'dropdown-open');
+    cy.get("@navSidebar")
+      .find(".has-caret")
+      .first()
+      .should("have.class", "dropdown-open");
 
-		cy.get('@navSidebar')
-			.find('.amp-caret-wrap')
-			.first()
-			.closest('li')
-			.find('.sub-menu')
-			.should('be.visible');
+    cy.get("@navSidebar")
+      .find(".amp-caret-wrap")
+      .first()
+      .closest("li")
+      .find(".sub-menu")
+      .should("be.visible");
 
-		cy.get('@navSidebar').find('.amp-caret-wrap').first().click();
+    cy.get("@navSidebar").find(".amp-caret-wrap").first().click();
 
-		cy.get('@navSidebar')
-			.find('.amp-caret-wrap')
-			.first()
-			.closest('li')
-			.find('.sub-menu')
-			.should('not.be.visible');
-	});
+    cy.get("@navSidebar")
+      .find(".amp-caret-wrap")
+      .first()
+      .closest("li")
+      .find(".sub-menu")
+      .should("not.be.visible");
+  });
 });

--- a/cypress/integration/customizer/general/color-control.spec.js
+++ b/cypress/integration/customizer/general/color-control.spec.js
@@ -1,57 +1,57 @@
-describe('Color Control', () => {
-	const color = '#fd8f6a';
-	const rgbColor = 'rgb(253, 143, 106)';
-	const controlSlug = 'hfg_header_layout_main_new_text_color';
+describe("Color Control", () => {
+  const color = "#fd8f6a";
+  const rgbColor = "rgb(253, 143, 106)";
+  const controlSlug = "hfg_header_layout_main_new_text_color";
 
-	before(() => {
-		cy.goToCustomizer();
-	});
+  before(() => {
+    cy.goToCustomizer();
+  });
 
-	it('Test Color Control - Customizer', () => {
-		cy.getCustomizerControl(controlSlug).as('control');
-		cy.get('label.hfg_header_layout_main_new_text_color').click();
-		// Open picker.
-		cy.get('@control').find('button.is-secondary').click();
-		// Set a color.
-		cy.get('@control').find('input').clear().type(color).wait(500);
-		// Open the picker.
-		cy.get('@control').find('button.is-secondary').click().click();
-		// Popover should exist and be visible.
-		cy.get('@control')
-			.find('.components-popover')
-			.should('exist')
-			.and('be.visible');
-		// Clear should not exist as there is no set color.
-		cy.get('@control').find('button.clear').should('exist').click();
-		// Set a color.
-		cy.get('@control').find('button.is-secondary').click();
-		cy.get('@control').find('input').clear().type(color);
-		// Clear should exist as there is a set color.
-		cy.get('@control').find('button.clear').should('not.exist');
-		// Click outside to hide popover.
-		cy.get('@control').find('.neve-color-control').click();
-		// Popover should not exist after click outside.
-		cy.get('@control').find('.components-popover').should('not.exist');
-		// Button should have a background color and it should be the color translated to RGB.
-		cy.get('@control')
-			.find('button .color')
-			.should('have.css', 'background-color')
-			.and('eq', rgbColor);
-		// Check the actual value of the control set through the API.
-		cy.getCustomizerControlValue(controlSlug).should('eq', color);
-		// Save the customizer.
-		cy.aliasRestRoutes();
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+  it("Test Color Control - Customizer", () => {
+    cy.getCustomizerControl(controlSlug).as("control");
+    cy.get("label.hfg_header_layout_main_new_text_color").click();
+    // Open picker.
+    cy.get("@control").find("button.is-secondary").click();
+    // Set a color.
+    cy.get("@control").find("input").clear().type(color).wait(500);
+    // Open the picker.
+    cy.get("@control").find("button.is-secondary").click().click();
+    // Popover should exist and be visible.
+    cy.get("@control")
+      .find(".components-popover")
+      .should("exist")
+      .and("be.visible");
+    // Clear should not exist as there is no set color.
+    cy.get("@control").find("button.clear").should("exist").click();
+    // Set a color.
+    cy.get("@control").find("button.is-secondary").click();
+    cy.get("@control").find("input").clear().type(color);
+    // Clear should exist as there is a set color.
+    cy.get("@control").find("button.clear").should("not.exist");
+    // Click outside to hide popover.
+    cy.get("@control").find(".neve-color-control").click();
+    // Popover should not exist after click outside.
+    cy.get("@control").find(".components-popover").should("not.exist");
+    // Button should have a background color and it should be the color translated to RGB.
+    cy.get("@control")
+      .find("button .color")
+      .should("have.css", "background-color")
+      .and("eq", rgbColor);
+    // Check the actual value of the control set through the API.
+    cy.getCustomizerControlValue(controlSlug).should("eq", color);
+    // Save the customizer.
+    cy.aliasRestRoutes();
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Test Color Control - Front End', () => {
-		cy.visit('/');
-		cy.get('.header-main-inner')
-			.should('have.css', 'color')
-			.and('eq', rgbColor);
-	});
+  it("Test Color Control - Front End", () => {
+    cy.visit("/");
+    cy.get(".header-main-inner")
+      .should("have.css", "color")
+      .and("eq", rgbColor);
+  });
 });

--- a/cypress/integration/customizer/general/global-colors-control.spec.js
+++ b/cypress/integration/customizer/general/global-colors-control.spec.js
@@ -1,122 +1,108 @@
-describe('Global Colors', () => {
-	before(() => {
-		cy.goToCustomizer();
-		cy.getCustomizerControl('neve_global_colors');
-		cy.get('.neve-global-colors-wrap').as('wrap');
-	});
+describe("Global Colors", () => {
+  before(() => {
+    cy.goToCustomizer();
+    cy.getCustomizerControl("neve_global_colors");
+    cy.get(".neve-global-colors-wrap").as("wrap");
+  });
 
-	it('Palette Selector', () => {
-		cy.get('.neve-global-color-palette-inner.active').should(
-			'contain',
-			'Base'
-		);
+  it("Palette Selector", () => {
+    cy.get(".neve-global-color-palette-inner.active").should("contain", "Base");
 
-		cy.get('.neve-global-color-palette-inner')
-			.contains('Dark Mode')
-			.click();
+    cy.get(".neve-global-color-palette-inner").contains("Dark Mode").click();
 
-		cy.get('.neve-global-color-palette-inner.active').should(
-			'contain',
-			'Dark Mode'
-		);
-	});
+    cy.get(".neve-global-color-palette-inner.active").should(
+      "contain",
+      "Dark Mode"
+    );
+  });
 
-	it('Palette Add', () => {
-		cy.get('.add-palette-form').as('form');
-		cy.get('@form').find('button').click();
-		cy.get('@form').find('input').type('Base');
-		cy.get('@form').find('button').contains('Add').should('be.disabled');
-		cy.get('@form').find('input').clear();
+  it("Palette Add", () => {
+    cy.get(".add-palette-form").as("form");
+    cy.get("@form").find("button").click();
+    cy.get("@form").find("input").type("Base");
+    cy.get("@form").find("button").contains("Add").should("be.disabled");
+    cy.get("@form").find("input").clear();
 
-		cy.get('@form').find('input').type('Test Palette');
-		cy.get('@form').find('select').select('darkMode');
-		cy.get('@form').find('button').contains('Add').click();
+    cy.get("@form").find("input").type("Test Palette");
+    cy.get("@form").find("select").select("darkMode");
+    cy.get("@form").find("button").contains("Add").click();
 
-		cy.get('.neve-global-color-palette-inner.active').should(
-			'contain',
-			'Test Palette'
-		);
-	});
+    cy.get(".neve-global-color-palette-inner.active").should(
+      "contain",
+      "Test Palette"
+    );
+  });
 
-	it('Palette Delete', () => {
-		cy.get('.neve-global-color-palette-inner.active')
-			.siblings('.delete-palette')
-			.click({ force: true });
+  it("Palette Delete", () => {
+    cy.get(".neve-global-color-palette-inner.active")
+      .siblings(".delete-palette")
+      .click({ force: true });
 
-		cy.get('.neve-global-colors-confirm-delete-modal button')
-			.contains('Delete')
-			.click({ force: true });
+    cy.get(".neve-global-colors-confirm-delete-modal button")
+      .contains("Delete")
+      .click({ force: true });
 
-		cy.get('.neve-global-colors-confirm-delete-modal').should('not.exist');
+    cy.get(".neve-global-colors-confirm-delete-modal").should("not.exist");
 
-		cy.get('.neve-global-color-palette-inner.active').should(
-			'contain',
-			'Base'
-		);
-	});
+    cy.get(".neve-global-color-palette-inner.active").should("contain", "Base");
+  });
 
-	it('Changes Colors', () => {
-		cy.get('.color-array-wrap .neve-color-component').each((control) => {
-			cy.get(control).find('button.is-secondary').click({ force: true });
-			cy.get(control).find('input').clear().type('#000000');
-			cy.get(control)
-				.find('.customize-control-title')
-				.click({ force: true });
-		});
+  it("Changes Colors", () => {
+    cy.get(".color-array-wrap .neve-color-component").each((control) => {
+      cy.get(control).find("button.is-secondary").click({ force: true });
+      cy.get(control).find("input").clear().type("#000000");
+      cy.get(control).find(".customize-control-title").click({ force: true });
+    });
 
-		cy.get('.neve-global-color-palette-inner.active .color').each(
-			(color) => {
-				cy.get(color)
-					.should('have.css', 'background-color')
-					.and('eq', 'rgb(0, 0, 0)');
-			}
-		);
-		cy.wait(100)
-			.window()
-			.then((win) => {
-				const controlValue = win.wp.customize
-					.control('neve_global_colors')
-					.setting.get();
-				const nonBlack = Object.values(
-					controlValue.palettes.base.colors
-				).filter((item) => item !== '#000000');
-				expect(nonBlack).to.have.length(0);
-			});
-	});
+    cy.get(".neve-global-color-palette-inner.active .color").each((color) => {
+      cy.get(color)
+        .should("have.css", "background-color")
+        .and("eq", "rgb(0, 0, 0)");
+    });
+    cy.wait(100)
+      .window()
+      .then((win) => {
+        const controlValue = win.wp.customize
+          .control("neve_global_colors")
+          .setting.get();
+        const nonBlack = Object.values(
+          controlValue.palettes.base.colors
+        ).filter((item) => item !== "#000000");
+        expect(nonBlack).to.have.length(0);
+      });
+  });
 
-	it('Palette Selector in Color Component', () => {
-		cy.getCustomizerControl('neve_button_appearance').as('buttonControl');
+  it("Palette Selector in Color Component", () => {
+    cy.getCustomizerControl("neve_button_appearance").as("buttonControl");
 
-		cy.get('@buttonControl').find('.global-color-picker').first().click();
+    cy.get("@buttonControl").find(".global-color-picker").first().click();
 
-		cy.get('.nv-custom-palette-wrap').should('be.visible');
-		cy.get('.nv-custom-palette-wrap .nv-custom-palette-color').should(
-			'have.length',
-			9
-		);
+    cy.get(".nv-custom-palette-wrap").should("be.visible");
+    cy.get(".nv-custom-palette-wrap .nv-custom-palette-color").should(
+      "have.length",
+      9
+    );
 
-		cy.get('.nv-custom-palette-wrap .nv-custom-palette-color')
-			.first()
-			.click();
+    cy.get(".nv-custom-palette-wrap .nv-custom-palette-color").first().click();
 
-		cy.get('@buttonControl')
-			.find('.global-color-picker')
-			.first()
-			.should('have.class', 'active');
+    cy.get("@buttonControl")
+      .find(".global-color-picker")
+      .first()
+      .should("have.class", "active");
 
-		cy.get('.nv-custom-palette-wrap button').contains('Edit').click();
-	});
+    cy.get(".nv-custom-palette-wrap button").contains("Edit").click();
+  });
 
-	it('Palette Reset', () => {
-		cy.get('.reset-palette').should('not.be', 'disabled').click();
-		cy.window().then((win) => {
-			const controlValue = win.wp.customize
-				.control('neve_global_colors')
-				.setting.get();
-			const nonBlack = Object.values(
-				controlValue.palettes.base.colors
-			).filter((item) => item !== '#000000');
-			expect(nonBlack).to.have.length(9);
-		});
-	});
+  it("Palette Reset", () => {
+    cy.get(".reset-palette").should("not.be", "disabled").click();
+    cy.window().then((win) => {
+      const controlValue = win.wp.customize
+        .control("neve_global_colors")
+        .setting.get();
+      const nonBlack = Object.values(controlValue.palettes.base.colors).filter(
+        (item) => item !== "#000000"
+      );
+      expect(nonBlack).to.have.length(9);
+    });
+  });
 });

--- a/cypress/integration/customizer/general/order-control.spec.js
+++ b/cypress/integration/customizer/general/order-control.spec.js
@@ -1,76 +1,74 @@
-describe('Ordering Control', () => {
-	let value = null;
+describe("Ordering Control", () => {
+  let value = null;
 
-	beforeEach(() => {
-		cy.goToCustomizer();
-		cy.window().then((win) => {
-			win.wp.customize.control('neve_post_content_ordering').focus();
-			value = JSON.parse(
-				win.wp.customize.control('neve_post_content_ordering').setting()
-			);
-			cy.get(
-				'#customize-control-neve_blog_ordering_content_heading'
-			).click();
-		});
+  beforeEach(() => {
+    cy.goToCustomizer();
+    cy.window().then((win) => {
+      win.wp.customize.control("neve_post_content_ordering").focus();
+      value = JSON.parse(
+        win.wp.customize.control("neve_post_content_ordering").setting()
+      );
+      cy.get("#customize-control-neve_blog_ordering_content_heading").click();
+    });
 
-		cy.get('#customize-control-neve_post_content_ordering').as('control');
-	});
+    cy.get("#customize-control-neve_post_content_ordering").as("control");
+  });
 
-	before(() => {
-		cy.goToCustomizer();
-		cy.window().then((win) => {
-			const defaultValue = JSON.stringify([
-				'thumbnail',
-				'title-meta',
-				'excerpt',
-			]);
-			const currentValue = win.wp.customize
-				.control('neve_post_content_ordering')
-				.setting();
-			if (currentValue !== defaultValue) {
-				win.wp.customize
-					.control('neve_post_content_ordering')
-					.setting.set(defaultValue);
-				cy.aliasRestRoutes();
-				cy.get('#save').click();
-				cy.wait('@customizerSave').then((interception) => {
-					expect(interception.response.body.success).to.be.true;
-					expect(interception.response.statusCode).to.equal(200);
-					cy.wait(2000);
-				});
-			}
-		});
-	});
+  before(() => {
+    cy.goToCustomizer();
+    cy.window().then((win) => {
+      const defaultValue = JSON.stringify([
+        "thumbnail",
+        "title-meta",
+        "excerpt",
+      ]);
+      const currentValue = win.wp.customize
+        .control("neve_post_content_ordering")
+        .setting();
+      if (currentValue !== defaultValue) {
+        win.wp.customize
+          .control("neve_post_content_ordering")
+          .setting.set(defaultValue);
+        cy.aliasRestRoutes();
+        cy.get("#save").click();
+        cy.wait("@customizerSave").then((interception) => {
+          expect(interception.response.body.success).to.be.true;
+          expect(interception.response.statusCode).to.equal(200);
+          cy.wait(2000);
+        });
+      }
+    });
+  });
 
-	it('Test Ordering', () => {
-		cy.get('@control').find('.handle').should('have.length', 3);
-		cy.dropElAfter(
-			'#customize-control-neve_post_content_ordering .items-list .neve-sortable-item .handle',
-			0,
-			1
-		);
-		cy.window().then((win) => {
-			const newValue = JSON.parse(
-				win.wp.customize.control('neve_post_content_ordering').setting()
-			);
-			const tmp = value[0];
-			value[0] = value[1];
-			value[1] = value[2];
-			value[2] = tmp;
-			expect(value).to.deep.eq(newValue);
-		});
-	});
+  it("Test Ordering", () => {
+    cy.get("@control").find(".handle").should("have.length", 3);
+    cy.dropElAfter(
+      "#customize-control-neve_post_content_ordering .items-list .neve-sortable-item .handle",
+      0,
+      1
+    );
+    cy.window().then((win) => {
+      const newValue = JSON.parse(
+        win.wp.customize.control("neve_post_content_ordering").setting()
+      );
+      const tmp = value[0];
+      value[0] = value[1];
+      value[1] = value[2];
+      value[2] = tmp;
+      expect(value).to.deep.eq(newValue);
+    });
+  });
 
-	it('Test Hiding', () => {
-		cy.get('@control').find('.toggle').should('have.length', 3);
-		cy.get('@control').find('.toggle').first().click();
-		cy.get('@control').find('.neve-sortable-item.disabled').should('exist');
-		cy.window().then((win) => {
-			const newValue = JSON.parse(
-				win.wp.customize.control('neve_post_content_ordering').setting()
-			);
-			value.shift();
-			expect(value).to.deep.eq(newValue);
-		});
-	});
+  it("Test Hiding", () => {
+    cy.get("@control").find(".toggle").should("have.length", 3);
+    cy.get("@control").find(".toggle").first().click();
+    cy.get("@control").find(".neve-sortable-item.disabled").should("exist");
+    cy.window().then((win) => {
+      const newValue = JSON.parse(
+        win.wp.customize.control("neve_post_content_ordering").setting()
+      );
+      value.shift();
+      expect(value).to.deep.eq(newValue);
+    });
+  });
 });

--- a/cypress/integration/customizer/hfg/hfg-alignment-control.spec.js
+++ b/cypress/integration/customizer/hfg/hfg-alignment-control.spec.js
@@ -1,40 +1,40 @@
-describe('Header Builder Alignment Control', () => {
-	beforeEach(() => {
-		// Login to wp and redirect to customizer.
+describe("Header Builder Alignment Control", () => {
+  beforeEach(() => {
+    // Login to wp and redirect to customizer.
 
-		cy.goToCustomizer();
+    cy.goToCustomizer();
 
-		cy.aliasRestRoutes();
-		// Open customizer panel.
-		cy.get('#accordion-panel-hfg_header').should('be.visible').click();
+    cy.aliasRestRoutes();
+    // Open customizer panel.
+    cy.get("#accordion-panel-hfg_header").should("be.visible").click();
 
-		// Check if Logo and Site title component is visible and click it.
-		cy.get(
-			'.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Logo & Site Identity"]'
-		)
-			.should('be.visible')
-			.click();
+    // Check if Logo and Site title component is visible and click it.
+    cy.get(
+      '.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Logo & Site Identity"]'
+    )
+      .should("be.visible")
+      .click();
 
-		// Switch to layout tab.
-		cy.get('#customize-control-logo_tabs [data-tab="layout"]')
-			.should('be.visible')
-			.click();
-	});
-	it('Sets up alignment for the Primary Menu to Center', () => {
-		cy.alignCenter();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-		cy.checkAlignCenter();
-	});
+    // Switch to layout tab.
+    cy.get('#customize-control-logo_tabs [data-tab="layout"]')
+      .should("be.visible")
+      .click();
+  });
+  it("Sets up alignment for the Primary Menu to Center", () => {
+    cy.alignCenter();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+    cy.checkAlignCenter();
+  });
 
-	it('Sets up alignment for the Primary Menu to Right', () => {
-		cy.alignRight();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-		cy.checkAlignRight();
-	});
+  it("Sets up alignment for the Primary Menu to Right", () => {
+    cy.alignRight();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+    cy.checkAlignRight();
+  });
 });

--- a/cypress/integration/customizer/hfg/hfg-margin-control.spec.js
+++ b/cypress/integration/customizer/hfg/hfg-margin-control.spec.js
@@ -1,86 +1,86 @@
-describe('Header Builder Margin Control', () => {
-	before(() => {
-		// Login to wp and redirect to customizer.
-		cy.goToCustomizer();
+describe("Header Builder Margin Control", () => {
+  before(() => {
+    // Login to wp and redirect to customizer.
+    cy.goToCustomizer();
 
-		// Open customizer panel.
-		cy.get('#accordion-panel-hfg_header').should('be.visible').click();
+    // Open customizer panel.
+    cy.get("#accordion-panel-hfg_header").should("be.visible").click();
 
-		// Check if Primary Menu component is visible and click it.
-		cy.get(
-			'.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Primary Menu"]'
-		)
-			.should('be.visible')
-			.click();
-		// Switch to layout tab.
-		cy.get('#customize-control-primary-menu_tabs [data-tab="layout"]')
-			.should('be.visible')
-			.click();
+    // Check if Primary Menu component is visible and click it.
+    cy.get(
+      '.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Primary Menu"]'
+    )
+      .should("be.visible")
+      .click();
+    // Switch to layout tab.
+    cy.get('#customize-control-primary-menu_tabs [data-tab="layout"]')
+      .should("be.visible")
+      .click();
 
-		// Increase Top Margin value
-		cy.get('#customize-control-primary-menu_component_margin .top-input')
-			.click()
-			.type('{uparrow}{uparrow}')
-			.trigger('change');
+    // Increase Top Margin value
+    cy.get("#customize-control-primary-menu_component_margin .top-input")
+      .click()
+      .type("{uparrow}{uparrow}")
+      .trigger("change");
 
-		// Check if linked values
-		cy.get(
-			'#customize-control-primary-menu_component_margin .top-input'
-		).should('have.value', '2');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .bottom-input'
-		).should('have.value', '2');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .left-input'
-		).should('have.value', '2');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .right-input'
-		).should('have.value', '2');
+    // Check if linked values
+    cy.get(
+      "#customize-control-primary-menu_component_margin .top-input"
+    ).should("have.value", "2");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .bottom-input"
+    ).should("have.value", "2");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .left-input"
+    ).should("have.value", "2");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .right-input"
+    ).should("have.value", "2");
 
-		// Click on Reset button
-		cy.get(
-			'#customize-control-primary-menu_component_margin button.reset'
-		).click();
+    // Click on Reset button
+    cy.get(
+      "#customize-control-primary-menu_component_margin button.reset"
+    ).click();
 
-		// Check if Reset button works
-		cy.get(
-			'#customize-control-primary-menu_component_margin .top-input'
-		).should('have.value', '0');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .bottom-input'
-		).should('have.value', '0');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .left-input'
-		).should('have.value', '0');
-		cy.get(
-			'#customize-control-primary-menu_component_margin .right-input'
-		).should('have.value', '0');
+    // Check if Reset button works
+    cy.get(
+      "#customize-control-primary-menu_component_margin .top-input"
+    ).should("have.value", "0");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .bottom-input"
+    ).should("have.value", "0");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .left-input"
+    ).should("have.value", "0");
+    cy.get(
+      "#customize-control-primary-menu_component_margin .right-input"
+    ).should("have.value", "0");
 
-		// Unlink values
-		cy.get(
-			'#customize-control-primary-menu_component_margin button.link'
-		).click();
+    // Unlink values
+    cy.get(
+      "#customize-control-primary-menu_component_margin button.link"
+    ).click();
 
-		// Increase Top Margin value
-		cy.get('#customize-control-primary-menu_component_margin .top-input')
-			.click()
-			.type('{uparrow}{uparrow}{uparrow}')
-			.trigger('change');
+    // Increase Top Margin value
+    cy.get("#customize-control-primary-menu_component_margin .top-input")
+      .click()
+      .type("{uparrow}{uparrow}{uparrow}")
+      .trigger("change");
 
-		// Decrease Bottom Padding value
-		cy.get('#customize-control-primary-menu_component_margin .bottom-input')
-			.click()
-			.type('{downarrow}')
-			.trigger('change');
+    // Decrease Bottom Padding value
+    cy.get("#customize-control-primary-menu_component_margin .bottom-input")
+      .click()
+      .type("{downarrow}")
+      .trigger("change");
 
-		cy.aliasRestRoutes();
-	});
-	it('Sets up Margin for the Primary Menu Component', () => {
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-			cy.checkMarginFrontEnd();
-		});
-	});
+    cy.aliasRestRoutes();
+  });
+  it("Sets up Margin for the Primary Menu Component", () => {
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+      cy.checkMarginFrontEnd();
+    });
+  });
 });

--- a/cypress/integration/customizer/hfg/hfg-padding-control.spec.js
+++ b/cypress/integration/customizer/hfg/hfg-padding-control.spec.js
@@ -1,97 +1,97 @@
-describe('Header Builder Padding Control', () => {
-	before(() => {
-		// Login to wp and redirect to customizer.
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
+describe("Header Builder Padding Control", () => {
+  before(() => {
+    // Login to wp and redirect to customizer.
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
 
-		// Open customizer panel.
-		cy.get('#accordion-panel-hfg_header').should('be.visible').click();
+    // Open customizer panel.
+    cy.get("#accordion-panel-hfg_header").should("be.visible").click();
 
-		// Check if Logo and Site title component is visible and click it.
-		cy.get(
-			'.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Logo & Site Identity"]'
-		)
-			.should('be.visible')
-			.click();
+    // Check if Logo and Site title component is visible and click it.
+    cy.get(
+      '.hfg--builder-show .hfg--panel-desktop .hfg--row-main .grid-stack-item[title="Logo & Site Identity"]'
+    )
+      .should("be.visible")
+      .click();
 
-		// Switch to layout tab.
-		cy.get('#customize-control-logo_tabs [data-tab="layout"]')
-			.should('be.visible')
-			.click();
+    // Switch to layout tab.
+    cy.get('#customize-control-logo_tabs [data-tab="layout"]')
+      .should("be.visible")
+      .click();
 
-		// Link values
-		cy.get('#customize-control-logo_component_padding button.link').click();
+    // Link values
+    cy.get("#customize-control-logo_component_padding button.link").click();
 
-		// Increase Top Padding value
-		cy.get('#customize-control-logo_component_padding .top-input')
-			.click()
-			.type(
-				'{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}'
-			)
-			.trigger('change');
+    // Increase Top Padding value
+    cy.get("#customize-control-logo_component_padding .top-input")
+      .click()
+      .type(
+        "{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}{uparrow}"
+      )
+      .trigger("change");
 
-		// Check if linked values
-		cy.get('#customize-control-logo_component_padding .top-input').should(
-			'have.value',
-			'30'
-		);
-		cy.get(
-			'#customize-control-logo_component_padding  .bottom-input'
-		).should('have.value', '30');
-		cy.get('#customize-control-logo_component_padding .left-input').should(
-			'have.value',
-			'30'
-		);
-		cy.get('#customize-control-logo_component_padding .right-input').should(
-			'have.value',
-			'30'
-		);
+    // Check if linked values
+    cy.get("#customize-control-logo_component_padding .top-input").should(
+      "have.value",
+      "30"
+    );
+    cy.get("#customize-control-logo_component_padding  .bottom-input").should(
+      "have.value",
+      "30"
+    );
+    cy.get("#customize-control-logo_component_padding .left-input").should(
+      "have.value",
+      "30"
+    );
+    cy.get("#customize-control-logo_component_padding .right-input").should(
+      "have.value",
+      "30"
+    );
 
-		// Click on Reset button
-		cy.get(
-			'#customize-control-logo_component_padding button.reset'
-		).click();
+    // Click on Reset button
+    cy.get("#customize-control-logo_component_padding button.reset").click();
 
-		// Check if Reset button works
-		cy.get('#customize-control-logo_component_padding .top-input').should(
-			'have.value',
-			'10'
-		);
-		cy.get('#customize-control-logo_component_padding .right-input').should(
-			'have.value',
-			'0'
-		);
-		cy.get(
-			'#customize-control-logo_component_padding .bottom-input'
-		).should('have.value', '10');
-		cy.get('#customize-control-logo_component_padding .left-input').should(
-			'have.value',
-			'0'
-		);
+    // Check if Reset button works
+    cy.get("#customize-control-logo_component_padding .top-input").should(
+      "have.value",
+      "10"
+    );
+    cy.get("#customize-control-logo_component_padding .right-input").should(
+      "have.value",
+      "0"
+    );
+    cy.get("#customize-control-logo_component_padding .bottom-input").should(
+      "have.value",
+      "10"
+    );
+    cy.get("#customize-control-logo_component_padding .left-input").should(
+      "have.value",
+      "0"
+    );
 
-		// Unlink values
-		cy.get('#customize-control-logo_component_padding button.link').click();
+    // Unlink values
+    cy.get("#customize-control-logo_component_padding button.link").click();
 
-		// Increase Top Padding value
-		cy.get('#customize-control-logo_component_padding .top-input')
-			.click()
-			.type('{uparrow}')
-			.trigger('change');
+    // Increase Top Padding value
+    cy.get("#customize-control-logo_component_padding .top-input")
+      .click()
+      .type("{uparrow}")
+      .trigger("change");
 
-		// Decrease Bottom Padding value
-		cy.get('#customize-control-logo_component_padding .bottom-input')
-			.click()
-			.type('{downarrow}')
-			.trigger('change');
+    // Decrease Bottom Padding value
+    cy.get("#customize-control-logo_component_padding .bottom-input")
+      .click()
+      .type("{downarrow}")
+      .trigger("change");
 
-		cy.get('#save').click();
-	});
+    cy.get("#save").click();
+  });
 
-	it('Sets up Padding for the Logo Component', () => {
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-			cy.checkPaddingFrontEnd();
-		});
-	});
+  it("Sets up Padding for the Logo Component", () => {
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+      cy.checkPaddingFrontEnd();
+    });
+  });
 });

--- a/cypress/integration/customizer/hfg/hfg-row-background.spec.js
+++ b/cypress/integration/customizer/hfg/hfg-row-background.spec.js
@@ -1,82 +1,71 @@
-describe('Header Row Background Control', () => {
-	before('Setup Customizer Control', () => {
-		cy.goToCustomizer();
+describe("Header Row Background Control", () => {
+  before("Setup Customizer Control", () => {
+    cy.goToCustomizer();
 
-		// Open customizer panel.
-		cy.get('#accordion-panel-hfg_header').should('be.visible').click();
+    // Open customizer panel.
+    cy.get("#accordion-panel-hfg_header").should("be.visible").click();
 
-		// Hover main HFG row in builder.
-		cy.get(
-			'.hfg--cb-body > .hfg--panel-desktop > .hfg--cp-rows > .hfg--row-main'
-		)
-			.should('be.visible')
-			.trigger('mouseover');
+    // Hover main HFG row in builder.
+    cy.get(
+      ".hfg--cb-body > .hfg--panel-desktop > .hfg--cp-rows > .hfg--row-main"
+    )
+      .should("be.visible")
+      .trigger("mouseover");
 
-		// Check if settings button is visible and click it.
-		cy.get(
-			'.hfg--cb-body > .hfg--panel-desktop > .hfg--cp-rows > .hfg--row-main > .hfg--cb-row-settings'
-		)
-			.should('exist')
-			.click();
+    // Check if settings button is visible and click it.
+    cy.get(
+      ".hfg--cb-body > .hfg--panel-desktop > .hfg--cp-rows > .hfg--row-main > .hfg--cb-row-settings"
+    )
+      .should("exist")
+      .click();
 
-		// Switch to style tab.
-		cy.get(
-			'#customize-control-hfg_header_layout_main_tabs [data-tab="style"]'
-		)
-			.should('be.visible')
-			.click();
+    // Switch to style tab.
+    cy.get('#customize-control-hfg_header_layout_main_tabs [data-tab="style"]')
+      .should("be.visible")
+      .click();
 
-		// Alias control.
-		cy.get('#customize-control-hfg_header_layout_main_background').as(
-			'bgCtrl'
-		);
+    // Alias control.
+    cy.get("#customize-control-hfg_header_layout_main_background").as("bgCtrl");
 
-		cy.get('@bgCtrl').should('be.visible');
-		cy.get('@bgCtrl').children().should('have.length', 3);
-		cy.get('@bgCtrl')
-			.find('.neve-background-type-control')
-			.children()
-			.should('have.length', 2);
+    cy.get("@bgCtrl").should("be.visible");
+    cy.get("@bgCtrl").children().should("have.length", 3);
+    cy.get("@bgCtrl")
+      .find(".neve-background-type-control")
+      .children()
+      .should("have.length", 2);
 
-		cy.get('@bgCtrl').find('button').contains('Image').click();
-		cy.get('@bgCtrl').find('button').contains('Add').click();
+    cy.get("@bgCtrl").find("button").contains("Image").click();
+    cy.get("@bgCtrl").find("button").contains("Add").click();
 
-		cy.get('.media-frame')
-			.find('.media-menu-item')
-			.contains('Media Library')
-			.click();
+    cy.get(".media-frame")
+      .find(".media-menu-item")
+      .contains("Media Library")
+      .click();
 
-		cy.get('.attachments-browser .attachments > li.attachment')
-			.first()
-			.click();
-		cy.get('.media-toolbar-primary')
-			.find('button')
-			.contains('Select')
-			.click();
-		cy.get('@bgCtrl').find('.components-form-toggle__input').click({
-			multiple: true,
-		});
-		cy.aliasRestRoutes();
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+    cy.get(".attachments-browser .attachments > li.attachment").first().click();
+    cy.get(".media-toolbar-primary").find("button").contains("Select").click();
+    cy.get("@bgCtrl").find(".components-form-toggle__input").click({
+      multiple: true,
+    });
+    cy.aliasRestRoutes();
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Background image control on front end.', function () {
-		cy.visit('/');
-		cy.get('.header-main[data-show-on="desktop"] .header--row-inner').as(
-			'row'
-		);
+  it("Background image control on front end.", function () {
+    cy.visit("/");
+    cy.get('.header-main[data-show-on="desktop"] .header--row-inner').as("row");
 
-		cy.get('@row').should('be.visible');
-		cy.get('@row')
-			.should('have.css', 'background-attachment')
-			.and('contain', 'fixed');
-		cy.get('@row')
-			.should('have.css', 'background-image')
-			.and('contain', 'url(')
-			.and('contain', 'wp-content/uploads');
-	});
+    cy.get("@row").should("be.visible");
+    cy.get("@row")
+      .should("have.css", "background-attachment")
+      .and("contain", "fixed");
+    cy.get("@row")
+      .should("have.css", "background-image")
+      .and("contain", "url(")
+      .and("contain", "wp-content/uploads");
+  });
 });

--- a/cypress/integration/customizer/hfg/hfg-search-component.spec.js
+++ b/cypress/integration/customizer/hfg/hfg-search-component.spec.js
@@ -1,70 +1,70 @@
-describe('Search Icon Component', () => {
-	const defaultHFG =
-		'{"desktop":{"top":[],"main":{"logo":{"id":"logo","width":4,"x":0,"settings":{"align":"left"}},"primary-menu":{"id":"primary-menu","settings":{"align":"right"},"width":8,"x":4}},"bottom":[]},"mobile":{"top":[],"main":{"logo":{"id":"logo","width":8,"x":0},"nav-icon":{"id":"nav-icon","width":4,"x":8}},"bottom":[],"sidebar":{"primary-menu":{"id":"primary-menu","width":8,"x":0}}}}';
-	const withSearch =
-		'{"desktop":{"top":[{"x":0,"y":1,"width":1,"height":1,"id":"header_search_responsive"}],"main":[{"x":0,"y":1,"width":4,"height":1,"id":"logo"},{"x":4,"y":1,"width":8,"height":1,"id":"primary-menu"}],"bottom":[]},"mobile":{"top":[],"main":[{"x":0,"y":1,"width":8,"height":1,"id":"logo"},{"x":8,"y":1,"width":4,"height":1,"id":"nav-icon"}],"bottom":[],"sidebar":[{"x":0,"y":1,"width":8,"height":1,"id":"primary-menu"}]}}';
+describe("Search Icon Component", () => {
+  const defaultHFG =
+    '{"desktop":{"top":[],"main":{"logo":{"id":"logo","width":4,"x":0,"settings":{"align":"left"}},"primary-menu":{"id":"primary-menu","settings":{"align":"right"},"width":8,"x":4}},"bottom":[]},"mobile":{"top":[],"main":{"logo":{"id":"logo","width":8,"x":0},"nav-icon":{"id":"nav-icon","width":4,"x":8}},"bottom":[],"sidebar":{"primary-menu":{"id":"primary-menu","width":8,"x":0}}}}';
+  const withSearch =
+    '{"desktop":{"top":[{"x":0,"y":1,"width":1,"height":1,"id":"header_search_responsive"}],"main":[{"x":0,"y":1,"width":4,"height":1,"id":"logo"},{"x":4,"y":1,"width":8,"height":1,"id":"primary-menu"}],"bottom":[]},"mobile":{"top":[],"main":[{"x":0,"y":1,"width":8,"height":1,"id":"logo"},{"x":8,"y":1,"width":4,"height":1,"id":"nav-icon"}],"bottom":[],"sidebar":[{"x":0,"y":1,"width":8,"height":1,"id":"primary-menu"}]}}';
 
-	before(() => {
-		cy.setCustomizeSettings({ hfg_header_layout: withSearch });
-	});
+  before(() => {
+    cy.setCustomizeSettings({ hfg_header_layout: withSearch });
+  });
 
-	after(() => {
-		cy.setCustomizeSettings({ hfg_header_layout: defaultHFG });
-	});
-	it('Canvas Search Works on Front End', () => {
-		cy.visit('/');
-		cy.get(
-			'.builder-item--header_search_responsive .menu-item-nav-search'
-		).as('searchIcon');
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-		cy.get('@searchIcon').should('have.class', 'canvas');
-		cy.get('@searchIcon').find('> .nv-search').click();
-		cy.get('@searchIcon').should('have.class', 'active');
-		cy.get('@searchIcon').find('.nv-nav-search').should('be.visible');
-		cy.get('@searchIcon').find('.close-responsive-search').click();
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-	});
+  after(() => {
+    cy.setCustomizeSettings({ hfg_header_layout: defaultHFG });
+  });
+  it("Canvas Search Works on Front End", () => {
+    cy.visit("/");
+    cy.get(".builder-item--header_search_responsive .menu-item-nav-search").as(
+      "searchIcon"
+    );
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+    cy.get("@searchIcon").should("have.class", "canvas");
+    cy.get("@searchIcon").find("> .nv-search").click();
+    cy.get("@searchIcon").should("have.class", "active");
+    cy.get("@searchIcon").find(".nv-nav-search").should("be.visible");
+    cy.get("@searchIcon").find(".close-responsive-search").click();
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+  });
 
-	it('Set search to minimal', () => {
-		cy.setCustomizeSettings({
-			header_search_responsive_open_type: 'minimal',
-		});
-	});
+  it("Set search to minimal", () => {
+    cy.setCustomizeSettings({
+      header_search_responsive_open_type: "minimal",
+    });
+  });
 
-	it('Minimal Search Works on Front End', () => {
-		cy.visit('/');
-		cy.get(
-			'.builder-item--header_search_responsive .menu-item-nav-search'
-		).as('searchIcon');
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-		cy.get('@searchIcon').should('have.class', 'minimal');
-		cy.get('@searchIcon').find('> .nv-search').click();
-		cy.get('@searchIcon').should('have.class', 'active');
-		cy.get('@searchIcon').find('.nv-nav-search').should('be.visible');
-		cy.get('.nav-clickaway-overlay').should('exist').click();
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-		cy.get('.nav-clickaway-overlay').should('not.exist');
-	});
+  it("Minimal Search Works on Front End", () => {
+    cy.visit("/");
+    cy.get(".builder-item--header_search_responsive .menu-item-nav-search").as(
+      "searchIcon"
+    );
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+    cy.get("@searchIcon").should("have.class", "minimal");
+    cy.get("@searchIcon").find("> .nv-search").click();
+    cy.get("@searchIcon").should("have.class", "active");
+    cy.get("@searchIcon").find(".nv-nav-search").should("be.visible");
+    cy.get(".nav-clickaway-overlay").should("exist").click();
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+    cy.get(".nav-clickaway-overlay").should("not.exist");
+  });
 
-	it('Set search to floating', () => {
-		cy.setCustomizeSettings({
-			header_search_responsive_open_type: 'floating',
-		});
-	});
+  it("Set search to floating", () => {
+    cy.setCustomizeSettings({
+      header_search_responsive_open_type: "floating",
+    });
+  });
 
-	it('Floating Search Works on Front End', () => {
-		cy.visit('/');
-		cy.get(
-			'.builder-item--header_search_responsive .menu-item-nav-search'
-		).as('searchIcon');
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-		cy.get('@searchIcon').should('have.class', 'floating');
-		cy.get('@searchIcon').find('> .nv-search').click();
-		cy.get('@searchIcon').should('have.class', 'active');
-		cy.get('@searchIcon').find('.nv-nav-search').should('be.visible');
-		cy.get('.nav-clickaway-overlay').should('exist');
-		cy.get('@searchIcon').find('.close-responsive-search').click();
-		cy.get('@searchIcon').find('.nv-nav-search').should('not.be.visible');
-		cy.get('.nav-clickaway-overlay').should('not.exist');
-	});
+  it("Floating Search Works on Front End", () => {
+    cy.visit("/");
+    cy.get(".builder-item--header_search_responsive .menu-item-nav-search").as(
+      "searchIcon"
+    );
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+    cy.get("@searchIcon").should("have.class", "floating");
+    cy.get("@searchIcon").find("> .nv-search").click();
+    cy.get("@searchIcon").should("have.class", "active");
+    cy.get("@searchIcon").find(".nv-nav-search").should("be.visible");
+    cy.get(".nav-clickaway-overlay").should("exist");
+    cy.get("@searchIcon").find(".close-responsive-search").click();
+    cy.get("@searchIcon").find(".nv-nav-search").should("not.be.visible");
+    cy.get(".nav-clickaway-overlay").should("not.exist");
+  });
 });

--- a/cypress/integration/customizer/layout/blog-archive-settings.spec.js
+++ b/cypress/integration/customizer/layout/blog-archive-settings.spec.js
@@ -1,216 +1,206 @@
-describe('Blog/Archive 1 / Default Layout', () => {
-	before('Setup', () => {
-		cy.insertPost('Blog test post', 'Blog test post.', 'post', true);
+describe("Blog/Archive 1 / Default Layout", () => {
+  before("Setup", () => {
+    cy.insertPost("Blog test post", "Blog test post.", "post", true);
 
-		cy.goToCustomizer();
-		cy.setCustomizeSettings({
-			neve_blog_archive_layout: 'default',
-			neve_post_excerpt_length: 15,
-			neve_post_thumbnail_box_shadow: 4,
-			neve_post_content_ordering: '["thumbnail","excerpt","title-meta"]',
-			neve_post_meta_ordering: '["date", "author", "category"]',
-			neve_pagination_type: 'number',
-		});
-	});
-	it('Tests Default Layout (List)', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			// Layout classes and styles.
-			cy.get(el).should('have.class', 'layout-default');
-			cy.get(el)
-				.find('.content')
-				.should('have.css', 'flex-direction', 'row');
-		});
-	});
+    cy.goToCustomizer();
+    cy.setCustomizeSettings({
+      neve_blog_archive_layout: "default",
+      neve_post_excerpt_length: 15,
+      neve_post_thumbnail_box_shadow: 4,
+      neve_post_content_ordering: '["thumbnail","excerpt","title-meta"]',
+      neve_post_meta_ordering: '["date", "author", "category"]',
+      neve_pagination_type: "number",
+    });
+  });
+  it("Tests Default Layout (List)", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      // Layout classes and styles.
+      cy.get(el).should("have.class", "layout-default");
+      cy.get(el).find(".content").should("have.css", "flex-direction", "row");
+    });
+  });
 
-	it('Post Content Order', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el)
-				.find('.excerpt-wrap:first-child')
-				.should('exist')
-				.and('be.visible');
-			cy.get(el)
-				.find('.nv-meta-list:last-child')
-				.should('exist')
-				.and('be.visible');
-			cy.get(el).should('have.descendants', '.nv-meta-list');
-			cy.get(el).should('have.descendants', '.excerpt-wrap');
-		});
-	});
+  it("Post Content Order", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el)
+        .find(".excerpt-wrap:first-child")
+        .should("exist")
+        .and("be.visible");
+      cy.get(el)
+        .find(".nv-meta-list:last-child")
+        .should("exist")
+        .and("be.visible");
+      cy.get(el).should("have.descendants", ".nv-meta-list");
+      cy.get(el).should("have.descendants", ".excerpt-wrap");
+    });
+  });
 
-	it('Meta Order', () => {
-		cy.visit('/');
+  it("Meta Order", () => {
+    cy.visit("/");
 
-		cy.get('article').each((el) => {
-			cy.get(el)
-				.find('.nv-meta-list > .date:first-child')
-				.should('exist');
-			cy.get(el)
-				.find('.nv-meta-list > .author:nth-child(2)')
-				.should('exist');
-			cy.get(el)
-				.find('.nv-meta-list > .category:last-child')
-				.should('exist');
-		});
-	});
+    cy.get("article").each((el) => {
+      cy.get(el).find(".nv-meta-list > .date:first-child").should("exist");
+      cy.get(el).find(".nv-meta-list > .author:nth-child(2)").should("exist");
+      cy.get(el).find(".nv-meta-list > .category:last-child").should("exist");
+    });
+  });
 
-	it('No Author Avatar', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el).find('.author .photo').should('not.exist');
-		});
-	});
+  it("No Author Avatar", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el).find(".author .photo").should("not.exist");
+    });
+  });
 
-	it('Excerpt length', () => {
-		cy.visit('/');
-		let count = 5;
-		cy.get('article').each((el) => {
-			if (count === 0) {
-				return false;
-			}
-			cy.get(el)
-				.find('.excerpt-wrap')
-				.invoke('text')
-				.then((val) => {
-					const res = val.split(' ');
-					cy.log(res);
-					expect(res.length).to.be.at.most(21);
-				});
-			count--;
-		});
-	});
+  it("Excerpt length", () => {
+    cy.visit("/");
+    let count = 5;
+    cy.get("article").each((el) => {
+      if (count === 0) {
+        return false;
+      }
+      cy.get(el)
+        .find(".excerpt-wrap")
+        .invoke("text")
+        .then((val) => {
+          const res = val.split(" ");
+          cy.log(res);
+          expect(res.length).to.be.at.most(21);
+        });
+      count--;
+    });
+  });
 
-	it('Thumbnail Shadow', () => {
-		cy.visit('/');
-		cy.get('.nv-post-thumbnail-wrap img').each((el) => {
-			cy.get(el).should(
-				'have.css',
-				'box-shadow',
-				'rgba(0, 0, 0, 0.12) 0px 14px 28px 0px, rgba(0, 0, 0, 0.12) 0px 10px 10px 0px'
-			);
-		});
-	});
+  it("Thumbnail Shadow", () => {
+    cy.visit("/");
+    cy.get(".nv-post-thumbnail-wrap img").each((el) => {
+      cy.get(el).should(
+        "have.css",
+        "box-shadow",
+        "rgba(0, 0, 0, 0.12) 0px 14px 28px 0px, rgba(0, 0, 0, 0.12) 0px 10px 10px 0px"
+      );
+    });
+  });
 
-	it('Pagination Number', () => {
-		cy.visit('/');
-		cy.get('.page-numbers').should('exist');
-	});
+  it("Pagination Number", () => {
+    cy.visit("/");
+    cy.get(".page-numbers").should("exist");
+  });
 
-	it('Alternative layout', () => {
-		cy.setCustomizeSettings({ neve_blog_list_alternative_layout: true });
+  it("Alternative layout", () => {
+    cy.setCustomizeSettings({ neve_blog_list_alternative_layout: true });
 
-		cy.visit('/');
-		let count = 0;
-		cy.get('article').each((el) => {
-			cy.get(el).should('have.class', 'layout-alternative');
-			if (count % 2 === 0) {
-				cy.get(el)
-					.find('.content')
-					.should('have.css', 'flex-direction', 'row-reverse');
-			} else {
-				cy.get(el)
-					.find('.content')
-					.should('have.css', 'flex-direction', 'row');
-			}
-			count++;
-		});
-	});
+    cy.visit("/");
+    let count = 0;
+    cy.get("article").each((el) => {
+      cy.get(el).should("have.class", "layout-alternative");
+      if (count % 2 === 0) {
+        cy.get(el)
+          .find(".content")
+          .should("have.css", "flex-direction", "row-reverse");
+      } else {
+        cy.get(el).find(".content").should("have.css", "flex-direction", "row");
+      }
+      count++;
+    });
+  });
 });
 
-describe('Blog/Archive 2 / Grid Layout', () => {
-	before('Setup', () => {
-		cy.setCustomizeSettings({
-			neve_blog_archive_layout: 'grid',
-			neve_grid_layout: '{"desktop":3,"tablet":2,"mobile":1}',
-			neve_pagination_type: 'infinite',
-			neve_enable_masonry: true,
-			neve_author_avatar: true,
-		});
-	});
+describe("Blog/Archive 2 / Grid Layout", () => {
+  before("Setup", () => {
+    cy.setCustomizeSettings({
+      neve_blog_archive_layout: "grid",
+      neve_grid_layout: '{"desktop":3,"tablet":2,"mobile":1}',
+      neve_pagination_type: "infinite",
+      neve_enable_masonry: true,
+      neve_author_avatar: true,
+    });
+  });
 
-	it('Grid layout', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el)
-				.should('have.class', 'layout-grid')
-				.and('have.class', 'col-md-4')
-				.and('have.class', 'col-sm-6')
-				.and('have.class', 'col-12');
-		});
-	});
+  it("Grid layout", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el)
+        .should("have.class", "layout-grid")
+        .and("have.class", "col-md-4")
+        .and("have.class", "col-sm-6")
+        .and("have.class", "col-12");
+    });
+  });
 
-	it('Pagination Infinite', () => {
-		cy.visit('/');
-		cy.get('.page-numbers').should('not.exist');
-		cy.get('.nv-loader').should('exist');
-	});
+  it("Pagination Infinite", () => {
+    cy.visit("/");
+    cy.get(".page-numbers").should("not.exist");
+    cy.get(".nv-loader").should("exist");
+  });
 
-	it('Masonry', () => {
-		cy.get('article').each((el) => {
-			cy.get(el).should('have.css', 'position', 'absolute');
-			cy.get(el).should('have.css', 'left');
-			cy.get(el).should('have.css', 'top');
-		});
-	});
+  it("Masonry", () => {
+    cy.get("article").each((el) => {
+      cy.get(el).should("have.css", "position", "absolute");
+      cy.get(el).should("have.css", "left");
+      cy.get(el).should("have.css", "top");
+    });
+  });
 
-	it('Author Avatar', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el).find('.author').should('have.descendants', '.photo');
-		});
-	});
+  it("Author Avatar", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el).find(".author").should("have.descendants", ".photo");
+    });
+  });
 });
 
-describe('Blog/Archive 3 / Covers Layout', () => {
-	before('Setup', () => {
-		cy.setCustomizeSettings({
-			neve_blog_archive_layout: 'covers',
-			neve_post_thumbnail_box_shadow: 4,
-			neve_post_content_ordering: '["thumbnail","title-meta"]',
-			neve_blog_covers_text_color: '#bada55',
-		});
-	});
+describe("Blog/Archive 3 / Covers Layout", () => {
+  before("Setup", () => {
+    cy.setCustomizeSettings({
+      neve_blog_archive_layout: "covers",
+      neve_post_thumbnail_box_shadow: 4,
+      neve_post_content_ordering: '["thumbnail","title-meta"]',
+      neve_blog_covers_text_color: "#bada55",
+    });
+  });
 
-	it('Covers layout', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el).should('have.class', 'layout-covers');
-			cy.get(el)
-				.find('.cover-post.nv-post-thumbnail-wrap')
-				.should('exist')
-				.and('be.visible')
-				.and('have.css', 'background-image');
-		});
-	});
+  it("Covers layout", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el).should("have.class", "layout-covers");
+      cy.get(el)
+        .find(".cover-post.nv-post-thumbnail-wrap")
+        .should("exist")
+        .and("be.visible")
+        .and("have.css", "background-image");
+    });
+  });
 
-	it('Thumbnail Box Shadow', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el)
-				.find('.cover-post.nv-post-thumbnail-wrap')
-				.should(
-					'have.css',
-					'box-shadow',
-					'rgba(0, 0, 0, 0.12) 0px 14px 28px 0px, rgba(0, 0, 0, 0.12) 0px 10px 10px 0px'
-				);
-		});
-	});
+  it("Thumbnail Box Shadow", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el)
+        .find(".cover-post.nv-post-thumbnail-wrap")
+        .should(
+          "have.css",
+          "box-shadow",
+          "rgba(0, 0, 0, 0.12) 0px 14px 28px 0px, rgba(0, 0, 0, 0.12) 0px 10px 10px 0px"
+        );
+    });
+  });
 
-	it('Post Content Order', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el).find('.entry-title:first-child').should('exist');
-			cy.get(el).find('.nv-meta-list:last-child').should('exist');
-		});
-	});
+  it("Post Content Order", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el).find(".entry-title:first-child").should("exist");
+      cy.get(el).find(".nv-meta-list:last-child").should("exist");
+    });
+  });
 
-	it('Text Color', () => {
-		cy.visit('/');
-		cy.get('article').each((el) => {
-			cy.get(el)
-				.find('.inner')
-				.should('have.css', 'color', 'rgb(186, 218, 85)');
-		});
-	});
+  it("Text Color", () => {
+    cy.visit("/");
+    cy.get("article").each((el) => {
+      cy.get(el)
+        .find(".inner")
+        .should("have.css", "color", "rgb(186, 218, 85)");
+    });
+  });
 });

--- a/cypress/integration/customizer/layout/container-settings.spec.js
+++ b/cypress/integration/customizer/layout/container-settings.spec.js
@@ -1,139 +1,137 @@
 /* eslint-disable array-callback-return */
-describe('Container Settings', () => {
-	const setup = {
-		pageTitle: 'Container on Page',
-		postTitle: 'Container on Post',
-		content: 'Container Test Content',
-		pageUrl: null,
-		postUrl: null,
-	};
+describe("Container Settings", () => {
+  const setup = {
+    pageTitle: "Container on Page",
+    postTitle: "Container on Post",
+    content: "Container Test Content",
+    pageUrl: null,
+    postUrl: null,
+  };
 
-	it('Create new page named "' + setup.pageTitle + '".', () => {
-		cy.insertPost(setup.pageTitle, setup.content, 'page');
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(setup.pageTitle)
-			.should('have.attr', 'href')
-			.then((href) => {
-				setup.pageUrl = href;
-			});
-	});
+  it('Create new page named "' + setup.pageTitle + '".', () => {
+    cy.insertPost(setup.pageTitle, setup.content, "page");
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(setup.pageTitle)
+      .should("have.attr", "href")
+      .then((href) => {
+        setup.pageUrl = href;
+      });
+  });
 
-	it('Create new post named "' + setup.postTitle + '".', () => {
-		cy.insertPost(setup.postTitle, setup.content, 'post', true);
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(setup.postTitle)
-			.should('have.attr', 'href')
-			.then((href) => {
-				setup.postUrl = href;
-			});
-	});
+  it('Create new post named "' + setup.postTitle + '".', () => {
+    cy.insertPost(setup.postTitle, setup.content, "post", true);
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(setup.postTitle)
+      .should("have.attr", "href")
+      .then((href) => {
+        setup.postUrl = href;
+      });
+  });
 
-	it('Setup customizer container width.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_container').click();
-		cy.get('#customize-control-neve_container_width').as('control');
+  it("Setup customizer container width.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_container").click();
+    cy.get("#customize-control-neve_container_width").as("control");
 
-		const devices = {
-			desktop: 1200,
-			tablet: 960,
-			mobile: 680,
-		};
-		Object.keys(devices).map((device) => {
-			cy.get('@control')
-				.find('button.' + device)
-				.click();
-			cy.get('@control')
-				.find('input[type=number]')
-				.type('{selectall}')
-				.type(devices[device]);
-		});
+    const devices = {
+      desktop: 1200,
+      tablet: 960,
+      mobile: 680,
+    };
+    Object.keys(devices).map((device) => {
+      cy.get("@control")
+        .find("button." + device)
+        .click();
+      cy.get("@control")
+        .find("input[type=number]")
+        .type("{selectall}")
+        .type(devices[device]);
+    });
 
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Container width on front end.', () => {
-		cy.visit(setup.pageUrl);
-		cy.get('.single-page-container').as('container');
-		cy.get('@container')
-			.should('have.css', 'max-width')
-			.and('eq', '1200px');
+  it("Container width on front end.", () => {
+    cy.visit(setup.pageUrl);
+    cy.get(".single-page-container").as("container");
+    cy.get("@container").should("have.css", "max-width").and("eq", "1200px");
 
-		cy.viewport(768, 1024); //iPad
-		cy.get('@container').should('have.css', 'max-width').and('eq', '960px');
+    cy.viewport(768, 1024); //iPad
+    cy.get("@container").should("have.css", "max-width").and("eq", "960px");
 
-		cy.viewport(375, 812); //iPhoneX
-		cy.get('@container').should('have.css', 'max-width').and('eq', '680px');
-	});
+    cy.viewport(375, 812); //iPhoneX
+    cy.get("@container").should("have.css", "max-width").and("eq", "680px");
+  });
 
-	it('Setup customizer container style.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_container').click();
-		cy.get('#_customize-input-neve_default_container_style').select(
-			'full-width'
-		);
-		cy.get('#_customize-input-neve_blog_archive_container_style').select(
-			'full-width'
-		);
-		cy.get('#_customize-input-neve_single_post_container_style').select(
-			'full-width'
-		);
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+  it("Setup customizer container style.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_container").click();
+    cy.get("#_customize-input-neve_default_container_style").select(
+      "full-width"
+    );
+    cy.get("#_customize-input-neve_blog_archive_container_style").select(
+      "full-width"
+    );
+    cy.get("#_customize-input-neve_single_post_container_style").select(
+      "full-width"
+    );
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Container style on front end.', () => {
-		cy.visit(setup.pageUrl);
-		cy.get('.single-page-container').as('container');
-		cy.get('@container').should('have.class', 'container-fluid');
-		cy.visit(setup.postUrl);
-		cy.get('.single-post-container').as('container');
-		cy.get('@container').should('have.class', 'container-fluid');
-	});
+  it("Container style on front end.", () => {
+    cy.visit(setup.pageUrl);
+    cy.get(".single-page-container").as("container");
+    cy.get("@container").should("have.class", "container-fluid");
+    cy.visit(setup.postUrl);
+    cy.get(".single-post-container").as("container");
+    cy.get("@container").should("have.class", "container-fluid");
+  });
 
-	it('Go back to defaults.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_container').click();
-		cy.get('#customize-control-neve_container_width').as('control');
-		cy.get('#_customize-input-neve_default_container_style').select(
-			'contained'
-		);
-		cy.get('#_customize-input-neve_blog_archive_container_style').select(
-			'contained'
-		);
-		cy.get('#_customize-input-neve_single_post_container_style').select(
-			'contained'
-		);
+  it("Go back to defaults.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_container").click();
+    cy.get("#customize-control-neve_container_width").as("control");
+    cy.get("#_customize-input-neve_default_container_style").select(
+      "contained"
+    );
+    cy.get("#_customize-input-neve_blog_archive_container_style").select(
+      "contained"
+    );
+    cy.get("#_customize-input-neve_single_post_container_style").select(
+      "contained"
+    );
 
-		cy.get('#customize-control-neve_container_width').as('control');
+    cy.get("#customize-control-neve_container_width").as("control");
 
-		const devices = ['desktop', 'tablet', 'mobile'];
-		devices.map((device) => {
-			cy.get('@control')
-				.find('button.' + device)
-				.click();
-			cy.get('@control')
-				.find('button')
-				.contains('Reset')
-				.should('be.visible')
-				.click();
-		});
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+    const devices = ["desktop", "tablet", "mobile"];
+    devices.map((device) => {
+      cy.get("@control")
+        .find("button." + device)
+        .click();
+      cy.get("@control")
+        .find("button")
+        .contains("Reset")
+        .should("be.visible")
+        .click();
+    });
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 });

--- a/cypress/integration/customizer/layout/sidebar-settings.spec.js
+++ b/cypress/integration/customizer/layout/sidebar-settings.spec.js
@@ -1,176 +1,150 @@
-describe('Sidebar/Content Settings', () => {
-	before('Setup customizer site wide Sidebar settings.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_sidebar').click();
-		cy.get('label[for="neve_default_sidebar_layout-left"]').click();
-		cy.get(
-			'#customize-control-neve_sitewide_content_width input[type=number]'
-		)
-			.type('{selectall}')
-			.type(50);
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+describe("Sidebar/Content Settings", () => {
+  before("Setup customizer site wide Sidebar settings.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_sidebar").click();
+    cy.get('label[for="neve_default_sidebar_layout-left"]').click();
+    cy.get("#customize-control-neve_sitewide_content_width input[type=number]")
+      .type("{selectall}")
+      .type(50);
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	after('Go back to defaults.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#customize-control-neve_advanced_layout_options label').click({
-			force: true,
-		});
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-		cy.reload();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_sidebar').click();
-		cy.get('label[for="neve_default_sidebar_layout-right"]').click();
-		cy.get('#customize-control-neve_sitewide_content_width button')
-			.contains('Reset')
-			.click();
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
-	it('Sidebar site wide on front end.', () => {
-		//Index
-		cy.visit('/');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-index-posts')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+  after("Go back to defaults.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#customize-control-neve_advanced_layout_options label").click({
+      force: true,
+    });
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+    cy.reload();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_sidebar").click();
+    cy.get('label[for="neve_default_sidebar_layout-right"]').click();
+    cy.get("#customize-control-neve_sitewide_content_width button")
+      .contains("Reset")
+      .click();
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
+  it("Sidebar site wide on front end.", () => {
+    //Index
+    cy.visit("/");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-index-posts").should("have.css", "max-width").and("eq", "50%");
 
-		//Page
-		cy.visit('/sample-page');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+    //Page
+    cy.visit("/sample-page");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "50%");
 
-		//Author archive
-		cy.visit('/?author=1');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-index-posts')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+    //Author archive
+    cy.visit("/?author=1");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-index-posts").should("have.css", "max-width").and("eq", "50%");
 
-		//Single Post
-		cy.get('.widget_recent_entries').first().find('a').first().click();
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-	});
+    //Single Post
+    cy.get(".widget_recent_entries").first().find("a").first().click();
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "50%");
+  });
 
-	it('Setup customizer site wide Sidebar settings.', () => {
-		cy.goToCustomizer();
-		cy.aliasRestRoutes();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_sidebar').click();
-		cy.get('#customize-control-neve_advanced_layout_options input').click();
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-		cy.reload();
-		cy.get('#accordion-panel-neve_layout').click();
-		cy.get('#accordion-section-neve_sidebar').click();
-		cy.get('#sub-accordion-section-neve_sidebar').as('section');
-		cy.get('@section')
-			.find('.customize-control-customizer-heading:not(.expanded)')
-			.click({
-				multiple: true,
-			});
+  it("Setup customizer site wide Sidebar settings.", () => {
+    cy.goToCustomizer();
+    cy.aliasRestRoutes();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_sidebar").click();
+    cy.get("#customize-control-neve_advanced_layout_options input").click();
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+    cy.reload();
+    cy.get("#accordion-panel-neve_layout").click();
+    cy.get("#accordion-section-neve_sidebar").click();
+    cy.get("#sub-accordion-section-neve_sidebar").as("section");
+    cy.get("@section")
+      .find(".customize-control-customizer-heading:not(.expanded)")
+      .click({
+        multiple: true,
+      });
 
-		cy.get('[for="neve_blog_archive_sidebar_layout-left"]').click();
-		cy.get(
-			'#customize-control-neve_blog_archive_content_width input[type=number]'
-		)
-			.type('{selectall}')
-			.type(50);
+    cy.get('[for="neve_blog_archive_sidebar_layout-left"]').click();
+    cy.get(
+      "#customize-control-neve_blog_archive_content_width input[type=number]"
+    )
+      .type("{selectall}")
+      .type(50);
 
-		cy.get('[for="neve_single_post_sidebar_layout-left"]').click();
-		cy.get(
-			'#customize-control-neve_single_post_content_width input[type=number]'
-		)
-			.type('{selectall}')
-			.type(50);
+    cy.get('[for="neve_single_post_sidebar_layout-left"]').click();
+    cy.get(
+      "#customize-control-neve_single_post_content_width input[type=number]"
+    )
+      .type("{selectall}")
+      .type(50);
 
-		cy.get('[for="neve_other_pages_sidebar_layout-left"]').click();
-		cy.get(
-			'#customize-control-neve_other_pages_content_width input[type=number]'
-		)
-			.type('{selectall}')
-			.type(50);
+    cy.get('[for="neve_other_pages_sidebar_layout-left"]').click();
+    cy.get(
+      "#customize-control-neve_other_pages_content_width input[type=number]"
+    )
+      .type("{selectall}")
+      .type(50);
 
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Sidebar advanced on front end.', () => {
-		//Index
-		cy.visit('/');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-index-posts')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+  it("Sidebar advanced on front end.", () => {
+    //Index
+    cy.visit("/");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-index-posts").should("have.css", "max-width").and("eq", "50%");
 
-		//Page
-		cy.visit('/sample-page');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+    //Page
+    cy.visit("/sample-page");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "50%");
 
-		//Author archive
-		cy.visit('/?author=1');
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-index-posts')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
+    //Author archive
+    cy.visit("/?author=1");
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-index-posts").should("have.css", "max-width").and("eq", "50%");
 
-		//Single Post
-		cy.get('.widget_recent_entries').first().find('a').first().click();
-		cy.get('.nv-sidebar-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-	});
+    //Single Post
+    cy.get(".widget_recent_entries").first().find("a").first().click();
+    cy.get(".nv-sidebar-wrap").should("have.css", "max-width").and("eq", "50%");
+    cy.get(".nv-sidebar-wrap").should("have.class", "nv-left");
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "50%");
+  });
 });

--- a/cypress/integration/customizer/layout/single-post-settings.spec.js
+++ b/cypress/integration/customizer/layout/single-post-settings.spec.js
@@ -1,60 +1,57 @@
-describe('Single Post Check', () => {
-	const CONTROL = 'neve_layout_single_post_elements_order';
-	const REORDERED =
-		'["post-navigation","tags","content","comments","title-meta","thumbnail"]';
+describe("Single Post Check", () => {
+  const CONTROL = "neve_layout_single_post_elements_order";
+  const REORDERED =
+    '["post-navigation","tags","content","comments","title-meta","thumbnail"]';
 
-	before(() => {
-		cy.login();
-		cy.visit('/markup-image-alignment/');
-		cy.get('#wp-admin-bar-edit').click();
-		cy.clearWelcome();
-		cy.wait(1000);
-		cy.get('.components-panel__body').contains('Discussion').click();
-		cy.get('label').contains('Allow comments').click();
-		cy.get('button').contains('Update').click();
-	});
+  before(() => {
+    cy.login();
+    cy.visit("/markup-image-alignment/");
+    cy.get("#wp-admin-bar-edit").click();
+    cy.clearWelcome();
+    cy.wait(1000);
+    cy.get(".components-panel__body").contains("Discussion").click();
+    cy.get("label").contains("Allow comments").click();
+    cy.get("button").contains("Update").click();
+  });
 
-	it('All elements hidden', function () {
-		cy.setCustomizeSettings({ [CONTROL]: '[]' });
+  it("All elements hidden", function () {
+    cy.setCustomizeSettings({ [CONTROL]: "[]" });
 
-		const HIDDEN = [
-			'.entry-header',
-			'.nv-thumb-wrap',
-			'.entry-content',
-			'.nv-tags-list',
-			'.comments-area',
-			'.nv-post-navigation',
-		];
+    const HIDDEN = [
+      ".entry-header",
+      ".nv-thumb-wrap",
+      ".entry-content",
+      ".nv-tags-list",
+      ".comments-area",
+      ".nv-post-navigation",
+    ];
 
-		cy.visit('/markup-image-alignment/');
-		HIDDEN.forEach((className) => {
-			cy.get('.nv-single-post-wrap').should(
-				'not.have.descendants',
-				className
-			);
-		});
-	});
+    cy.visit("/markup-image-alignment/");
+    HIDDEN.forEach((className) => {
+      cy.get(".nv-single-post-wrap").should("not.have.descendants", className);
+    });
+  });
 
-	it('All elements enabled and reordered', () => {
-		cy.setCustomizeSettings({ [CONTROL]: REORDERED });
+  it("All elements enabled and reordered", () => {
+    cy.setCustomizeSettings({ [CONTROL]: REORDERED });
 
-		const ORDER = [
-			'nv-post-navigation',
-			'nv-tags-list',
-			'nv-content-wrap',
-			'comments-area',
-			'entry-header',
-			'nv-thumb-wrap',
-		];
+    const ORDER = [
+      "nv-post-navigation",
+      "nv-tags-list",
+      "nv-content-wrap",
+      "comments-area",
+      "entry-header",
+      "nv-thumb-wrap",
+    ];
 
-		cy.visit('/markup-image-alignment/');
-		// eslint-disable-next-line no-unused-vars
-		ORDER.forEach((className) => {
-			cy.get('.nv-single-post-wrap')
-				.find('> *')
-				.each((el, index) => {
-					cy.get(el).should('have.class', ORDER[index]);
-				});
-		});
-	});
+    cy.visit("/markup-image-alignment/");
+    // eslint-disable-next-line no-unused-vars
+    ORDER.forEach((className) => {
+      cy.get(".nv-single-post-wrap")
+        .find("> *")
+        .each((el, index) => {
+          cy.get(el).should("have.class", ORDER[index]);
+        });
+    });
+  });
 });

--- a/cypress/integration/customizer/typography/blog-typography.spec.js
+++ b/cypress/integration/customizer/typography/blog-typography.spec.js
@@ -1,263 +1,231 @@
 const setup = {
-	textTransform: 'lowercase',
-	fontWeight: '100',
-	fontSize: {
-		suffix: {
-			mobile: 'px',
-			tablet: 'px',
-			desktop: 'px',
-		},
-		mobile: '10',
-		tablet: '11',
-		desktop: '12',
-	},
-	lineHeight: {
-		suffix: {
-			mobile: 'em',
-			tablet: 'em',
-			desktop: 'em',
-		},
-		mobile: '4',
-		tablet: '3',
-		desktop: '2',
-	},
-	letterSpacing: {
-		mobile: '3',
-		tablet: '2',
-		desktop: '1',
-	},
+  textTransform: "lowercase",
+  fontWeight: "100",
+  fontSize: {
+    suffix: {
+      mobile: "px",
+      tablet: "px",
+      desktop: "px",
+    },
+    mobile: "10",
+    tablet: "11",
+    desktop: "12",
+  },
+  lineHeight: {
+    suffix: {
+      mobile: "em",
+      tablet: "em",
+      desktop: "em",
+    },
+    mobile: "4",
+    tablet: "3",
+    desktop: "2",
+  },
+  letterSpacing: {
+    mobile: "3",
+    tablet: "2",
+    desktop: "1",
+  },
 };
 
 const homeSettings = {
-	pageToVisit: '/',
-	titleSelector: '.blog-entry-title',
-	metaSelector: '.blog .nv-meta-list li',
-	excerptSelector: '.entry-summary',
+  pageToVisit: "/",
+  titleSelector: ".blog-entry-title",
+  metaSelector: ".blog .nv-meta-list li",
+  excerptSelector: ".entry-summary",
 };
 
 const commentSettings = {
-	pageToVisit: '/template-comments/',
-	titleSelector: '.nv-title-meta-wrap .entry-title',
-	metaSelector: '.single .nv-meta-list li',
-	commentsSelector: '.single .comment-reply-title',
+  pageToVisit: "/template-comments/",
+  titleSelector: ".nv-title-meta-wrap .entry-title",
+  metaSelector: ".single .nv-meta-list li",
+  commentsSelector: ".single .comment-reply-title",
 };
 // .single .comment-reply-title
 const deviceMap = {
-	desktop: {
-		height: 1080,
-		width: 1920,
-	},
-	tablet: {
-		height: 1024,
-		width: 768,
-	},
-	mobile: {
-		height: 667,
-		width: 375,
-	},
+  desktop: {
+    height: 1080,
+    width: 1920,
+  },
+  tablet: {
+    height: 1024,
+    width: 768,
+  },
+  mobile: {
+    height: 667,
+    width: 375,
+  },
 };
 
-describe('Blog Typography', () => {
-	before('Sets up blog typography in customizer', () => {
-		cy.goToCustomizer();
-		cy.window().then((win) => {
-			win.wp.customize
-				.control('neve_archive_typography_post_title')
-				.setting.set(setup);
-			win.wp.customize
-				.control('neve_archive_typography_post_excerpt')
-				.setting.set(setup);
-			win.wp.customize
-				.control('neve_archive_typography_post_meta')
-				.setting.set(setup);
-			win.wp.customize
-				.control('neve_single_post_typography_post_title')
-				.setting.set(setup);
-			win.wp.customize
-				.control('neve_single_post_typography_post_meta')
-				.setting.set(setup);
-			win.wp.customize
-				.control('neve_single_post_typography_comments_title')
-				.setting.set(setup);
-		});
-		cy.aliasRestRoutes();
-		cy.get('#save').click();
-		cy.wait('@customizerSave').then((interception) => {
-			expect(interception.response.body.success).to.be.true;
-			expect(interception.response.statusCode).to.equal(200);
-			cy.wait(2000);
-		});
-	});
+describe("Blog Typography", () => {
+  before("Sets up blog typography in customizer", () => {
+    cy.goToCustomizer();
+    cy.window().then((win) => {
+      win.wp.customize
+        .control("neve_archive_typography_post_title")
+        .setting.set(setup);
+      win.wp.customize
+        .control("neve_archive_typography_post_excerpt")
+        .setting.set(setup);
+      win.wp.customize
+        .control("neve_archive_typography_post_meta")
+        .setting.set(setup);
+      win.wp.customize
+        .control("neve_single_post_typography_post_title")
+        .setting.set(setup);
+      win.wp.customize
+        .control("neve_single_post_typography_post_meta")
+        .setting.set(setup);
+      win.wp.customize
+        .control("neve_single_post_typography_comments_title")
+        .setting.set(setup);
+    });
+    cy.aliasRestRoutes();
+    cy.get("#save").click();
+    cy.wait("@customizerSave").then((interception) => {
+      expect(interception.response.body.success).to.be.true;
+      expect(interception.response.statusCode).to.equal(200);
+      cy.wait(2000);
+    });
+  });
 
-	it('Test blog typography for transform and weight on frontend on home page', () => {
-		cy.visit(homeSettings.pageToVisit);
-		cy.get(homeSettings.titleSelector).each((elem) => {
-			cy.testTransformAndWeight(
-				elem,
-				setup.textTransform,
-				setup.fontWeight
-			);
-		});
-		cy.get(homeSettings.metaSelector).each((elem) => {
-			cy.testTransformAndWeight(
-				elem,
-				setup.textTransform,
-				setup.fontWeight
-			);
-		});
-		if (homeSettings && homeSettings.excerptSelector) {
-			cy.get(homeSettings.excerptSelector).each((elem) => {
-				cy.testTransformAndWeight(
-					elem,
-					setup.textTransform,
-					setup.fontWeight
-				);
-			});
-		}
-		if (homeSettings && homeSettings.commentsSelector) {
-			cy.get(homeSettings.commentsSelector).each((elem) => {
-				cy.testTransformAndWeight(
-					elem,
-					setup.textTransform,
-					setup.fontWeight
-				);
-			});
-		}
-	});
+  it("Test blog typography for transform and weight on frontend on home page", () => {
+    cy.visit(homeSettings.pageToVisit);
+    cy.get(homeSettings.titleSelector).each((elem) => {
+      cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+    });
+    cy.get(homeSettings.metaSelector).each((elem) => {
+      cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+    });
+    if (homeSettings && homeSettings.excerptSelector) {
+      cy.get(homeSettings.excerptSelector).each((elem) => {
+        cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+      });
+    }
+    if (homeSettings && homeSettings.commentsSelector) {
+      cy.get(homeSettings.commentsSelector).each((elem) => {
+        cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+      });
+    }
+  });
 
-	it('Test blog typography for transform and weight on frontend on comment templates', () => {
-		cy.visit(commentSettings.pageToVisit);
-		cy.get(commentSettings.titleSelector).each((elem) => {
-			cy.testTransformAndWeight(
-				elem,
-				setup.textTransform,
-				setup.fontWeight
-			);
-		});
-		cy.get(commentSettings.metaSelector).each((elem) => {
-			cy.testTransformAndWeight(
-				elem,
-				setup.textTransform,
-				setup.fontWeight
-			);
-		});
-		if (commentSettings && commentSettings.excerptSelector) {
-			cy.get(commentSettings.excerptSelector).each((elem) => {
-				cy.testTransformAndWeight(
-					elem,
-					setup.textTransform,
-					setup.fontWeight
-				);
-			});
-		}
-		if (commentSettings && commentSettings.commentsSelector) {
-			cy.get(commentSettings.commentsSelector).each((elem) => {
-				cy.testTransformAndWeight(
-					elem,
-					setup.textTransform,
-					setup.fontWeight
-				);
-			});
-		}
-	});
+  it("Test blog typography for transform and weight on frontend on comment templates", () => {
+    cy.visit(commentSettings.pageToVisit);
+    cy.get(commentSettings.titleSelector).each((elem) => {
+      cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+    });
+    cy.get(commentSettings.metaSelector).each((elem) => {
+      cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+    });
+    if (commentSettings && commentSettings.excerptSelector) {
+      cy.get(commentSettings.excerptSelector).each((elem) => {
+        cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+      });
+    }
+    if (commentSettings && commentSettings.commentsSelector) {
+      cy.get(commentSettings.commentsSelector).each((elem) => {
+        cy.testTransformAndWeight(elem, setup.textTransform, setup.fontWeight);
+      });
+    }
+  });
 
-	it('Test blog typography for size, line height, and spacing on frontend on home page', () => {
-		cy.visit(homeSettings.pageToVisit);
+  it("Test blog typography for size, line height, and spacing on frontend on home page", () => {
+    cy.visit(homeSettings.pageToVisit);
 
-		// eslint-disable-next-line array-callback-return
-		Object.keys(deviceMap).map((device) => {
-			// Change viewport.
-			cy.viewport(deviceMap[device].width, deviceMap[device].height);
+    // eslint-disable-next-line array-callback-return
+    Object.keys(deviceMap).map((device) => {
+      // Change viewport.
+      cy.viewport(deviceMap[device].width, deviceMap[device].height);
 
-			cy.get(homeSettings.titleSelector).each((elem) => {
-				cy.testSizeLineHeightSpacing(
-					elem,
-					setup.fontSize[device],
-					setup.lineHeight[device],
-					setup.letterSpacing[device]
-				);
-			});
+      cy.get(homeSettings.titleSelector).each((elem) => {
+        cy.testSizeLineHeightSpacing(
+          elem,
+          setup.fontSize[device],
+          setup.lineHeight[device],
+          setup.letterSpacing[device]
+        );
+      });
 
-			cy.get(homeSettings.metaSelector).each((elem) => {
-				cy.testSizeLineHeightSpacing(
-					elem,
-					setup.fontSize[device],
-					setup.lineHeight[device],
-					setup.letterSpacing[device]
-				);
-			});
+      cy.get(homeSettings.metaSelector).each((elem) => {
+        cy.testSizeLineHeightSpacing(
+          elem,
+          setup.fontSize[device],
+          setup.lineHeight[device],
+          setup.letterSpacing[device]
+        );
+      });
 
-			if (homeSettings && homeSettings.excerptSelector) {
-				cy.get(homeSettings.excerptSelector).each((elem) => {
-					cy.testSizeLineHeightSpacing(
-						elem,
-						setup.fontSize[device],
-						setup.lineHeight[device],
-						setup.letterSpacing[device]
-					);
-				});
-			}
+      if (homeSettings && homeSettings.excerptSelector) {
+        cy.get(homeSettings.excerptSelector).each((elem) => {
+          cy.testSizeLineHeightSpacing(
+            elem,
+            setup.fontSize[device],
+            setup.lineHeight[device],
+            setup.letterSpacing[device]
+          );
+        });
+      }
 
-			if (homeSettings && homeSettings.commentsSelector) {
-				cy.get(homeSettings.commentsSelector).each((elem) => {
-					cy.testSizeLineHeightSpacing(
-						elem,
-						setup.fontSize[device],
-						setup.lineHeight[device],
-						setup.letterSpacing[device]
-					);
-				});
-			}
-		});
-	});
+      if (homeSettings && homeSettings.commentsSelector) {
+        cy.get(homeSettings.commentsSelector).each((elem) => {
+          cy.testSizeLineHeightSpacing(
+            elem,
+            setup.fontSize[device],
+            setup.lineHeight[device],
+            setup.letterSpacing[device]
+          );
+        });
+      }
+    });
+  });
 
-	it('Test blog typography for size, line height, and spacing on frontend on template comments', () => {
-		cy.visit(commentSettings.pageToVisit);
+  it("Test blog typography for size, line height, and spacing on frontend on template comments", () => {
+    cy.visit(commentSettings.pageToVisit);
 
-		// eslint-disable-next-line array-callback-return
-		Object.keys(deviceMap).map((device) => {
-			// Change viewport.
-			cy.viewport(deviceMap[device].width, deviceMap[device].height);
+    // eslint-disable-next-line array-callback-return
+    Object.keys(deviceMap).map((device) => {
+      // Change viewport.
+      cy.viewport(deviceMap[device].width, deviceMap[device].height);
 
-			cy.get(commentSettings.titleSelector).each((elem) => {
-				cy.testSizeLineHeightSpacing(
-					elem,
-					setup.fontSize[device],
-					setup.lineHeight[device],
-					setup.letterSpacing[device]
-				);
-			});
+      cy.get(commentSettings.titleSelector).each((elem) => {
+        cy.testSizeLineHeightSpacing(
+          elem,
+          setup.fontSize[device],
+          setup.lineHeight[device],
+          setup.letterSpacing[device]
+        );
+      });
 
-			cy.get(commentSettings.metaSelector).each((elem) => {
-				cy.testSizeLineHeightSpacing(
-					elem,
-					setup.fontSize[device],
-					setup.lineHeight[device],
-					setup.letterSpacing[device]
-				);
-			});
+      cy.get(commentSettings.metaSelector).each((elem) => {
+        cy.testSizeLineHeightSpacing(
+          elem,
+          setup.fontSize[device],
+          setup.lineHeight[device],
+          setup.letterSpacing[device]
+        );
+      });
 
-			if (commentSettings && commentSettings.excerptSelector) {
-				cy.get(commentSettings.excerptSelector).each((elem) => {
-					cy.testSizeLineHeightSpacing(
-						elem,
-						setup.fontSize[device],
-						setup.lineHeight[device],
-						setup.letterSpacing[device]
-					);
-				});
-			}
+      if (commentSettings && commentSettings.excerptSelector) {
+        cy.get(commentSettings.excerptSelector).each((elem) => {
+          cy.testSizeLineHeightSpacing(
+            elem,
+            setup.fontSize[device],
+            setup.lineHeight[device],
+            setup.letterSpacing[device]
+          );
+        });
+      }
 
-			if (commentSettings && commentSettings.commentsSelector) {
-				cy.get(commentSettings.commentsSelector).each((elem) => {
-					cy.testSizeLineHeightSpacing(
-						elem,
-						setup.fontSize[device],
-						setup.lineHeight[device],
-						setup.letterSpacing[device]
-					);
-				});
-			}
-		});
-	});
+      if (commentSettings && commentSettings.commentsSelector) {
+        cy.get(commentSettings.commentsSelector).each((elem) => {
+          cy.testSizeLineHeightSpacing(
+            elem,
+            setup.fontSize[device],
+            setup.lineHeight[device],
+            setup.letterSpacing[device]
+          );
+        });
+      }
+    });
+  });
 });

--- a/cypress/integration/customizer/typography/font-family.spec.js
+++ b/cypress/integration/customizer/typography/font-family.spec.js
@@ -1,43 +1,41 @@
 const fonts = {
-	general: 'Arapey',
-	headings: 'Allerta Stencil',
+  general: "Arapey",
+  headings: "Allerta Stencil",
 };
 
-describe('Font Family', () => {
-	before(() => {
-		cy.setCustomizeSettings({
-			neve_body_font_family: fonts.general,
-			neve_headings_font_family: fonts.headings,
-		});
-	});
+describe("Font Family", () => {
+  before(() => {
+    cy.setCustomizeSettings({
+      neve_body_font_family: fonts.general,
+      neve_headings_font_family: fonts.headings,
+    });
+  });
 
-	it('Font Family on Front End', () => {
-		cy.visit('/markup-html-tags-and-formatting/');
+  it("Font Family on Front End", () => {
+    cy.visit("/markup-html-tags-and-formatting/");
 
-		cy.get('body')
-			.should('have.css', 'font-family')
-			.and('match', new RegExp(fonts.general, 'g'));
+    cy.get("body")
+      .should("have.css", "font-family")
+      .and("match", new RegExp(fonts.general, "g"));
 
-		cy.get('h1, h2, h3, h4, h5, h6')
-			.should('have.css', 'font-family')
-			.and('match', new RegExp(fonts.headings, 'g'));
-	});
+    cy.get("h1, h2, h3, h4, h5, h6")
+      .should("have.css", "font-family")
+      .and("match", new RegExp(fonts.headings, "g"));
+  });
 
-	it('Test Font Family inside the Editor', () => {
-		cy.visit('/markup-html-tags-and-formatting/');
-		cy.get('#wp-admin-bar-edit > a').click();
-		cy.clearWelcome();
-		cy.get('.editor-styles-wrapper .block-editor-writing-flow p').as(
-			'body'
-		);
-		cy.get('@body')
-			.should('have.css', 'font-family')
-			.and('match', new RegExp(fonts.general, 'g'));
+  it("Test Font Family inside the Editor", () => {
+    cy.visit("/markup-html-tags-and-formatting/");
+    cy.get("#wp-admin-bar-edit > a").click();
+    cy.clearWelcome();
+    cy.get(".editor-styles-wrapper .block-editor-writing-flow p").as("body");
+    cy.get("@body")
+      .should("have.css", "font-family")
+      .and("match", new RegExp(fonts.general, "g"));
 
-		['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].forEach((heading) => {
-			cy.get(`.editor-styles-wrapper ${heading}`)
-				.should('have.css', 'font-family')
-				.and('match', new RegExp(fonts.headings, 'g'));
-		});
-	});
+    ["h1", "h2", "h3", "h4", "h5", "h6"].forEach((heading) => {
+      cy.get(`.editor-styles-wrapper ${heading}`)
+        .should("have.css", "font-family")
+        .and("match", new RegExp(fonts.headings, "g"));
+    });
+  });
 });

--- a/cypress/integration/customizer/typography/font-sizes.spec.js
+++ b/cypress/integration/customizer/typography/font-sizes.spec.js
@@ -1,117 +1,115 @@
 const setup = {
-	fontSize: {
-		suffix: {
-			mobile: 'px',
-			tablet: 'px',
-			desktop: 'px',
-		},
-		mobile: '10',
-		tablet: '11',
-		desktop: '12',
-	},
-	lineHeight: {
-		mobile: '4',
-		tablet: '3',
-		desktop: '2',
-		suffix: {
-			mobile: 'em',
-			tablet: 'em',
-			desktop: 'em',
-		},
-	},
-	letterSpacing: {
-		mobile: '3',
-		tablet: '2',
-		desktop: '1',
-	},
-	fontWeight: 500,
-	textTransform: 'lowercase',
+  fontSize: {
+    suffix: {
+      mobile: "px",
+      tablet: "px",
+      desktop: "px",
+    },
+    mobile: "10",
+    tablet: "11",
+    desktop: "12",
+  },
+  lineHeight: {
+    mobile: "4",
+    tablet: "3",
+    desktop: "2",
+    suffix: {
+      mobile: "em",
+      tablet: "em",
+      desktop: "em",
+    },
+  },
+  letterSpacing: {
+    mobile: "3",
+    tablet: "2",
+    desktop: "1",
+  },
+  fontWeight: 500,
+  textTransform: "lowercase",
 };
 
-describe('Typography Control', () => {
-	before('Setup', () =>
-		cy.setCustomizeSettings({ neve_typeface_general: setup })
-	);
+describe("Typography Control", () => {
+  before("Setup", () =>
+    cy.setCustomizeSettings({ neve_typeface_general: setup })
+  );
 
-	it('Test Typography on Front End', () => {
-		cy.visit('/markup-html-tags-and-formatting/');
+  it("Test Typography on Front End", () => {
+    cy.visit("/markup-html-tags-and-formatting/");
 
-		// Test text transform.
-		cy.get('body')
-			.should('have.css', 'text-transform')
-			.and('eq', 'lowercase');
+    // Test text transform.
+    cy.get("body").should("have.css", "text-transform").and("eq", "lowercase");
 
-		// Test font weight.
-		cy.get('body')
-			.should('have.css', 'font-weight')
-			.and('match', new RegExp(setup.fontWeight, 'g'));
+    // Test font weight.
+    cy.get("body")
+      .should("have.css", "font-weight")
+      .and("match", new RegExp(setup.fontWeight, "g"));
 
-		const deviceMap = {
-			desktop: {
-				height: 1080,
-				width: 1920,
-			},
-			tablet: {
-				height: 1024,
-				width: 768,
-			},
-			mobile: {
-				height: 667,
-				width: 375,
-			},
-		};
+    const deviceMap = {
+      desktop: {
+        height: 1080,
+        width: 1920,
+      },
+      tablet: {
+        height: 1024,
+        width: 768,
+      },
+      mobile: {
+        height: 667,
+        width: 375,
+      },
+    };
 
-		// eslint-disable-next-line array-callback-return
-		Object.keys(deviceMap).map((device) => {
-			// Change viewport.
-			cy.viewport(deviceMap[device].width, deviceMap[device].height);
+    // eslint-disable-next-line array-callback-return
+    Object.keys(deviceMap).map((device) => {
+      // Change viewport.
+      cy.viewport(deviceMap[device].width, deviceMap[device].height);
 
-			// Test font size.
-			cy.get('body')
-				.should('have.css', 'font-size')
-				.and('match', new RegExp(setup.fontSize[device] + 'px', 'g'));
+      // Test font size.
+      cy.get("body")
+        .should("have.css", "font-size")
+        .and("match", new RegExp(setup.fontSize[device] + "px", "g"));
 
-			// Test line height.
-			cy.get('body')
-				.should('have.css', 'line-height')
-				.and('match', new RegExp(setup.lineHeight[device], 'g'));
+      // Test line height.
+      cy.get("body")
+        .should("have.css", "line-height")
+        .and("match", new RegExp(setup.lineHeight[device], "g"));
 
-			// Test letter spacing.
-			cy.get('body')
-				.should('have.css', 'letter-spacing')
-				.and('match', new RegExp(setup.letterSpacing[device], 'g'));
-		});
-	});
+      // Test letter spacing.
+      cy.get("body")
+        .should("have.css", "letter-spacing")
+        .and("match", new RegExp(setup.letterSpacing[device], "g"));
+    });
+  });
 
-	it('Test Typography inside the Editor', () => {
-		cy.visit('/markup-html-tags-and-formatting/');
-		cy.get('#wp-admin-bar-edit > a').click();
+  it("Test Typography inside the Editor", () => {
+    cy.visit("/markup-html-tags-and-formatting/");
+    cy.get("#wp-admin-bar-edit > a").click();
 
-		cy.clearWelcome();
-		cy.get('.editor-styles-wrapper .wp-block p').first().as('editorBody');
-		// Test text transform.
-		cy.get('@editorBody')
-			.should('have.css', 'text-transform')
-			.and('match', new RegExp(setup.textTransform.toLowerCase(), 'g'));
+    cy.clearWelcome();
+    cy.get(".editor-styles-wrapper .wp-block p").first().as("editorBody");
+    // Test text transform.
+    cy.get("@editorBody")
+      .should("have.css", "text-transform")
+      .and("match", new RegExp(setup.textTransform.toLowerCase(), "g"));
 
-		// Test font weight.
-		cy.get('@editorBody')
-			.should('have.css', 'font-weight')
-			.and('match', new RegExp(setup.fontWeight, 'g'));
+    // Test font weight.
+    cy.get("@editorBody")
+      .should("have.css", "font-weight")
+      .and("match", new RegExp(setup.fontWeight, "g"));
 
-		// Test font size.
-		cy.get('@editorBody')
-			.should('have.css', 'font-size')
-			.and('match', new RegExp(setup.fontSize.desktop + 'px', 'g'));
+    // Test font size.
+    cy.get("@editorBody")
+      .should("have.css", "font-size")
+      .and("match", new RegExp(setup.fontSize.desktop + "px", "g"));
 
-		// Test line height.
-		cy.get('@editorBody')
-			.should('have.css', 'line-height')
-			.and('match', new RegExp(setup.lineHeight.desktop, 'g'));
+    // Test line height.
+    cy.get("@editorBody")
+      .should("have.css", "line-height")
+      .and("match", new RegExp(setup.lineHeight.desktop, "g"));
 
-		// Test letter spacing.
-		cy.get('@editorBody')
-			.should('have.css', 'letter-spacing')
-			.and('match', new RegExp(setup.letterSpacing.desktop, 'g'));
-	});
+    // Test letter spacing.
+    cy.get("@editorBody")
+      .should("have.css", "letter-spacing")
+      .and("match", new RegExp(setup.letterSpacing.desktop, "g"));
+  });
 });

--- a/cypress/integration/dashboard/changelog.spec.js
+++ b/cypress/integration/dashboard/changelog.spec.js
@@ -1,40 +1,38 @@
-describe('Changelog Tab - Check Content Parsing and Interaction', () => {
-	beforeEach(() => {
-		cy.login();
-		cy.visit('/wp-admin/themes.php?page=neve-welcome#changelog');
-		cy.get('.tab-content.changelog').as('changelogTab');
-		cy.get('@changelogTab').find('.accordion.open').as('latestRelease');
-	});
+describe("Changelog Tab - Check Content Parsing and Interaction", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/wp-admin/themes.php?page=neve-welcome#changelog");
+    cy.get(".tab-content.changelog").as("changelogTab");
+    cy.get("@changelogTab").find(".accordion.open").as("latestRelease");
+  });
 
-	it('Has Content', () => {
-		cy.get('@changelogTab')
-			.find('.accordion')
-			.should('have.length.greaterThan', 4);
-	});
+  it("Has Content", () => {
+    cy.get("@changelogTab")
+      .find(".accordion")
+      .should("have.length.greaterThan", 4);
+  });
 
-	it('Parses Release Properly', () => {
-		cy.get('@latestRelease')
-			.find('.changelog-category')
-			.should('have.length.greaterThan', 0);
-		cy.get('@latestRelease')
-			.find('.label')
-			.should('have.length.greaterThan', 0);
-		cy.get('@latestRelease')
-			.find('.entries li')
-			.should('have.length.greaterThan', 0);
-	});
+  it("Parses Release Properly", () => {
+    cy.get("@latestRelease")
+      .find(".changelog-category")
+      .should("have.length.greaterThan", 0);
+    cy.get("@latestRelease")
+      .find(".label")
+      .should("have.length.greaterThan", 0);
+    cy.get("@latestRelease")
+      .find(".entries li")
+      .should("have.length.greaterThan", 0);
+  });
 
-	it('Collapses and Opens Accordion', () => {
-		cy.get('@latestRelease').find('button').click();
-		cy.get('@latestRelease').should('not.have.class', 'open');
-		cy.get('@latestRelease')
-			.find('.changelog-category')
-			.should('not.be.visible');
+  it("Collapses and Opens Accordion", () => {
+    cy.get("@latestRelease").find("button").click();
+    cy.get("@latestRelease").should("not.have.class", "open");
+    cy.get("@latestRelease")
+      .find(".changelog-category")
+      .should("not.be.visible");
 
-		cy.get('@latestRelease').find('button').click();
-		cy.get('@latestRelease').should('have.class', 'open');
-		cy.get('@latestRelease')
-			.find('.changelog-category')
-			.should('be.visible');
-	});
+    cy.get("@latestRelease").find("button").click();
+    cy.get("@latestRelease").should("have.class", "open");
+    cy.get("@latestRelease").find(".changelog-category").should("be.visible");
+  });
 });

--- a/cypress/integration/dashboard/general.spec.js
+++ b/cypress/integration/dashboard/general.spec.js
@@ -1,58 +1,56 @@
 /* eslint-disable array-callback-return */
-describe('General UI', () => {
-	const TABS = [
-		'start',
-		'plugins',
-		'help',
-		'changelog',
-		'free-pro',
-		'starter-sites',
-	];
+describe("General UI", () => {
+  const TABS = [
+    "start",
+    "plugins",
+    "help",
+    "changelog",
+    "free-pro",
+    "starter-sites",
+  ];
 
-	beforeEach(() => {
-		cy.login();
-		cy.visit('/wp-admin/themes.php?page=neve-welcome');
-		cy.intercept('GET', '/wp-json/wp/v2/settings/').as('getSettings');
-		cy.intercept('POST', '/wp-json/wp/v2/settings/').as('saveSettings');
-	});
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/wp-admin/themes.php?page=neve-welcome");
+    cy.intercept("GET", "/wp-json/wp/v2/settings/").as("getSettings");
+    cy.intercept("POST", "/wp-json/wp/v2/settings/").as("saveSettings");
+  });
 
-	it('Placeholder Loading', () => {
-		cy.get('.mock-dash').should('exist.and.be.visible');
-		cy.reload();
-		cy.wait('@getSettings').then((interception) => {
-			cy.get('.mock-dash').should('not.exist');
-			expect(interception.response.statusCode).to.equal(200);
-		});
-	});
+  it("Placeholder Loading", () => {
+    cy.get(".mock-dash").should("exist.and.be.visible");
+    cy.reload();
+    cy.wait("@getSettings").then((interception) => {
+      cy.get(".mock-dash").should("not.exist");
+      expect(interception.response.statusCode).to.equal(200);
+    });
+  });
 
-	it('Test Logger Flag', () => {
-		cy.get('.sidebar-section input').as('loggerToggle');
-		cy.get('@loggerToggle').should('not.be.checked');
-		cy.get('@loggerToggle').check();
-		cy.wait('@saveSettings').then((interception) => {
-			expect(interception.response.statusCode).to.equal(200);
-			expect(interception.response.body.neve_logger_flag).to.equal('yes');
-		});
+  it("Test Logger Flag", () => {
+    cy.get(".sidebar-section input").as("loggerToggle");
+    cy.get("@loggerToggle").should("not.be.checked");
+    cy.get("@loggerToggle").check();
+    cy.wait("@saveSettings").then((interception) => {
+      expect(interception.response.statusCode).to.equal(200);
+      expect(interception.response.body.neve_logger_flag).to.equal("yes");
+    });
 
-		cy.reload();
-		cy.get('@loggerToggle').should('be.checked');
-	});
+    cy.reload();
+    cy.get("@loggerToggle").should("be.checked");
+  });
 
-	it('URL Hash Tab Focus', () => {
-		TABS.map((hash) => {
-			cy.reload();
-			cy.visit(`/wp-admin/themes.php?page=neve-welcome#${hash}`);
-			cy.get(`nav.navigation a.${hash}`).should('have.class', 'active');
-			cy.get('.tab-content').should('have.class', hash);
-		});
-	});
+  it("URL Hash Tab Focus", () => {
+    TABS.map((hash) => {
+      cy.reload();
+      cy.visit(`/wp-admin/themes.php?page=neve-welcome#${hash}`);
+      cy.get(`nav.navigation a.${hash}`).should("have.class", "active");
+      cy.get(".tab-content").should("have.class", hash);
+    });
+  });
 
-	it('Tabs Navigation', () => {
-		TABS.map((slug) => {
-			cy.get(`nav.navigation a.${slug}`)
-				.click()
-				.should('have.class', 'active');
-			cy.get('.tab-content').should('have.class', slug);
-		});
-	});
+  it("Tabs Navigation", () => {
+    TABS.map((slug) => {
+      cy.get(`nav.navigation a.${slug}`).click().should("have.class", "active");
+      cy.get(".tab-content").should("have.class", slug);
+    });
+  });
 });

--- a/cypress/integration/dashboard/useful-plugins.spec.js
+++ b/cypress/integration/dashboard/useful-plugins.spec.js
@@ -1,41 +1,39 @@
-describe('Useful Plugins Tab - Install Optimole', () => {
-	beforeEach(() => {
-		cy.login();
-		cy.visit('/wp-admin/themes.php?page=neve-welcome#plugins');
-		cy.intercept('POST', '/wp-admin/admin-ajax.php').as('adminAjax');
-		cy.get('.tab-content.plugins').as('pluginsTab');
-	});
+describe("Useful Plugins Tab - Install Optimole", () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit("/wp-admin/themes.php?page=neve-welcome#plugins");
+    cy.intercept("POST", "/wp-admin/admin-ajax.php").as("adminAjax");
+    cy.get(".tab-content.plugins").as("pluginsTab");
+  });
 
-	it('Installs Plugins', () => {
-		cy.get('@pluginsTab')
-			.find('.plugin.card')
-			.should('have.length.greaterThan', 4);
-		cy.get('@pluginsTab')
-			.find('.plugin.optimole-wp button')
-			.then((btn) => {
-				if (btn.text().includes('Install')) {
-					btn.trigger('click');
-					cy.wait('@adminAjax').then((interception) => {
-						expect(interception.response.statusCode).to.equal(200);
-						expect(interception.response.body.success).to.equal(
-							true
-						);
-					});
-				}
-			});
-	});
+  it("Installs Plugins", () => {
+    cy.get("@pluginsTab")
+      .find(".plugin.card")
+      .should("have.length.greaterThan", 4);
+    cy.get("@pluginsTab")
+      .find(".plugin.optimole-wp button")
+      .then((btn) => {
+        if (btn.text().includes("Install")) {
+          btn.trigger("click");
+          cy.wait("@adminAjax").then((interception) => {
+            expect(interception.response.statusCode).to.equal(200);
+            expect(interception.response.body.success).to.equal(true);
+          });
+        }
+      });
+  });
 
-	it('Activates Plugins', () => {
-		cy.get('@pluginsTab').find('.plugin.optimole-wp button').as('button');
-		cy.get('@button').contains('Activate').click();
-		cy.get('@button').should('contain', 'Deactivate');
+  it("Activates Plugins", () => {
+    cy.get("@pluginsTab").find(".plugin.optimole-wp button").as("button");
+    cy.get("@button").contains("Activate").click();
+    cy.get("@button").should("contain", "Deactivate");
 
-		cy.reload();
-		cy.get('@button').should('contain', 'Deactivate').click();
-		cy.get('@button').should('contain', 'Activate');
+    cy.reload();
+    cy.get("@button").should("contain", "Deactivate").click();
+    cy.get("@button").should("contain", "Activate");
 
-		cy.reload();
-		cy.get('@button').should('contain', 'Activate').click();
-		cy.get('@button').should('contain', 'Deactivate');
-	});
+    cy.reload();
+    cy.get("@button").should("contain", "Activate").click();
+    cy.get("@button").should("contain", "Deactivate");
+  });
 });

--- a/cypress/integration/editor/classic/page.spec.js
+++ b/cypress/integration/editor/classic/page.spec.js
@@ -1,106 +1,104 @@
-describe('Page meta box settings', () => {
-	const pageSetup = {
-		title: 'Test Page',
-		content: 'The Page Content',
-		url: null,
-	};
+describe("Page meta box settings", () => {
+  const pageSetup = {
+    title: "Test Page",
+    content: "The Page Content",
+    url: null,
+  };
 
-	it('Create new page named "' + pageSetup.title + '".', () => {
-		cy.insertPost(pageSetup.title, pageSetup.content, 'page');
+  it('Create new page named "' + pageSetup.title + '".', () => {
+    cy.insertPost(pageSetup.title, pageSetup.content, "page");
 
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(pageSetup.title)
-			.should('have.attr', 'href')
-			.then((href) => {
-				pageSetup.url = href;
-			});
-	});
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(pageSetup.title)
+      .should("have.attr", "href")
+      .then((href) => {
+        pageSetup.url = href;
+      });
+  });
 
-	it('Default page should not have sidebar and use 100% width.', () => {
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap').should('not.exist');
-		cy.get('.single-page-container')
-			.should('not.have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '100%');
-		cy.get('.nv-page-title')
-			.should('exist')
-			.and('contain', pageSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-content-wrap').should('contain', pageSetup.content);
-	});
+  it("Default page should not have sidebar and use 100% width.", () => {
+    cy.visit(pageSetup.url);
+    cy.get(".nv-sidebar-wrap").should("not.exist");
+    cy.get(".single-page-container")
+      .should("not.have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "100%");
+    cy.get(".nv-page-title").should("exist").and("contain", pageSetup.title);
+    cy.get(".hfg_header").should("exist");
+    cy.get("footer.site-footer").should("exist");
+    cy.get(".nv-content-wrap").should("contain", pageSetup.content);
+  });
 
-	it('Content default width should be preserved', () => {
-		const defaultWidth = 1170;
-		cy.get('.single-page-container').should(
-			'have.css',
-			'max-width',
-			defaultWidth + 'px'
-		);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('.wp-block').should('have.css', 'max-width', '1170px');
-		cy.clearWelcome();
-		cy.insertCoverBlock();
-		cy.visit(pageSetup.url);
-		cy.matchContentWidth(defaultWidth);
-	});
+  it("Content default width should be preserved", () => {
+    const defaultWidth = 1170;
+    cy.get(".single-page-container").should(
+      "have.css",
+      "max-width",
+      defaultWidth + "px"
+    );
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.get(".wp-block").should("have.css", "max-width", "1170px");
+    cy.clearWelcome();
+    cy.insertCoverBlock();
+    cy.visit(pageSetup.url);
+    cy.matchContentWidth(defaultWidth);
+  });
 
-	it('Activates Classic Editor', () => {
-		cy.activateClassicEditorPlugin();
-	});
+  it("Activates Classic Editor", () => {
+    cy.activateClassicEditorPlugin();
+  });
 
-	it('Edit meta box content width "' + pageSetup.title + '".', () => {
-		cy.login(pageSetup.url);
+  it('Edit meta box content width "' + pageSetup.title + '".', () => {
+    cy.login(pageSetup.url);
 
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('#neve_meta_content_width-range')
-			.invoke('val', 70)
-			.trigger('change');
-		cy.get('#publish').contains('Update').click();
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.get("#neve_meta_content_width-range")
+      .invoke("val", 70)
+      .trigger("change");
+    cy.get("#publish").contains("Update").click();
 
-		cy.visit(pageSetup.url);
-		cy.get('.single-page-container .nv-content-wrap')
-			.invoke('width')
-			.should('be.eq', 0.7 * 1170 - 30); //we substract the padding.
-	});
+    cy.visit(pageSetup.url);
+    cy.get(".single-page-container .nv-content-wrap")
+      .invoke("width")
+      .should("be.eq", 0.7 * 1170 - 30); //we substract the padding.
+  });
 
-	it('Edit meta box settings "' + pageSetup.title + '".', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('label[for="neve_meta_container_full-width"]').click();
-		cy.get('label[for="neve_meta_sidebar_left"]').click();
-		cy.get('label[for="neve_meta_disable_title"]').click();
-		cy.get('label[for="neve_meta_disable_header"]').click();
-		cy.get('label[for="neve_meta_disable_footer"]').click();
-		cy.get('#neve_meta_content_width-range')
-			.invoke('val', 70)
-			.trigger('change');
+  it('Edit meta box settings "' + pageSetup.title + '".', () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.get('label[for="neve_meta_container_full-width"]').click();
+    cy.get('label[for="neve_meta_sidebar_left"]').click();
+    cy.get('label[for="neve_meta_disable_title"]').click();
+    cy.get('label[for="neve_meta_disable_header"]').click();
+    cy.get('label[for="neve_meta_disable_footer"]').click();
+    cy.get("#neve_meta_content_width-range")
+      .invoke("val", 70)
+      .trigger("change");
 
-		cy.get('#publish').contains('Update').click();
-	});
+    cy.get("#publish").contains("Update").click();
+  });
 
-	it('Edited meta box settings on front end.', () => {
-		cy.visit(pageSetup.url);
-		cy.reload();
-		cy.get('.nv-sidebar-wrap')
-			.should('have.class', 'nv-left')
-			.and('be.visible');
-		cy.get('.single-page-container')
-			.should('have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '70%');
-		cy.get('.nv-page-title').should('not.exist');
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('footer.site-footer').should('not.exist');
-		cy.get('.nv-content-wrap').should('not.contain', pageSetup.content);
-	});
+  it("Edited meta box settings on front end.", () => {
+    cy.visit(pageSetup.url);
+    cy.reload();
+    cy.get(".nv-sidebar-wrap")
+      .should("have.class", "nv-left")
+      .and("be.visible");
+    cy.get(".single-page-container")
+      .should("have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "70%");
+    cy.get(".nv-page-title").should("not.exist");
+    cy.get(".hfg_header").should("not.exist");
+    cy.get("footer.site-footer").should("not.exist");
+    cy.get(".nv-content-wrap").should("not.contain", pageSetup.content);
+  });
 
-	it('Deactivate Classic Editor', () => {
-		cy.deactivateClassicEditorPlugin();
-	});
+  it("Deactivate Classic Editor", () => {
+    cy.deactivateClassicEditorPlugin();
+  });
 });

--- a/cypress/integration/editor/classic/post.spec.js
+++ b/cypress/integration/editor/classic/post.spec.js
@@ -1,85 +1,85 @@
-describe('Posts meta box default settings', () => {
-	const postSetup = {
-		title: 'Test Post',
-		content: 'The Post Content',
-		url: null,
-	};
-	it('Create new post named "' + postSetup.title + '".', () => {
-		cy.insertPost(postSetup.title, postSetup.content, 'post', true);
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(postSetup.title)
-			.should('have.attr', 'href')
-			.then((href) => {
-				postSetup.url = href;
-			});
-	});
-	it('Default meta box settings on front end.', () => {
-		cy.visit(postSetup.url);
+describe("Posts meta box default settings", () => {
+  const postSetup = {
+    title: "Test Post",
+    content: "The Post Content",
+    url: null,
+  };
+  it('Create new post named "' + postSetup.title + '".', () => {
+    cy.insertPost(postSetup.title, postSetup.content, "post", true);
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(postSetup.title)
+      .should("have.attr", "href")
+      .then((href) => {
+        postSetup.url = href;
+      });
+  });
+  it("Default meta box settings on front end.", () => {
+    cy.visit(postSetup.url);
 
-		cy.get('.nv-sidebar-wrap')
-			.should('have.class', 'nv-right')
-			.and('be.visible');
-		cy.get('.single-post-container')
-			.should('not.have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '70%');
-		cy.get('.entry-title').should('exist').and('contain', postSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-thumb-wrap > img')
-			.should('exist')
-			.and('be.visible')
-			.and('have.attr', 'src')
-			.then(($href) => {
-				expect($href).to.contain('/wp-content/uploads/');
-			});
-		cy.get('.nv-content-wrap').should('contain', postSetup.content);
-	});
+    cy.get(".nv-sidebar-wrap")
+      .should("have.class", "nv-right")
+      .and("be.visible");
+    cy.get(".single-post-container")
+      .should("not.have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "70%");
+    cy.get(".entry-title").should("exist").and("contain", postSetup.title);
+    cy.get(".hfg_header").should("exist");
+    cy.get("footer.site-footer").should("exist");
+    cy.get(".nv-thumb-wrap > img")
+      .should("exist")
+      .and("be.visible")
+      .and("have.attr", "src")
+      .then(($href) => {
+        expect($href).to.contain("/wp-content/uploads/");
+      });
+    cy.get(".nv-content-wrap").should("contain", postSetup.content);
+  });
 
-	it('Activates Classic Editor', () => {
-		cy.activateClassicEditorPlugin();
-	});
+  it("Activates Classic Editor", () => {
+    cy.activateClassicEditorPlugin();
+  });
 
-	it('Edit meta box settings "' + postSetup.title + '".', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
+  it('Edit meta box settings "' + postSetup.title + '".', () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.get('label[for="neve_meta_container_full-width"]').click();
-		cy.get('label[for="neve_meta_sidebar_left"]').click();
-		cy.get('label[for="neve_meta_disable_title"]').click();
-		cy.get('label[for="neve_meta_disable_header"]').click();
-		cy.get('label[for="neve_meta_disable_featured_image"]').click();
-		cy.get('label[for="neve_meta_disable_footer"]').click();
-		cy.get('label[for="neve_meta_enable_content_width"]').click();
-		cy.get('#neve_meta_content_width-range')
-			.invoke('val', 50)
-			.trigger('change');
-		cy.wait(1000);
-		cy.get('#publish').contains('Update').click();
-	});
+    cy.get('label[for="neve_meta_container_full-width"]').click();
+    cy.get('label[for="neve_meta_sidebar_left"]').click();
+    cy.get('label[for="neve_meta_disable_title"]').click();
+    cy.get('label[for="neve_meta_disable_header"]').click();
+    cy.get('label[for="neve_meta_disable_featured_image"]').click();
+    cy.get('label[for="neve_meta_disable_footer"]').click();
+    cy.get('label[for="neve_meta_enable_content_width"]').click();
+    cy.get("#neve_meta_content_width-range")
+      .invoke("val", 50)
+      .trigger("change");
+    cy.wait(1000);
+    cy.get("#publish").contains("Update").click();
+  });
 
-	it('Edited meta box settings on front end.', () => {
-		cy.visit(postSetup.url);
-		cy.reload();
-		cy.get('.nv-sidebar-wrap')
-			.should('have.class', 'nv-left')
-			.and('be.visible');
-		cy.get('.single-post-container')
-			.should('have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '50%');
-		cy.get('.entry-title').should('not.exist');
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('footer.site-footer').should('not.exist');
-		cy.get('.nv-thumb-wrap').should('not.exist');
-		cy.get('.nv-content-wrap').should('contain', postSetup.content);
-	});
+  it("Edited meta box settings on front end.", () => {
+    cy.visit(postSetup.url);
+    cy.reload();
+    cy.get(".nv-sidebar-wrap")
+      .should("have.class", "nv-left")
+      .and("be.visible");
+    cy.get(".single-post-container")
+      .should("have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "50%");
+    cy.get(".entry-title").should("not.exist");
+    cy.get(".hfg_header").should("not.exist");
+    cy.get("footer.site-footer").should("not.exist");
+    cy.get(".nv-thumb-wrap").should("not.exist");
+    cy.get(".nv-content-wrap").should("contain", postSetup.content);
+  });
 
-	it('Deactivates Classic Editor', () => {
-		cy.deactivateClassicEditorPlugin();
-	});
+  it("Deactivates Classic Editor", () => {
+    cy.deactivateClassicEditorPlugin();
+  });
 });

--- a/cypress/integration/editor/modern/page-meta-sidebar.spec.js
+++ b/cypress/integration/editor/modern/page-meta-sidebar.spec.js
@@ -1,206 +1,193 @@
-describe('Single page sidebar', () => {
-	const pageSetup = {
-		title: 'Test Page',
-		content: 'The Page Content',
-		url: null,
-	};
+describe("Single page sidebar", () => {
+  const pageSetup = {
+    title: "Test Page",
+    content: "The Page Content",
+    url: null,
+  };
 
-	it('Create new page named "' + pageSetup.title + '".', () => {
-		cy.insertPost(pageSetup.title, pageSetup.content, 'page');
+  it('Create new page named "' + pageSetup.title + '".', () => {
+    cy.insertPost(pageSetup.title, pageSetup.content, "page");
 
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(pageSetup.title)
-			.should('have.attr', 'href')
-			.then((href) => {
-				pageSetup.url = href;
-			});
-	});
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(pageSetup.title)
+      .should("have.attr", "href")
+      .then((href) => {
+        pageSetup.url = href;
+      });
+  });
 
-	it('Default page should not have sidebar and use 100% width.', () => {
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap').should('not.exist');
-		cy.get('.single-page-container')
-			.should('not.have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '100%');
-		cy.get('.nv-page-title')
-			.should('exist')
-			.and('contain', pageSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-content-wrap').should('contain', pageSetup.content);
-	});
+  it("Default page should not have sidebar and use 100% width.", () => {
+    cy.visit(pageSetup.url);
+    cy.get(".nv-sidebar-wrap").should("not.exist");
+    cy.get(".single-page-container")
+      .should("not.have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "100%");
+    cy.get(".nv-page-title").should("exist").and("contain", pageSetup.title);
+    cy.get(".hfg_header").should("exist");
+    cy.get("footer.site-footer").should("exist");
+    cy.get(".nv-content-wrap").should("contain", pageSetup.content);
+  });
 
-	it('Check sidebar layout', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check sidebar layout", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="full-width"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap').should('not.exist');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="full-width"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-sidebar-wrap").should("not.exist");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="left"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap').should('exist').and('have.class', 'nv-left');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="left"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-sidebar-wrap").should("exist").and("have.class", "nv-left");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="right"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap')
-			.should('exist')
-			.and('have.class', 'nv-right');
-	});
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="right"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-sidebar-wrap").should("exist").and("have.class", "nv-right");
+  });
 
-	it('Check container layout', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check container layout", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.getControl('neve_meta_container')
-			.find('.components-button')
-			.contains('Contained')
-			.click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.single-page-container')
-			.should('have.class', 'container')
-			.and('be.visible');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_container")
+      .find(".components-button")
+      .contains("Contained")
+      .click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".single-page-container")
+      .should("have.class", "container")
+      .and("be.visible");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_container')
-			.find('.components-button')
-			.contains('Full Width')
-			.click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.single-page-container')
-			.should('not.have.class', 'container')
-			.and('be.visible');
-	});
+    cy.getControl("neve_meta_container")
+      .find(".components-button")
+      .contains("Full Width")
+      .click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".single-page-container")
+      .should("not.have.class", "container")
+      .and("be.visible");
+  });
 
-	it('Check container width', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check container width", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Custom Content Width (%)'
-		);
+    cy.activateCheckbox(
+      ".components-toggle-control__label",
+      "Custom Content Width (%)"
+    );
 
-		cy.get('.neve_meta_content_width')
-			.find('input[type=number]')
-			.type('{selectall}')
-			.type(60);
-		cy.updatePost();
-		cy.visit(pageSetup.url);
+    cy.get(".neve_meta_content_width")
+      .find("input[type=number]")
+      .type("{selectall}")
+      .type(60);
+    cy.updatePost();
+    cy.visit(pageSetup.url);
 
-		cy.get('.nv-single-page-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '60%');
-	});
+    cy.get(".nv-single-page-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "60%");
+  });
 
-	it('Check title alignment', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check title alignment", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.get('.neve_meta_title_alignment .nv-align-center').click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-page-title')
-			.should('have.class', 'has-text-align-center')
-			.and('have.css', 'text-align')
-			.and('eq', 'center');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.get(".neve_meta_title_alignment .nv-align-center").click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-page-title")
+      .should("have.class", "has-text-align-center")
+      .and("have.css", "text-align")
+      .and("eq", "center");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.get('.neve_meta_title_alignment .nv-align-right').click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-page-title')
-			.should('have.class', 'has-text-align-right')
-			.and('have.css', 'text-align')
-			.and('eq', 'right');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.get(".neve_meta_title_alignment .nv-align-right").click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-page-title")
+      .should("have.class", "has-text-align-right")
+      .and("have.css", "text-align")
+      .and("eq", "right");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.get('.neve_meta_title_alignment .nv-align-left').click();
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-page-title')
-			.should('have.class', 'has-text-align-left')
-			.and('have.css', 'text-align')
-			.and('eq', 'left');
-		cy.get('#wp-admin-bar-edit a').click();
-	});
+    cy.get(".neve_meta_title_alignment .nv-align-left").click();
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-page-title")
+      .should("have.class", "has-text-align-left")
+      .and("have.css", "text-align")
+      .and("eq", "left");
+    cy.get("#wp-admin-bar-edit a").click();
+  });
 
-	it('Check author avatar not to exist for page', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check author avatar not to exist for page", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.get('.components-toggle-control__label')
-			.contains('Author Avatar')
-			.should('not.exist');
-	});
+    cy.get(".components-toggle-control__label")
+      .contains("Author Avatar")
+      .should("not.exist");
+  });
 
-	it('Check post elements', () => {
-		cy.login(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check post elements", () => {
+    cy.login(pageSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
-		cy.get('.neve-meta-sortable').should('not.exist');
+    cy.openNeveSidebar();
+    cy.get(".neve-meta-sortable").should("not.exist");
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Disable Header'
-		);
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.activateCheckbox(".components-toggle-control__label", "Disable Header");
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".hfg_header").should("not.exist");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Disable Footer'
-		);
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('footer.site-footer').should('not.exist');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.activateCheckbox(".components-toggle-control__label", "Disable Footer");
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get("footer.site-footer").should("not.exist");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Disable Title'
-		);
-		cy.updatePost();
-		cy.visit(pageSetup.url);
-		cy.get('.nv-page-title-wrap').should('not.exist');
-	});
+    cy.activateCheckbox(".components-toggle-control__label", "Disable Title");
+    cy.updatePost();
+    cy.visit(pageSetup.url);
+    cy.get(".nv-page-title-wrap").should("not.exist");
+  });
 });

--- a/cypress/integration/editor/modern/post-meta-sidebar.spec.js
+++ b/cypress/integration/editor/modern/post-meta-sidebar.spec.js
@@ -1,261 +1,250 @@
-describe('Single post meta sidebar', () => {
-	const postSetup = {
-		title: 'Test Post',
-		content: 'The Post Content',
-		url: null,
-	};
+describe("Single post meta sidebar", () => {
+  const postSetup = {
+    title: "Test Post",
+    content: "The Post Content",
+    url: null,
+  };
 
-	it('Create new post named "' + postSetup.title + '".', () => {
-		cy.insertPost(postSetup.title, postSetup.content, 'post', true, true);
-		cy.get('.post-publish-panel__postpublish-header a')
-			.contains(postSetup.title)
-			.should('have.attr', 'href')
-			.then((href) => {
-				postSetup.url = href;
-			});
-	});
+  it('Create new post named "' + postSetup.title + '".', () => {
+    cy.insertPost(postSetup.title, postSetup.content, "post", true, true);
+    cy.get(".post-publish-panel__postpublish-header a")
+      .contains(postSetup.title)
+      .should("have.attr", "href")
+      .then((href) => {
+        postSetup.url = href;
+      });
+  });
 
-	it('Default meta box settings on front end.', () => {
-		cy.visit(postSetup.url);
+  it("Default meta box settings on front end.", () => {
+    cy.visit(postSetup.url);
 
-		cy.get('.nv-sidebar-wrap')
-			.should('have.class', 'nv-right')
-			.and('be.visible');
-		cy.get('.single-post-container')
-			.should('not.have.class', 'container-fluid')
-			.and('be.visible');
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '70%');
-		cy.get('.entry-title').should('exist').and('contain', postSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-thumb-wrap > img')
-			.should('exist')
-			.and('be.visible')
-			.and('have.attr', 'src')
-			.then(($href) => {
-				expect($href).to.contain('/wp-content/uploads/');
-			});
-		cy.get('.nv-content-wrap').should('contain', postSetup.content);
-	});
+    cy.get(".nv-sidebar-wrap")
+      .should("have.class", "nv-right")
+      .and("be.visible");
+    cy.get(".single-post-container")
+      .should("not.have.class", "container-fluid")
+      .and("be.visible");
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "70%");
+    cy.get(".entry-title").should("exist").and("contain", postSetup.title);
+    cy.get(".hfg_header").should("exist");
+    cy.get("footer.site-footer").should("exist");
+    cy.get(".nv-thumb-wrap > img")
+      .should("exist")
+      .and("be.visible")
+      .and("have.attr", "src")
+      .then(($href) => {
+        expect($href).to.contain("/wp-content/uploads/");
+      });
+    cy.get(".nv-content-wrap").should("contain", postSetup.content);
+  });
 
-	it('Check sidebar layout', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check sidebar layout", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="full-width"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.nv-sidebar-wrap').should('not.exist');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="full-width"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".nv-sidebar-wrap").should("not.exist");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="left"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.nv-sidebar-wrap').should('exist').and('have.class', 'nv-left');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="left"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".nv-sidebar-wrap").should("exist").and("have.class", "nv-left");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_sidebar')
-			.find('.components-radio-control__input[value="right"]')
-			.parent()
-			.click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.nv-sidebar-wrap')
-			.should('exist')
-			.and('have.class', 'nv-right');
-	});
+    cy.getControl("neve_meta_sidebar")
+      .find('.components-radio-control__input[value="right"]')
+      .parent()
+      .click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".nv-sidebar-wrap").should("exist").and("have.class", "nv-right");
+  });
 
-	it('Check container layout', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check container layout", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.getControl('neve_meta_container')
-			.find('.components-button')
-			.contains('Contained')
-			.click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.single-post-container')
-			.should('have.class', 'container')
-			.and('be.visible');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.getControl("neve_meta_container")
+      .find(".components-button")
+      .contains("Contained")
+      .click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".single-post-container")
+      .should("have.class", "container")
+      .and("be.visible");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.getControl('neve_meta_container')
-			.find('.components-button')
-			.contains('Full Width')
-			.click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.single-post-container')
-			.should('not.have.class', 'container')
-			.and('be.visible');
-	});
+    cy.getControl("neve_meta_container")
+      .find(".components-button")
+      .contains("Full Width")
+      .click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".single-post-container")
+      .should("not.have.class", "container")
+      .and("be.visible");
+  });
 
-	it('Check container width', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check container width", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		// const enableContentWidth = cy.get('.components-toggle-control__label').contains('Custom Content Width (%)');
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Custom Content Width (%'
-		);
+    // const enableContentWidth = cy.get('.components-toggle-control__label').contains('Custom Content Width (%)');
+    cy.activateCheckbox(
+      ".components-toggle-control__label",
+      "Custom Content Width (%"
+    );
 
-		cy.get('.neve_meta_content_width')
-			.find('input[type=number]')
-			.type('{selectall}')
-			.type(60);
-		cy.updatePost();
-		cy.visit(postSetup.url);
+    cy.get(".neve_meta_content_width")
+      .find("input[type=number]")
+      .type("{selectall}")
+      .type(60);
+    cy.updatePost();
+    cy.visit(postSetup.url);
 
-		cy.get('.nv-single-post-wrap')
-			.should('have.css', 'max-width')
-			.and('eq', '60%');
-	});
+    cy.get(".nv-single-post-wrap")
+      .should("have.css", "max-width")
+      .and("eq", "60%");
+  });
 
-	it('Check title alignment', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check title alignment", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.get('.neve_meta_title_alignment .nv-align-center').click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('h1.entry-title')
-			.should('have.class', 'has-text-align-center')
-			.and('have.css', 'text-align')
-			.and('eq', 'center');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.get(".neve_meta_title_alignment .nv-align-center").click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get("h1.entry-title")
+      .should("have.class", "has-text-align-center")
+      .and("have.css", "text-align")
+      .and("eq", "center");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.get('.neve_meta_title_alignment .nv-align-right').click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('h1.entry-title')
-			.should('have.class', 'has-text-align-right')
-			.and('have.css', 'text-align')
-			.and('eq', 'right');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.get(".neve_meta_title_alignment .nv-align-right").click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get("h1.entry-title")
+      .should("have.class", "has-text-align-right")
+      .and("have.css", "text-align")
+      .and("eq", "right");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.get('.neve_meta_title_alignment .nv-align-left').click();
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('h1.entry-title')
-			.should('have.class', 'has-text-align-left')
-			.and('have.css', 'text-align')
-			.and('eq', 'left');
-		cy.get('#wp-admin-bar-edit a').click();
-	});
+    cy.get(".neve_meta_title_alignment .nv-align-left").click();
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get("h1.entry-title")
+      .should("have.class", "has-text-align-left")
+      .and("have.css", "text-align")
+      .and("eq", "left");
+    cy.get("#wp-admin-bar-edit a").click();
+  });
 
-	it('Check author avatar', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check author avatar", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Author Avatar'
-		);
-		cy.updatePost();
+    cy.activateCheckbox(".components-toggle-control__label", "Author Avatar");
+    cy.updatePost();
 
-		cy.visit(postSetup.url);
-		cy.get('.nv-meta-list .author .photo').should('exist');
-	});
+    cy.visit(postSetup.url);
+    cy.get(".nv-meta-list .author .photo").should("exist");
+  });
 
-	it('Check post elements', () => {
-		cy.login(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.clearWelcome();
+  it("Check post elements", () => {
+    cy.login(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.clearWelcome();
 
-		cy.openNeveSidebar();
+    cy.openNeveSidebar();
 
-		cy.get('.ti-sortable-item-label').each((el, index) => {
-			const shouldContain = [
-				'Post Title',
-				'Post Meta',
-				'Featured Image',
-				'Content',
-				'Tags',
-				'Comments',
-				'Post Navigation',
-			];
-			expect(el).to.contain(shouldContain[index]);
-			if (index === 6) {
-				cy.get(el).parent().should('have.class', 'hidden');
-			} else {
-				cy.get(el).parent().should('not.have.class', 'hidden');
-			}
-		});
+    cy.get(".ti-sortable-item-label").each((el, index) => {
+      const shouldContain = [
+        "Post Title",
+        "Post Meta",
+        "Featured Image",
+        "Content",
+        "Tags",
+        "Comments",
+        "Post Navigation",
+      ];
+      expect(el).to.contain(shouldContain[index]);
+      if (index === 6) {
+        cy.get(el).parent().should("have.class", "hidden");
+      } else {
+        cy.get(el).parent().should("not.have.class", "hidden");
+      }
+    });
 
-		cy.toggleElements(false);
-		cy.get('.components-toggle-control__label')
-			.contains('Author Avatar')
-			.should('not.exist');
-		cy.updatePost();
-		cy.visit(postSetup.url);
+    cy.toggleElements(false);
+    cy.get(".components-toggle-control__label")
+      .contains("Author Avatar")
+      .should("not.exist");
+    cy.updatePost();
+    cy.visit(postSetup.url);
 
-		cy.get('h1.title').should('not.exist');
-		cy.get('.nv-thumb-wrap').should('not.exist');
-		cy.get('.nv-tags-list').should('not.exist');
-		cy.get('.nv-meta-list').should('not.exist');
-		cy.get('.nv-content-wrap').should('not.exist');
-		cy.get('#comments').should('not.exist');
-		cy.get('.nv-post-navigation').should('not.exist');
+    cy.get("h1.title").should("not.exist");
+    cy.get(".nv-thumb-wrap").should("not.exist");
+    cy.get(".nv-tags-list").should("not.exist");
+    cy.get(".nv-meta-list").should("not.exist");
+    cy.get(".nv-content-wrap").should("not.exist");
+    cy.get("#comments").should("not.exist");
+    cy.get(".nv-post-navigation").should("not.exist");
 
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.toggleElements(true);
-		cy.get('.components-toggle-control__label')
-			.contains('Author Avatar')
-			.should('exist');
-		cy.updatePost();
-		cy.visit(postSetup.url);
+    cy.get("#wp-admin-bar-edit a").click();
+    cy.toggleElements(true);
+    cy.get(".components-toggle-control__label")
+      .contains("Author Avatar")
+      .should("exist");
+    cy.updatePost();
+    cy.visit(postSetup.url);
 
-		cy.get('h1.title').should('exist');
-		cy.get('.nv-thumb-wrap').should('exist');
-		cy.get('.nv-tags-list').should('exist');
-		cy.get('.nv-meta-list').should('exist');
-		cy.get('.nv-content-wrap').should('exist');
-		cy.get('#comments').should('exist');
-		cy.get('.nv-post-navigation').should('exist');
-		cy.visit(postSetup.url);
+    cy.get("h1.title").should("exist");
+    cy.get(".nv-thumb-wrap").should("exist");
+    cy.get(".nv-tags-list").should("exist");
+    cy.get(".nv-meta-list").should("exist");
+    cy.get(".nv-content-wrap").should("exist");
+    cy.get("#comments").should("exist");
+    cy.get(".nv-post-navigation").should("exist");
+    cy.visit(postSetup.url);
 
-		cy.get('#wp-admin-bar-edit a').click();
-		// const headerToggle = cy.get('.components-toggle-control__label').contains('Disable Header');
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Disable Header'
-		);
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('#wp-admin-bar-edit a').click();
+    cy.get("#wp-admin-bar-edit a").click();
+    // const headerToggle = cy.get('.components-toggle-control__label').contains('Disable Header');
+    cy.activateCheckbox(".components-toggle-control__label", "Disable Header");
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get(".hfg_header").should("not.exist");
+    cy.get("#wp-admin-bar-edit a").click();
 
-		cy.activateCheckbox(
-			'.components-toggle-control__label',
-			'Disable Footer'
-		);
-		cy.updatePost();
-		cy.visit(postSetup.url);
-		cy.get('footer.site-footer').should('not.exist');
-	});
+    cy.activateCheckbox(".components-toggle-control__label", "Disable Footer");
+    cy.updatePost();
+    cy.visit(postSetup.url);
+    cy.get("footer.site-footer").should("not.exist");
+  });
 });

--- a/cypress/integration/starter-sites/starter-sites.spec.js
+++ b/cypress/integration/starter-sites/starter-sites.spec.js
@@ -1,17 +1,15 @@
-describe('Starter sites import', () => {
-	before(() => {
-		cy.login('/wp-admin/themes.php?page=tiob-starter-sites');
-	});
-	it('Successfully imports Web Agency starter site template', () => {
-		cy.get(':nth-child(1) > .top > .actions > .import').click();
-		cy.get('.modal-footer > .import')
-			.contains('Import entire site')
-			.click();
-		cy.get('.import-done-actions > .is-secondary', {
-			timeout: 30000,
-		}).click();
-		cy.get('h1.has-text-align-center').contains(
-			'Create and grow your unique website today'
-		);
-	});
+describe("Starter sites import", () => {
+  before(() => {
+    cy.login("/wp-admin/themes.php?page=tiob-starter-sites");
+  });
+  it("Successfully imports Web Agency starter site template", () => {
+    cy.get(":nth-child(1) > .top > .actions > .import").click();
+    cy.get(".modal-footer > .import").contains("Import entire site").click();
+    cy.get(".import-done-actions > .is-secondary", {
+      timeout: 30000,
+    }).click();
+    cy.get("h1.has-text-align-center").contains(
+      "Create and grow your unique website today"
+    );
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-01-blocks-embeds.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-01-blocks-embeds.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/01/blocks-embeds/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/01/blocks-embeds/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/01/blocks-embeds/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/01/blocks-embeds/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-02-column-blocks.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-02-column-blocks.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/02/column-blocks/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/02/column-blocks/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/02/column-blocks/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/02/column-blocks/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-button.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-button.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-button/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-button/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-button/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-button/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-gallery.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-gallery.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-gallery/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-gallery/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-gallery/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-gallery/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-image-amp.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-image-amp.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-image/?amp', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-image/?amp";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-image/?amp", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-image/?amp";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-image.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-2018-11-03-block-image.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-image/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-image/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/2018/11/03/block-image/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/2018/11/03/block-image/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-about-page-markup-and-formatting.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-about-page-markup-and-formatting.spec.js
@@ -1,7 +1,8 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/about/page-markup-and-formatting/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/about/page-markup-and-formatting/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/about/page-markup-and-formatting/", () => {
+  const url =
+    "https://qa-neve.themeisle.com/nv/about/page-markup-and-formatting/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-amp.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-amp.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/?amp', () => {
-	let url = "https://qa-neve.themeisle.com/nv/?amp";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/?amp", () => {
+  const url = "https://qa-neve.themeisle.com/nv/?amp";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-blog-v2-yes.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-blog-v2-yes.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/?blog_v2=yes', () => {
-	let url = "https://qa-neve.themeisle.com/nv/?blog_v2=yes";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/?blog_v2=yes", () => {
+  const url = "https://qa-neve.themeisle.com/nv/?blog_v2=yes";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-blog-v3-yes.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-blog-v3-yes.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/?blog_v3=yes', () => {
-	let url = "https://qa-neve.themeisle.com/nv/?blog_v3=yes";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/?blog_v3=yes", () => {
+  const url = "https://qa-neve.themeisle.com/nv/?blog_v3=yes";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-d-rtl.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-d-rtl.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/?d=rtl', () => {
-	let url = "https://qa-neve.themeisle.com/nv/?d=rtl";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/?d=rtl", () => {
+  const url = "https://qa-neve.themeisle.com/nv/?d=rtl";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-df480-shop-amp.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-df480-shop-amp.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/df480-shop/?amp', () => {
-	let url = "https://qa-neve.themeisle.com/nv/df480-shop/?amp";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/df480-shop/?amp", () => {
+  const url = "https://qa-neve.themeisle.com/nv/df480-shop/?amp";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-df480-shop.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-df480-shop.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/df480-shop/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/df480-shop/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/df480-shop/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/df480-shop/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-product-apple-peppermint-smoothie-d-rtl.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-product-apple-peppermint-smoothie-d-rtl.spec.js
@@ -1,7 +1,8 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/?d=rtl', () => {
-	let url = "https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/?d=rtl";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/?d=rtl", () => {
+  const url =
+    "https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/?d=rtl";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-product-apple-peppermint-smoothie.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-product-apple-peppermint-smoothie.spec.js
@@ -1,7 +1,8 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/", () => {
+  const url =
+    "https://qa-neve.themeisle.com/nv/product/apple-peppermint-smoothie/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv-product-ship-your-idea-2.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv-product-ship-your-idea-2.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/ship-your-idea-2/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/product/ship-your-idea-2/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/product/ship-your-idea-2/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/product/ship-your-idea-2/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/qa-pages/nv.spec.js
+++ b/cypress/integration/visual-regression/qa-pages/nv.spec.js
@@ -1,7 +1,7 @@
-describe('Visual Regression Testing - https://qa-neve.themeisle.com/nv/', () => {
-	let url = "https://qa-neve.themeisle.com/nv/";
-	it('Should not add any visual change', function () {
-		cy.visit(url);
-		cy.captureDocument();
-	});
+describe("Visual Regression Testing - https://qa-neve.themeisle.com/nv/", () => {
+  const url = "https://qa-neve.themeisle.com/nv/";
+  it("Should not add any visual change", function () {
+    cy.visit(url);
+    cy.captureDocument();
+  });
 });

--- a/cypress/integration/visual-regression/starter-sites/blogger-gb.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/blogger-gb.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/blogger-gb/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/blogger-gb/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/blogger-gb/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/blogger-gb/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/blogger.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/blogger.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/blogger/ ', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/blogger/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/blogger/ ", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/blogger/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/fitness.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/fitness.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/fitness/ ', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/fitness/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/fitness/ ", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/fitness/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/freelancer.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/freelancer.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/freelancer/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/freelancer/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/freelancer/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/freelancer/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/onboarding-gutenberg.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/onboarding-gutenberg.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/onboarding-gutenberg/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/onboarding-gutenberg/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/onboarding-gutenberg/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/onboarding-gutenberg/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/onboarding.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/onboarding.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/onboarding/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/onboarding/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/onboarding/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/onboarding/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/shop.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/shop.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/shop/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/shop/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/shop/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/shop/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/web-agency-gb.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/web-agency-gb.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/web-agency-gb/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/web-agency-gb/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/web-agency-gb/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/web-agency-gb/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/web-agency.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/web-agency.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/web-agency/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/web-agency/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/web-agency/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/web-agency/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/integration/visual-regression/starter-sites/zelle.spec.js
+++ b/cypress/integration/visual-regression/starter-sites/zelle.spec.js
@@ -1,28 +1,27 @@
-describe( 'Starter Sites VR - https://staging.demosites.io/zelle/', () => {
-    let pages = [];
-    it( 'Check frontpage', () => {
-    	let frontpage = "https://staging.demosites.io/zelle/"
-	    cy.visit(frontpage );
-		cy.captureDocument();
-        cy.get( '#nv-primary-navigation-main' ).then( $headerMenu => {
-            [ ...$headerMenu.find( '.menu-item a' ) ].forEach( $url => {
-            	let url = $url.href;
-            	if(url.includes("#")){
-            		return;
-	            }
-            	if(frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")){
-            		return;
-	            }
+describe("Starter Sites VR - https://staging.demosites.io/zelle/", () => {
+  const pages = [];
+  it("Check frontpage", () => {
+    const frontpage = "https://staging.demosites.io/zelle/";
+    cy.visit(frontpage);
+    cy.captureDocument();
+    cy.get("#nv-primary-navigation-main").then(($headerMenu) => {
+      [...$headerMenu.find(".menu-item a")].forEach(($url) => {
+        const url = $url.href;
+        if (url.includes("#")) {
+          return;
+        }
+        if (frontpage.replace(/\/*$/, "") === url.replace(/\/*$/, "")) {
+          return;
+        }
 
-                pages.push( $url.href );
-            } );
-        } );
-    } );
-    it( 'Check additional pages', () => {
-        pages.forEach( page => {
-            cy.visit( page );
-            cy.captureDocument(true, "Check additional - " + page);
-        } );
-    } );
-
-} );
+        pages.push($url.href);
+      });
+    });
+  });
+  it("Check additional pages", () => {
+    pages.forEach((page) => {
+      cy.visit(page);
+      cy.captureDocument(true, "Check additional - " + page);
+    });
+  });
+});

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -3,18 +3,18 @@
 // } = require('cypress-image-snapshot/plugin');
 
 module.exports = (on) => {
-	//	addMatchImageSnapshotPlugin(on, config);
+  //	addMatchImageSnapshotPlugin(on, config);
 
-	on('before:browser:launch', (browser, launchOptions) => {
-		if (browser.name === 'chrome' && browser.isHeadless) {
-			launchOptions.args.push('--window-size=1366,768');
-			launchOptions.args.push('--force-device-scale-factor=1');
-			return launchOptions;
-		}
-	});
+  on("before:browser:launch", (browser, launchOptions) => {
+    if (browser.name === "chrome" && browser.isHeadless) {
+      launchOptions.args.push("--window-size=1366,768");
+      launchOptions.args.push("--force-device-scale-factor=1");
+      return launchOptions;
+    }
+  });
 };
-const percyHealthCheck = require('@percy/cypress/task');
+const percyHealthCheck = require("@percy/cypress/task");
 
 module.exports = (on) => {
-	on('task', percyHealthCheck);
+  on("task", percyHealthCheck);
 };

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,165 +1,161 @@
-import 'cypress-file-upload';
-import '@percy/cypress';
+import "cypress-file-upload";
+import "@percy/cypress";
 
-const scrollToBottom = require('scroll-to-bottomjs');
+const scrollToBottom = require("scroll-to-bottomjs");
 Cypress.Cookies.defaults({
-	preserve: /wordpress_.*/,
+  preserve: /wordpress_.*/,
 });
-Cypress.Commands.add('login', (nextRoute = null) => {
-	//console.log(cy.getCookies());
+Cypress.Commands.add("login", (nextRoute = null) => {
+  //console.log(cy.getCookies());
 
-	const cookies = cy
-		.getCookies({
-			log: true,
-		})
-		.then(function (cookies) {
-			let isLoggedIn = false;
-			cookies.forEach(function (value) {
-				if (value.name.includes('wordpress_')) {
-					isLoggedIn = true;
-				}
-			});
+  const cookies = cy
+    .getCookies({
+      log: true,
+    })
+    .then(function (cookies) {
+      let isLoggedIn = false;
+      cookies.forEach(function (value) {
+        if (value.name.includes("wordpress_")) {
+          isLoggedIn = true;
+        }
+      });
 
-			if (isLoggedIn) {
-				if (nextRoute !== null) {
-					cy.visit(nextRoute);
-				}
-				return;
-			}
-			cy.visit('/wp-admin');
-			cy.wait(500);
-			cy.get('#user_login').type(Cypress.config().user);
-			cy.get('#user_pass').type(Cypress.config().password);
-			cy.get('#wp-submit').click();
-			if (nextRoute === null) {
-				return;
-			}
-			cy.visit(nextRoute);
-		});
+      if (isLoggedIn) {
+        if (nextRoute !== null) {
+          cy.visit(nextRoute);
+        }
+        return;
+      }
+      cy.visit("/wp-admin");
+      cy.wait(500);
+      cy.get("#user_login").type(Cypress.config().user);
+      cy.get("#user_pass").type(Cypress.config().password);
+      cy.get("#wp-submit").click();
+      if (nextRoute === null) {
+        return;
+      }
+      cy.visit(nextRoute);
+    });
 });
-Cypress.Commands.add('navigate', (nextRoute = '/') => {
-	cy.visit(nextRoute);
+Cypress.Commands.add("navigate", (nextRoute = "/") => {
+  cy.visit(nextRoute);
 });
-Cypress.Commands.add('clearWelcome', () => {
-	cy.window().then((win) => {
-		win.wp &&
-			win.wp.data &&
-			win.wp.data
-				.select('core/edit-post')
-				.isFeatureActive('welcomeGuide') &&
-			win.wp.data
-				.dispatch('core/edit-post')
-				.toggleFeature('welcomeGuide');
-	});
+Cypress.Commands.add("clearWelcome", () => {
+  cy.window().then((win) => {
+    win.wp &&
+      win.wp.data &&
+      win.wp.data.select("core/edit-post").isFeatureActive("welcomeGuide") &&
+      win.wp.data.dispatch("core/edit-post").toggleFeature("welcomeGuide");
+  });
 });
-Cypress.Commands.add('insertCoverBlock', () => {
-	const text =
-		'<!-- wp:cover {"overlayColor":"neve-button-color","align":"full"} -->\n' +
-		'<div class="wp-block-cover alignfull has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
-		'<p class="has-text-align-center has-large-font-size">test</p>\n' +
-		'<!-- /wp:paragraph --></div></div>\n' +
-		'<!-- /wp:cover -->\n' +
-		'\n' +
-		'<!-- wp:cover {"overlayColor":"neve-button-color","align":"wide"} -->\n' +
-		'<div class="wp-block-cover alignwide has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
-		'<p class="has-text-align-center has-large-font-size">test</p>\n' +
-		'<!-- /wp:paragraph --></div></div>\n' +
-		'<!-- /wp:cover -->\n' +
-		'\n' +
-		'<!-- wp:cover {"overlayColor":"neve-button-color"} -->\n' +
-		'<div class="wp-block-cover has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
-		'<p class="has-text-align-center has-large-font-size">test</p>\n' +
-		'<!-- /wp:paragraph --></div></div>\n' +
-		'<!-- /wp:cover -->';
-	cy.get('.edit-post-more-menu')
-		.click()
-		.get('.components-dropdown-menu__menu button')
-		.contains('Code editor')
-		.click();
-	cy.get('textarea.editor-post-text-editor')
-		.focus()
-		.invoke('val', text)
-		.type('{enter}');
-	cy.get('.edit-post-text-editor__toolbar button')
-		.contains(/Exit Code Editor/i)
-		.click();
+Cypress.Commands.add("insertCoverBlock", () => {
+  const text =
+    '<!-- wp:cover {"overlayColor":"neve-button-color","align":"full"} -->\n' +
+    '<div class="wp-block-cover alignfull has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
+    '<p class="has-text-align-center has-large-font-size">test</p>\n' +
+    "<!-- /wp:paragraph --></div></div>\n" +
+    "<!-- /wp:cover -->\n" +
+    "\n" +
+    '<!-- wp:cover {"overlayColor":"neve-button-color","align":"wide"} -->\n' +
+    '<div class="wp-block-cover alignwide has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
+    '<p class="has-text-align-center has-large-font-size">test</p>\n' +
+    "<!-- /wp:paragraph --></div></div>\n" +
+    "<!-- /wp:cover -->\n" +
+    "\n" +
+    '<!-- wp:cover {"overlayColor":"neve-button-color"} -->\n' +
+    '<div class="wp-block-cover has-neve-button-color-background-color has-background-dim"><div class="wp-block-cover__inner-container"><!-- wp:paragraph {"align":"center","placeholder":"Write title…","fontSize":"large"} -->\n' +
+    '<p class="has-text-align-center has-large-font-size">test</p>\n' +
+    "<!-- /wp:paragraph --></div></div>\n" +
+    "<!-- /wp:cover -->";
+  cy.get(".edit-post-more-menu")
+    .click()
+    .get(".components-dropdown-menu__menu button")
+    .contains("Code editor")
+    .click();
+  cy.get("textarea.editor-post-text-editor")
+    .focus()
+    .invoke("val", text)
+    .type("{enter}");
+  cy.get(".edit-post-text-editor__toolbar button")
+    .contains(/Exit Code Editor/i)
+    .click();
 
-	cy.updatePost();
+  cy.updatePost();
 });
 
-Cypress.Commands.add('editCurrentPost', () => {
-	cy.get('#wp-admin-bar-edit a').click();
-	cy.clearWelcome();
+Cypress.Commands.add("editCurrentPost", () => {
+  cy.get("#wp-admin-bar-edit a").click();
+  cy.clearWelcome();
 });
 
 Cypress.Commands.add(
-	'insertPost',
-	(
-		title = 'Test',
-		content = 'Content',
-		type = 'post',
-		featured = false,
-		tags = false
-	) => {
-		let loginRoute = '/wp-admin/post-new.php';
-		if (type !== 'post') {
-			loginRoute += '?post_type=' + type;
-		}
+  "insertPost",
+  (
+    title = "Test",
+    content = "Content",
+    type = "post",
+    featured = false,
+    tags = false
+  ) => {
+    let loginRoute = "/wp-admin/post-new.php";
+    if (type !== "post") {
+      loginRoute += "?post_type=" + type;
+    }
 
-		cy.login(loginRoute);
-		cy.clearWelcome();
-		if (featured) {
-			cy.wait(500);
-			cy.get('button').contains('Featured image').click();
-			cy.get('.editor-post-featured-image__toggle').click();
-			cy.get('.media-frame')
-				.find('.media-menu-item')
-				.contains('Media Library')
-				.click({
-					force: true,
-				});
+    cy.login(loginRoute);
+    cy.clearWelcome();
+    if (featured) {
+      cy.wait(500);
+      cy.get("button").contains("Featured image").click();
+      cy.get(".editor-post-featured-image__toggle").click();
+      cy.get(".media-frame")
+        .find(".media-menu-item")
+        .contains("Media Library")
+        .click({
+          force: true,
+        });
 
-			cy.get('.attachments-browser .attachments > li.attachment')
-				.first()
-				.click({
-					force: true,
-				});
-			cy.get('.media-button-select').click();
-		}
+      cy.get(".attachments-browser .attachments > li.attachment")
+        .first()
+        .click({
+          force: true,
+        });
+      cy.get(".media-button-select").click();
+    }
 
-		if (tags) {
-			cy.get('.components-panel__body-toggle').contains('Tags').click();
-			cy.get('.components-form-token-field__label')
-				.contains('Add New Tag')
-				.parent()
-				.find('input')
-				.type('test-tag,');
-		}
-		cy.get('.editor-post-title__input').type(title);
-		cy.get(' textarea.block-editor-default-block-appender__content').click({
-			force: true,
-		});
-		cy.get('.block-editor-rich-text__editable').type(content);
-		cy.get('.editor-post-publish-panel__toggle').click();
-		cy.updatePost();
-	}
+    if (tags) {
+      cy.get(".components-panel__body-toggle").contains("Tags").click();
+      cy.get(".components-form-token-field__label")
+        .contains("Add New Tag")
+        .parent()
+        .find("input")
+        .type("test-tag,");
+    }
+    cy.get(".editor-post-title__input").type(title);
+    cy.get(" textarea.block-editor-default-block-appender__content").click({
+      force: true,
+    });
+    cy.get(".block-editor-rich-text__editable").type(content);
+    cy.get(".editor-post-publish-panel__toggle").click();
+    cy.updatePost();
+  }
 );
-Cypress.Commands.add('updatePost', () => {
-	cy.get('.editor-post-publish-button').click();
-	cy.wait(500);
+Cypress.Commands.add("updatePost", () => {
+  cy.get(".editor-post-publish-button").click();
+  cy.wait(500);
 });
 
-Cypress.Commands.add('getCustomizerControl', (slug) => {
-	cy.window().then((win) => {
-		win.wp.customize.control(slug).focus();
-	});
-	return cy.get('#customize-control-' + slug);
+Cypress.Commands.add("getCustomizerControl", (slug) => {
+  cy.window().then((win) => {
+    win.wp.customize.control(slug).focus();
+  });
+  return cy.get("#customize-control-" + slug);
 });
 
-Cypress.Commands.add('getCustomizerControlValue', (slug) => {
-	return cy
-		.window()
-		.then((win) => win.wp.customize.control(slug).setting.get());
+Cypress.Commands.add("getCustomizerControlValue", (slug) => {
+  return cy
+    .window()
+    .then((win) => win.wp.customize.control(slug).setting.get());
 });
 
 /**
@@ -168,76 +164,67 @@ Cypress.Commands.add('getCustomizerControlValue', (slug) => {
  * @param controlSelector
  * @param values
  */
-Cypress.Commands.add('setTypographyControl', (controlSelector, values) => {
-	const changeNumberInputValue = (input, value) => {
-		cy.get(input)
-			.clear({
-				force: true,
-			})
-			.type('{leftarrow}' + value + '{rightarrow}{backspace}');
-	};
-	cy.get(controlSelector).as('control');
+Cypress.Commands.add("setTypographyControl", (controlSelector, values) => {
+  const changeNumberInputValue = (input, value) => {
+    cy.get(input)
+      .clear({
+        force: true,
+      })
+      .type("{leftarrow}" + value + "{rightarrow}{backspace}");
+  };
+  cy.get(controlSelector).as("control");
 
-	cy.get('@control')
-		.should('be.visible')
-		.and('contain', 'Transform')
-		.and('contain', 'Weight')
-		.and('contain', 'Font Size')
-		.and('contain', 'Line Height')
-		.and('contain', 'Letter Spacing');
+  cy.get("@control")
+    .should("be.visible")
+    .and("contain", "Transform")
+    .and("contain", "Weight")
+    .and("contain", "Font Size")
+    .and("contain", "Line Height")
+    .and("contain", "Letter Spacing");
 
-	// Change text transform.
-	cy.get('@control').find('.text-transform select').select(values.transform);
+  // Change text transform.
+  cy.get("@control").find(".text-transform select").select(values.transform);
 
-	// Change font weight.
-	cy.get('@control').find('.font-weight select').select(values.weight);
+  // Change font weight.
+  cy.get("@control").find(".font-weight select").select(values.weight);
 
-	const devices = ['desktop', 'tablet', 'mobile'],
-		controls = ['fontSize', 'lineHeight', 'letterSpacing'];
+  const devices = ["desktop", "tablet", "mobile"],
+    controls = ["fontSize", "lineHeight", "letterSpacing"];
 
-	devices.map((device) => {
-		cy.get('@control')
-			.find('button.' + device)
-			.first()
-			.click();
-		// Change font size.
-		cy.get('@control').find('.font-size input').as('fontSize');
+  devices.map((device) => {
+    cy.get("@control")
+      .find("button." + device)
+      .first()
+      .click();
+    // Change font size.
+    cy.get("@control").find(".font-size input").as("fontSize");
 
-		cy.get('@control').find('.line-height input').as('lineHeight');
+    cy.get("@control").find(".line-height input").as("lineHeight");
 
-		cy.get('@control').find('.letter-spacing input').as('letterSpacing');
+    cy.get("@control").find(".letter-spacing input").as("letterSpacing");
 
-		controls.map((control) => {
-			cy.get('@' + control)
-				.invoke('val')
-				.then((value) => {
-					// Make sure value is default.
-					cy.get('@' + control).should('have.value', value);
-					// Change the value.
-					changeNumberInputValue(
-						'@' + control,
-						values[control][device]
-					);
-					// Value was changed?
-					cy.get('@' + control).should(
-						'have.value',
-						values[control][device]
-					);
-					// Reset to old value.
-					cy.get('@' + control)
-						.closest('.neve-responsive-sizing')
-						.find('button')
-						.click();
-					// Make sure value has been reset.
-					cy.get('@' + control).should('have.value', value);
-					// Change the value.
-					changeNumberInputValue(
-						'@' + control,
-						values[control][device]
-					);
-				});
-		});
-	});
+    controls.map((control) => {
+      cy.get("@" + control)
+        .invoke("val")
+        .then((value) => {
+          // Make sure value is default.
+          cy.get("@" + control).should("have.value", value);
+          // Change the value.
+          changeNumberInputValue("@" + control, values[control][device]);
+          // Value was changed?
+          cy.get("@" + control).should("have.value", values[control][device]);
+          // Reset to old value.
+          cy.get("@" + control)
+            .closest(".neve-responsive-sizing")
+            .find("button")
+            .click();
+          // Make sure value has been reset.
+          cy.get("@" + control).should("have.value", value);
+          // Change the value.
+          changeNumberInputValue("@" + control, values[control][device]);
+        });
+    });
+  });
 });
 
 /**
@@ -245,23 +232,23 @@ Cypress.Commands.add('setTypographyControl', (controlSelector, values) => {
  *
  */
 Cypress.Commands.add(
-	'captureDocument',
-	(generalMaskAndClip = true, screenShotName = false) => {
-		if (generalMaskAndClip) {
-			const maskElement =
-				'.elementor-element-31b9e15, .pikaday__display--pikaday, .elementor-widget-video, label[for="vscf_captcha"],.elementor-widget-google_maps,.pikaday__display,.elementor-video-iframe';
-			const clipElement =
-				'.widget_top_rated_products, .wpcf7-quiz-label, .eaw-typed-text,.product .related.products,.captcha_img,.elementor-element-38f7ff1e,.elementor-widget-container[style*="will-change"], .particles-js-canvas-el,.product_list_widget li + li, .exclusive.products';
-			cy.maskAndClip(maskElement, clipElement);
-		}
-		cy.window().then((cyWindow) =>
-			scrollToBottom({
-				remoteWindow: cyWindow,
-			})
-		);
-		cy.wait(5000);
-		cy.percySnapshot(screenShotName);
-	}
+  "captureDocument",
+  (generalMaskAndClip = true, screenShotName = false) => {
+    if (generalMaskAndClip) {
+      const maskElement =
+        '.elementor-element-31b9e15, .pikaday__display--pikaday, .elementor-widget-video, label[for="vscf_captcha"],.elementor-widget-google_maps,.pikaday__display,.elementor-video-iframe';
+      const clipElement =
+        '.widget_top_rated_products, .wpcf7-quiz-label, .eaw-typed-text,.product .related.products,.captcha_img,.elementor-element-38f7ff1e,.elementor-widget-container[style*="will-change"], .particles-js-canvas-el,.product_list_widget li + li, .exclusive.products';
+      cy.maskAndClip(maskElement, clipElement);
+    }
+    cy.window().then((cyWindow) =>
+      scrollToBottom({
+        remoteWindow: cyWindow,
+      })
+    );
+    cy.wait(5000);
+    cy.percySnapshot(screenShotName);
+  }
 );
 /**
  * Capture and compare the fullpage snapshots.
@@ -269,76 +256,76 @@ Cypress.Commands.add(
  * @param {string} path The path to store the snapshot.
  */
 Cypress.Commands.add(
-	'maskAndClip',
-	(maskSelectors, clipSelectors, hideElements) => {
-		cy.get('body').then(($body) => {
-			// synchronously query from body
-			// to find which element was created
-			if ($body.find(maskSelectors).length) {
-				cy.get(maskSelectors).invoke(
-					'css',
-					'background',
-					'url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACWBAMAAACWdajhAAAAG1BMVEUAAAD///+fn59fX18fHx/f398/Pz9/f3+/v78mHjoVAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAC00lEQVR4nO2WTW/TQBCGN7Hj9Nip68THWmo5x1Ir5ei0CnDstoA4OghEjg0Czlil8LeZmV3HCUlQIa64vI9UrT3exs+OZz+MAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkeHHJvxP98bOnxCK2j9FRuv2xGH1tbX7Yj/L60sNiagE2Pe2eSzi8ub9fn49am2lzZ5Jn2Dh5ui1goe6O1I+nWTExOe0U0p0bFN7lvRmiaF/vW5/pNyTeuAQzmJNXPHfSui2GtFlmOp9Mt4TDnfDDn6QXp+20tLOdRMScYWSfmCXq1pZWlxKXM1T0ZRxW/t0vcw81rT5DzM2bVDcVQGdGvmfBPa2+JK/fbWYicxC1nJZMNVrYiuJUHuUY8KM0skg05rMZAsXnO/E2MmnG1jjznjpQyiFa1p4r7hnfz8qlafuHZy34r6QsvQaVluQr7uiIk8MPkRu3M72TGZHqlVX3HlxJKFYhn3Whqa+DbkzFTHTmWJavFDeSBj+u2X99IyUrNuoOtaGtLWJ1Yy1CwQ4ccz1eJL2+wYzz/ZlrQmMuDOplbHay2/N61qXbiYdlpuZIHdtqH9m5Zma4tWb6nlO65ma0r08/1Sy6uGltKvrdZWTwupKXmtqVLbnrRCNWhqixcPX/LiO3AdeAVpreTdTOzqtDtyWlzBM3KTk2diV9qIV8nFcGUmHkvMa2WyVM1SN7ZZO1pu3XKL1EDjNm7WKyvtQGbqSJenntcS9YNaayL5rGI/LffT8mVar/JZWr7kS3kNL/i6unM715bOo4o3mj69iSqvVaXllWU31epTXMw5nQf0I+SpULSgVe+J3XqP03Im+RQSWpDR7VJ3uox3vqbkKbaxz/rC/XMoE/FCymFvrZUTRDryH/dL4k4OY3tfnyD0XBA8pCOvJWeGIk+9Ft/JcUI6ngZ77dUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJ6KX6rsak4Q9c5cAAAAAElFTkSuQmCC) #000 no-repeat center center'
-				);
-				cy.get(maskSelectors).invoke('css', 'color', 'transparent');
-				if ($body.find(maskSelectors).find('*').length > 0) {
-					cy.get(maskSelectors)
-						.children()
-						.invoke('css', 'visibility', 'hidden');
-				}
-			}
-			if ($body.find(clipSelectors).length) {
-				cy.get(clipSelectors).invoke('css', 'display', 'none');
-			}
-			if (
-				hideElements &&
-				hideElements.length > 0 &&
-				$body.find(hideElements).length
-			) {
-				cy.get(hideElements).invoke('css', 'visibility', 'hidden');
-			}
-		});
-	}
+  "maskAndClip",
+  (maskSelectors, clipSelectors, hideElements) => {
+    cy.get("body").then(($body) => {
+      // synchronously query from body
+      // to find which element was created
+      if ($body.find(maskSelectors).length) {
+        cy.get(maskSelectors).invoke(
+          "css",
+          "background",
+          "url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAASwAAACWBAMAAACWdajhAAAAG1BMVEUAAAD///+fn59fX18fHx/f398/Pz9/f3+/v78mHjoVAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAC00lEQVR4nO2WTW/TQBCGN7Hj9Nip68THWmo5x1Ir5ei0CnDstoA4OghEjg0Czlil8LeZmV3HCUlQIa64vI9UrT3exs+OZz+MAQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHkeHHJvxP98bOnxCK2j9FRuv2xGH1tbX7Yj/L60sNiagE2Pe2eSzi8ub9fn49am2lzZ5Jn2Dh5ui1goe6O1I+nWTExOe0U0p0bFN7lvRmiaF/vW5/pNyTeuAQzmJNXPHfSui2GtFlmOp9Mt4TDnfDDn6QXp+20tLOdRMScYWSfmCXq1pZWlxKXM1T0ZRxW/t0vcw81rT5DzM2bVDcVQGdGvmfBPa2+JK/fbWYicxC1nJZMNVrYiuJUHuUY8KM0skg05rMZAsXnO/E2MmnG1jjznjpQyiFa1p4r7hnfz8qlafuHZy34r6QsvQaVluQr7uiIk8MPkRu3M72TGZHqlVX3HlxJKFYhn3Whqa+DbkzFTHTmWJavFDeSBj+u2X99IyUrNuoOtaGtLWJ1Yy1CwQ4ccz1eJL2+wYzz/ZlrQmMuDOplbHay2/N61qXbiYdlpuZIHdtqH9m5Zma4tWb6nlO65ma0r08/1Sy6uGltKvrdZWTwupKXmtqVLbnrRCNWhqixcPX/LiO3AdeAVpreTdTOzqtDtyWlzBM3KTk2diV9qIV8nFcGUmHkvMa2WyVM1SN7ZZO1pu3XKL1EDjNm7WKyvtQGbqSJenntcS9YNaayL5rGI/LffT8mVar/JZWr7kS3kNL/i6unM715bOo4o3mj69iSqvVaXllWU31epTXMw5nQf0I+SpULSgVe+J3XqP03Im+RQSWpDR7VJ3uox3vqbkKbaxz/rC/XMoE/FCymFvrZUTRDryH/dL4k4OY3tfnyD0XBA8pCOvJWeGIk+9Ft/JcUI6ngZ77dUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJ6KX6rsak4Q9c5cAAAAAElFTkSuQmCC) #000 no-repeat center center"
+        );
+        cy.get(maskSelectors).invoke("css", "color", "transparent");
+        if ($body.find(maskSelectors).find("*").length > 0) {
+          cy.get(maskSelectors)
+            .children()
+            .invoke("css", "visibility", "hidden");
+        }
+      }
+      if ($body.find(clipSelectors).length) {
+        cy.get(clipSelectors).invoke("css", "display", "none");
+      }
+      if (
+        hideElements &&
+        hideElements.length > 0 &&
+        $body.find(hideElements).length
+      ) {
+        cy.get(hideElements).invoke("css", "visibility", "hidden");
+      }
+    });
+  }
 );
 
-Cypress.Commands.add('setCustomizeSettings', (to) => {
-	cy.goToCustomizer();
-	cy.window().then((win) => {
-		Object.keys(to).map((mod) => {
-			win.wp.customize.control(mod).setting.set(to[mod]);
-		});
-	});
-	cy.wait(500);
-	cy.intercept('POST', '/wp-admin/admin-ajax.php').as('save');
-	cy.get('#save').click();
-	cy.wait('@save').then((interception) => {
-		expect(interception.response.body.success).to.be.true;
-		expect(interception.response.statusCode).to.equal(200);
-	});
+Cypress.Commands.add("setCustomizeSettings", (to) => {
+  cy.goToCustomizer();
+  cy.window().then((win) => {
+    Object.keys(to).map((mod) => {
+      win.wp.customize.control(mod).setting.set(to[mod]);
+    });
+  });
+  cy.wait(500);
+  cy.intercept("POST", "/wp-admin/admin-ajax.php").as("save");
+  cy.get("#save").click();
+  cy.wait("@save").then((interception) => {
+    expect(interception.response.body.success).to.be.true;
+    expect(interception.response.statusCode).to.equal(200);
+  });
 });
 
-Cypress.Commands.add('goToCustomizer', () => {
-	cy.login('/wp-admin/customize.php');
-	cy.window()
-		.then((win) => {
-			//If the customizer is not ready, bind the flag to ready event.
-			win.wp.customize.bind('ready', () => {
-				win.appReady = true;
-			});
-		})
-		.then(() => {
-			// If we bind to the ready event too late, we can check the body class 'ready'.
-			cy.get('body').then(($body) => {
-				if ($body.hasClass('ready')) {
-					cy.window().then((win) => {
-						win.appReady = true;
-					});
-				}
-			});
-		});
-	cy.window({
-		timeout: 15000,
-	}).should('have.property', 'appReady', true);
+Cypress.Commands.add("goToCustomizer", () => {
+  cy.login("/wp-admin/customize.php");
+  cy.window()
+    .then((win) => {
+      //If the customizer is not ready, bind the flag to ready event.
+      win.wp.customize.bind("ready", () => {
+        win.appReady = true;
+      });
+    })
+    .then(() => {
+      // If we bind to the ready event too late, we can check the body class 'ready'.
+      cy.get("body").then(($body) => {
+        if ($body.hasClass("ready")) {
+          cy.window().then((win) => {
+            win.appReady = true;
+          });
+        }
+      });
+    });
+  cy.window({
+    timeout: 15000,
+  }).should("have.property", "appReady", true);
 });
 
 /**
@@ -346,8 +333,8 @@ Cypress.Commands.add('goToCustomizer', () => {
  *
  * @example cy.aliasRestRoutes()
  */
-Cypress.Commands.add('aliasRestRoutes', () => {
-	cy.intercept('POST', '/wp-admin/admin-ajax.php').as('customizerSave');
+Cypress.Commands.add("aliasRestRoutes", () => {
+  cy.intercept("POST", "/wp-admin/admin-ajax.php").as("customizerSave");
 });
 
 /**
@@ -356,19 +343,17 @@ Cypress.Commands.add('aliasRestRoutes', () => {
  * @param show
  * @example cy.toggleElements(false)
  */
-Cypress.Commands.add('toggleElements', (show) => {
-	const icon = show ? 'dashicons-hidden' : 'dashicons-visibility';
-	cy.get('.ti-sortable-item-area .ti-sortable-item-toggle').each(function (
-		el
-	) {
-		cy.get(el)
-			.find('.dashicon')
-			.then(($icon) => {
-				if ($icon.hasClass(icon)) {
-					cy.get($icon).click();
-				}
-			});
-	});
+Cypress.Commands.add("toggleElements", (show) => {
+  const icon = show ? "dashicons-hidden" : "dashicons-visibility";
+  cy.get(".ti-sortable-item-area .ti-sortable-item-toggle").each(function (el) {
+    cy.get(el)
+      .find(".dashicon")
+      .then(($icon) => {
+        if ($icon.hasClass(icon)) {
+          cy.get($icon).click();
+        }
+      });
+  });
 });
 
 /**
@@ -377,21 +362,21 @@ Cypress.Commands.add('toggleElements', (show) => {
  * @param control
  * @example cy.getControl('neve_sidebar')
  */
-Cypress.Commands.add('getControl', (control) => {
-	cy.get(
-		'label.components-base-control__label[for="' + control + '"]'
-	).parent();
+Cypress.Commands.add("getControl", (control) => {
+  cy.get(
+    'label.components-base-control__label[for="' + control + '"]'
+  ).parent();
 });
 
-Cypress.Commands.add('activateCheckbox', (checkboxSelector, checkboxText) => {
-	cy.get(checkboxSelector)
-		.contains(checkboxText)
-		.prev()
-		.then((checkbox) => {
-			if (!checkbox.hasClass('is-checked')) {
-				cy.get(checkbox).click();
-			}
-		});
+Cypress.Commands.add("activateCheckbox", (checkboxSelector, checkboxText) => {
+  cy.get(checkboxSelector)
+    .contains(checkboxText)
+    .prev()
+    .then((checkbox) => {
+      if (!checkbox.hasClass("is-checked")) {
+        cy.get(checkbox).click();
+      }
+    });
 });
 
 /**
@@ -399,21 +384,17 @@ Cypress.Commands.add('activateCheckbox', (checkboxSelector, checkboxText) => {
  *
  * @example cy.openNeveSidebar()
  */
-Cypress.Commands.add('openNeveSidebar', () => {
-	cy.get('button.components-button[aria-label="Neve Options"]').then(
-		($btn) => {
-			cy.get($btn)
-				.invoke('attr', 'aria-expanded')
-				.then((value) => {
-					if (value === true) {
-						return true;
-					}
-					cy.get(
-						'button.components-button[aria-label="Neve Options"]'
-					).click();
-				});
-		}
-	);
+Cypress.Commands.add("openNeveSidebar", () => {
+  cy.get('button.components-button[aria-label="Neve Options"]').then(($btn) => {
+    cy.get($btn)
+      .invoke("attr", "aria-expanded")
+      .then((value) => {
+        if (value === true) {
+          return true;
+        }
+        cy.get('button.components-button[aria-label="Neve Options"]').click();
+      });
+  });
 });
 
 /**
@@ -421,10 +402,10 @@ Cypress.Commands.add('openNeveSidebar', () => {
  *
  * @example cy.activateClassicEditorPlugin()
  */
-Cypress.Commands.add('activateClassicEditorPlugin', () => {
-	cy.login('/wp-admin/plugins.php');
-	cy.get('#activate-classic-editor').contains('Activate').click();
-	cy.get('#deactivate-classic-editor').should('exist');
+Cypress.Commands.add("activateClassicEditorPlugin", () => {
+  cy.login("/wp-admin/plugins.php");
+  cy.get("#activate-classic-editor").contains("Activate").click();
+  cy.get("#deactivate-classic-editor").should("exist");
 });
 
 /**
@@ -432,10 +413,10 @@ Cypress.Commands.add('activateClassicEditorPlugin', () => {
  *
  * @example cy.deactivateClassicEditorPlugin()
  */
-Cypress.Commands.add('deactivateClassicEditorPlugin', () => {
-	cy.login('/wp-admin/plugins.php');
-	cy.get('#deactivate-classic-editor').contains('Deactivate').click();
-	cy.get('#activate-classic-editor').should('exist');
+Cypress.Commands.add("deactivateClassicEditorPlugin", () => {
+  cy.login("/wp-admin/plugins.php");
+  cy.get("#deactivate-classic-editor").contains("Deactivate").click();
+  cy.get("#activate-classic-editor").should("exist");
 });
 
 /**
@@ -444,17 +425,17 @@ Cypress.Commands.add('deactivateClassicEditorPlugin', () => {
  * @param defaultWidth
  * @example cy.matchContentWidth(2250)
  */
-Cypress.Commands.add('matchContentWidth', (defaultWidth) => {
-	cy.get(
-		'.single-page-container .alignfull [class*="__inner-container"] > *, .single-page-container .alignwide [class*="__inner-container"] > *'
-	)
-		.invoke('width')
-		.should('be.eq', defaultWidth - 30); //we substract the padding.
-	cy.get('.single-page-container .nv-content-wrap')
-		.invoke('width')
-		.should('be.eq', defaultWidth - 30); //we substract the padding.
-	cy.get('#wp-admin-bar-edit a').click();
-	cy.get('.wp-block').should('have.css', 'max-width', defaultWidth + 'px');
+Cypress.Commands.add("matchContentWidth", (defaultWidth) => {
+  cy.get(
+    '.single-page-container .alignfull [class*="__inner-container"] > *, .single-page-container .alignwide [class*="__inner-container"] > *'
+  )
+    .invoke("width")
+    .should("be.eq", defaultWidth - 30); //we substract the padding.
+  cy.get(".single-page-container .nv-content-wrap")
+    .invoke("width")
+    .should("be.eq", defaultWidth - 30); //we substract the padding.
+  cy.get("#wp-admin-bar-edit a").click();
+  cy.get(".wp-block").should("have.css", "max-width", defaultWidth + "px");
 });
 
 /**
@@ -465,23 +446,23 @@ Cypress.Commands.add('matchContentWidth', (defaultWidth) => {
  * @param moveTo
  * @example cy.dropElAfter('control', 0, 1)
  */
-Cypress.Commands.add('dropElAfter', (selector, moveFrom, moveTo) => {
-	cy.get(selector).then((el) => {
-		const drag = el[moveFrom].getBoundingClientRect();
-		const drop = el[moveTo].getBoundingClientRect();
-		cy.get(el[moveFrom]).trigger('mousedown', {
-			which: 1,
-			pageX: drag.x,
-			pageY: drag.y,
-		});
-		cy.document().trigger('mousemove', {
-			which: 1,
-			pageX: drop.x,
-			pageY: drop.y + 35,
-		});
-		cy.wait(200);
-		cy.document().trigger('mouseup');
-	});
+Cypress.Commands.add("dropElAfter", (selector, moveFrom, moveTo) => {
+  cy.get(selector).then((el) => {
+    const drag = el[moveFrom].getBoundingClientRect();
+    const drop = el[moveTo].getBoundingClientRect();
+    cy.get(el[moveFrom]).trigger("mousedown", {
+      which: 1,
+      pageX: drag.x,
+      pageY: drag.y,
+    });
+    cy.document().trigger("mousemove", {
+      which: 1,
+      pageX: drop.x,
+      pageY: drop.y + 35,
+    });
+    cy.wait(200);
+    cy.document().trigger("mouseup");
+  });
 });
 
 /**
@@ -489,12 +470,12 @@ Cypress.Commands.add('dropElAfter', (selector, moveFrom, moveTo) => {
  *
  * @example cy.alignCenter()
  */
-Cypress.Commands.add('alignCenter', () => {
-	cy.get(
-		'#customize-control-logo_component_align button[aria-label="Center"]'
-	).click();
+Cypress.Commands.add("alignCenter", () => {
+  cy.get(
+    '#customize-control-logo_component_align button[aria-label="Center"]'
+  ).click();
 
-	cy.get('#save').should('be.visible').click();
+  cy.get("#save").should("be.visible").click();
 });
 
 /**
@@ -502,15 +483,15 @@ Cypress.Commands.add('alignCenter', () => {
  *
  * @example cy.CheckAlignCenter()
  */
-Cypress.Commands.add('checkAlignCenter', () => {
-	cy.visit('/');
+Cypress.Commands.add("checkAlignCenter", () => {
+  cy.visit("/");
 
-	cy.get('.desktop-center')
-		.should('be.visible')
-		.and('have.class', 'mobile-left')
-		.and('have.class', 'tablet-left')
-		.find('.site-logo')
-		.should('be.visible');
+  cy.get(".desktop-center")
+    .should("be.visible")
+    .and("have.class", "mobile-left")
+    .and("have.class", "tablet-left")
+    .find(".site-logo")
+    .should("be.visible");
 });
 
 /**
@@ -518,12 +499,12 @@ Cypress.Commands.add('checkAlignCenter', () => {
  *
  * @example cy.alignRight()
  */
-Cypress.Commands.add('alignRight', () => {
-	cy.get(
-		'#customize-control-logo_component_align button[aria-label="Right"]'
-	).click();
+Cypress.Commands.add("alignRight", () => {
+  cy.get(
+    '#customize-control-logo_component_align button[aria-label="Right"]'
+  ).click();
 
-	cy.get('#save').should('be.visible').click();
+  cy.get("#save").should("be.visible").click();
 });
 
 /**
@@ -531,15 +512,15 @@ Cypress.Commands.add('alignRight', () => {
  *
  * @example cy.checkAlignRight()
  */
-Cypress.Commands.add('checkAlignRight', () => {
-	cy.visit('/');
+Cypress.Commands.add("checkAlignRight", () => {
+  cy.visit("/");
 
-	cy.get('.desktop-right')
-		.should('be.visible')
-		.and('have.class', 'mobile-left')
-		.and('have.class', 'tablet-left')
-		.find('.site-logo')
-		.should('be.visible');
+  cy.get(".desktop-right")
+    .should("be.visible")
+    .and("have.class", "mobile-left")
+    .and("have.class", "tablet-left")
+    .find(".site-logo")
+    .should("be.visible");
 });
 
 /**
@@ -547,20 +528,16 @@ Cypress.Commands.add('checkAlignRight', () => {
  *
  * @example cy.checkMarginFrontEnd()
  */
-Cypress.Commands.add('checkMarginFrontEnd', () => {
-	cy.visit('/');
+Cypress.Commands.add("checkMarginFrontEnd", () => {
+  cy.visit("/");
 
-	cy.get('.builder-item--primary-menu').should('be.visible');
-	cy.get('.builder-item--primary-menu').should(
-		'have.css',
-		'margin-top',
-		'3px'
-	);
-	cy.get('.builder-item--primary-menu').should(
-		'have.css',
-		'margin-bottom',
-		'-1px'
-	);
+  cy.get(".builder-item--primary-menu").should("be.visible");
+  cy.get(".builder-item--primary-menu").should("have.css", "margin-top", "3px");
+  cy.get(".builder-item--primary-menu").should(
+    "have.css",
+    "margin-bottom",
+    "-1px"
+  );
 });
 
 /**
@@ -568,16 +545,14 @@ Cypress.Commands.add('checkMarginFrontEnd', () => {
  *
  * @example cy.checkPaddingFrontEnd()
  */
-Cypress.Commands.add('checkPaddingFrontEnd', () => {
-	cy.visit('/');
+Cypress.Commands.add("checkPaddingFrontEnd", () => {
+  cy.visit("/");
 
-	cy.get('.site-logo').should('be.visible');
-	cy.get('.site-logo')
-		.should('have.css', 'padding-top')
-		.and('contain', '11px');
-	cy.get('.site-logo')
-		.should('have.css', 'padding-bottom')
-		.and('contain', '9px');
+  cy.get(".site-logo").should("be.visible");
+  cy.get(".site-logo").should("have.css", "padding-top").and("contain", "11px");
+  cy.get(".site-logo")
+    .should("have.css", "padding-bottom")
+    .and("contain", "9px");
 });
 
 /**
@@ -588,18 +563,18 @@ Cypress.Commands.add('checkPaddingFrontEnd', () => {
  * @param weightMatcher
  */
 Cypress.Commands.add(
-	'testTransformAndWeight',
-	(elem, transformMatcher, weightMatcher) => {
-		// Test text transform.
-		cy.get(elem)
-			.should('have.css', 'text-transform')
-			.and('match', new RegExp(transformMatcher, 'g'));
+  "testTransformAndWeight",
+  (elem, transformMatcher, weightMatcher) => {
+    // Test text transform.
+    cy.get(elem)
+      .should("have.css", "text-transform")
+      .and("match", new RegExp(transformMatcher, "g"));
 
-		// Test font weight
-		cy.get(elem)
-			.should('have.css', 'font-weight')
-			.and('match', new RegExp(weightMatcher, 'g'));
-	}
+    // Test font weight
+    cy.get(elem)
+      .should("have.css", "font-weight")
+      .and("match", new RegExp(weightMatcher, "g"));
+  }
 );
 
 /**
@@ -612,21 +587,21 @@ Cypress.Commands.add(
  * @param letterSpacingMatcher
  */
 Cypress.Commands.add(
-	'testSizeLineHeightSpacing',
-	(elem, fontSizeMatcher, lineHeightMatcher, letterSpacingMatcher) => {
-		// Test font size.
-		cy.get(elem)
-			.should('have.css', 'font-size')
-			.and('match', new RegExp(fontSizeMatcher + 'px', 'g'));
+  "testSizeLineHeightSpacing",
+  (elem, fontSizeMatcher, lineHeightMatcher, letterSpacingMatcher) => {
+    // Test font size.
+    cy.get(elem)
+      .should("have.css", "font-size")
+      .and("match", new RegExp(fontSizeMatcher + "px", "g"));
 
-		// Test line height.
-		cy.get(elem)
-			.should('have.css', 'line-height')
-			.and('match', new RegExp(lineHeightMatcher, 'g'));
+    // Test line height.
+    cy.get(elem)
+      .should("have.css", "line-height")
+      .and("match", new RegExp(lineHeightMatcher, "g"));
 
-		// Test letter spacing.
-		cy.get(elem)
-			.should('have.css', 'letter-spacing')
-			.and('match', new RegExp(letterSpacingMatcher, 'g'));
-	}
+    // Test letter spacing.
+    cy.get(elem)
+      .should("have.css", "letter-spacing")
+      .and("match", new RegExp(letterSpacingMatcher, "g"));
+  }
 );


### PR DESCRIPTION
### Summary
Prettier configs on .prettierrc now will run together with ESLint.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- When `eslint cypress` command run, the rules should be according to the .pretterrc file on the cypress folder
