### PR TITLE
fix: changelog parsing regex in the dashboard [closes #2536]

### DIFF
--- a/dashboard/inc/Changelog_Handler.php
+++ b/dashboard/inc/Changelog_Handler.php
@@ -49,47 +49,47 @@ class Changelog_Handler {
 		if ( is_wp_error( $changelog ) ) {
 			$changelog = '';
 		}
-		$changelog = explode( PHP_EOL, $changelog );
-		$releases  = [];
+		$changelog     = explode( PHP_EOL, $changelog );
+		$releases      = [];
+		$release_count = 0;
 
 		foreach ( $changelog as $changelog_line ) {
 			if ( strpos( $changelog_line, '**Changes:**' ) !== false || empty( $changelog_line ) ) {
 				continue;
 			}
 			if ( substr( ltrim( $changelog_line ), 0, 3 ) === '###' ) {
-				if ( isset( $release ) ) {
-					$releases[] = $release;
-				}
+				$release_count ++;
 
-				preg_match( '/[0-99].[0-99].[0-99]/', $changelog_line, $found_v );
+				preg_match( '/[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}/', $changelog_line, $found_v );
 				preg_match( '/[0-9]{4}-[0-9]{1,2}-[0-9]{1,2}/', $changelog_line, $found_d );
-				$release = array(
+				$releases[ $release_count ] = array(
 					'version' => $found_v[0],
 					'date'    => $found_d[0],
 				);
-			} else {
-				if ( preg_match( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', $changelog_line ) ) {
-					$changelog_line     = preg_replace( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', '', $changelog_line );
-					$release['fixes'][] = $this->parse_md_and_clean( $changelog_line );
-					continue;
-				}
-
-				if ( preg_match( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', $changelog_line ) ) {
-					$changelog_line        = preg_replace( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', '', $changelog_line );
-					$release['features'][] = $this->parse_md_and_clean( $changelog_line );
-					continue;
-				}
-
-				$changelog_line = $this->parse_md_and_clean( $changelog_line );
-
-				if ( empty( $changelog_line ) ) {
-					continue;
-				}
-
-				$release['tweaks'][] = $changelog_line;
+				continue;
 			}
+			if ( preg_match( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', $changelog_line ) ) {
+				$changelog_line                        = preg_replace( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', '', $changelog_line );
+				$releases[ $release_count ]['fixes'][] = $this->parse_md_and_clean( $changelog_line );
+				continue;
+			}
+
+			if ( preg_match( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', $changelog_line ) ) {
+				$changelog_line                           = preg_replace( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', '', $changelog_line );
+				$releases[ $release_count ]['features'][] = $this->parse_md_and_clean( $changelog_line );
+				continue;
+			}
+
+			$changelog_line = $this->parse_md_and_clean( $changelog_line );
+
+			if ( empty( $changelog_line ) ) {
+				continue;
+			}
+
+			$releases[ $release_count ]['tweaks'][] = $changelog_line;
 		}
-		return $releases;
+
+		return array_values( $releases );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Fixes changelog parsing for double-digit releases:
e.g. 1.21.3 | 10.1.24
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go into the dashboard page for Neve 
- The changelog should be properly parsed as opposed to what's mentioned inside the issue

<!-- Issues that this pull request closes. -->
Closes #2536.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
