### PR TITLE
enh: allow html tags in comments title [closes #2470]

### DIFF
--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -37,7 +37,7 @@ class Comments extends Base_View {
 		if ( have_comments() ) { ?>
 			<div class="nv-comments-title-wrap">
 				<h2 class="comments-title">
-					<?php echo esc_html( $this->get_comments_title() ); ?>
+					<?php echo wp_kses_post( $this->get_comments_title() ); ?>
 				</h2>
 			</div>
 


### PR DESCRIPTION
### Summary
Allows HTML in title of post displayed in the comments area.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add a new post and use HTML inside the title - `<span style="color: red">HELLO</span> WORLD` something like this should work
- Go to the post and add a comment.
- The post title in the comments area should display the styled `span` tag, and not escape it.

![image](https://user-images.githubusercontent.com/15010186/107011726-b855ef80-67a0-11eb-9ca3-7bdb2ffb272d.png)

<!-- Issues that this pull request closes. -->
Closes #2470.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
