### PR TITLE
fix: meta_comments and current_post_meta magic tags [#2490]

### DIFF
--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -212,12 +212,18 @@ class Post_Meta extends Base_View {
 	 * @return string
 	 */
 	public static function get_comments() {
+		if ( ! get_post() ) {
+			return false;
+		}
 		if ( ! comments_open() ) {
-			return '';
+			return false;
 		}
 		$comments_number = get_comments_number();
 		if ( $comments_number < 1 ) {
-			return '';
+			return false;
+		}
+		if ( ! is_front_page() && is_home() ) {
+			return false;
 		}
 		/* translators: %s: number of comments */
 		$comments = sprintf( _n( '%s Comment', '%s Comments', $comments_number, 'neve' ), $comments_number );

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -133,8 +133,13 @@ class Post_Layout extends Base_View {
 	 * Render the post meta.
 	 *
 	 * @param bool $is_list Flag to render meta as a list or as a text.
+	 *
+	 * @return bool
 	 */
 	public static function render_post_meta( $is_list = true ) {
+		if ( ! get_post() ) {
+			return false;
+		}
 		$default_meta_order = wp_json_encode(
 			array(
 				'author',
@@ -147,6 +152,7 @@ class Post_Layout extends Base_View {
 		$meta_order = is_string( $meta_order ) ? json_decode( $meta_order ) : $meta_order;
 		$meta_order = apply_filters( 'neve_post_meta_ordering_filter', $meta_order );
 		do_action( 'neve_post_meta_single', $meta_order, $is_list );
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Fixed the meta_comments and current_post_meta magic tags on the 404 page

### Will affect visual aspect of the product
NO


### Test instructions
- Add these magic tags in the HTML header component and check the 404 page

Closes #2490.
