### PR TITLE
Show last updated date on posts [#1804]

### DIFF
--- a/assets/scss/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/elements/blog/_blogpost-meta.scss
@@ -23,17 +23,8 @@
 		}
 	}
 
-	.posted-on .updated {
+	.posted-on:not(.nv-show-updated) .updated {
 		display: none;
-	}
-
-  	.posted-on.last-up {
-	  .updated {
-		display: inline;
-	  }
-	  .published {
-		display: none;
-	  }
 	}
 
 	.meta.author {

--- a/assets/scss/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/elements/blog/_blogpost-meta.scss
@@ -27,6 +27,15 @@
 		display: none;
 	}
 
+  	.posted-on.updated-time:not(.not-updated) {
+	  .updated {
+		display: inline;
+	  }
+	  .published {
+		display: none;
+	  }
+	}
+
 	.meta.author {
 		.photo {
 			width: $spacing-sm;

--- a/assets/scss/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/elements/blog/_blogpost-meta.scss
@@ -27,7 +27,7 @@
 		display: none;
 	}
 
-  	.posted-on.updated-time {
+  	.posted-on.last-up {
 	  .updated {
 		display: inline;
 	  }

--- a/assets/scss/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/elements/blog/_blogpost-meta.scss
@@ -27,7 +27,7 @@
 		display: none;
 	}
 
-  	.posted-on.updated-time:not(.not-updated) {
+  	.posted-on.updated-time {
 	  .updated {
 		display: inline;
 	  }

--- a/inc/customizer/options/layout_blog.php
+++ b/inc/customizer/options/layout_blog.php
@@ -371,7 +371,7 @@ class Layout_Blog extends Base_Customizer {
 					'priority'         => 70,
 					'class'            => 'blog-layout-post-meta-accordion',
 					'accordion'        => true,
-					'controls_to_wrap' => 2,
+					'controls_to_wrap' => 3,
 					'expanded'         => false,
 				),
 				'Neve\Customizer\Controls\Heading'
@@ -424,6 +424,22 @@ class Layout_Blog extends Base_Customizer {
 					'section'  => 'neve_blog_archive_layout',
 					'type'     => 'neve_toggle_control',
 					'priority' => 80,
+				)
+			)
+		);
+
+		$this->add_control(
+			new Control(
+				'neve_show_last_updated_date',
+				array(
+					'sanitize_callback' => 'neve_sanitize_checkbox',
+					'default'           => false,
+				),
+				array(
+					'label'    => esc_html__( 'Use last updated date instead of the published one', 'neve' ),
+					'section'  => 'neve_blog_archive_layout',
+					'type'     => 'neve_toggle_control',
+					'priority' => 85,
 				)
 			)
 		);

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -78,12 +78,10 @@ class Post_Meta extends Base_View {
 						'posted-on',
 					);
 
-					if ( get_theme_mod( 'neve_show_last_updated_date', false ) ) {
+					$created = get_the_time( 'U' );
+					$modified = get_the_modified_time( 'U' );
+					if ( get_theme_mod( 'neve_show_last_updated_date', false ) && $created !== $modified ) {
 						$date_meta_classes[] = 'updated-time';
-					}
-
-					if ( get_the_time( 'U' ) === get_the_modified_time( 'U' ) ) {
-						$date_meta_classes[] = 'not-updated';
 					}
 
 					$markup .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . '">';

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -78,10 +78,12 @@ class Post_Meta extends Base_View {
 						'posted-on',
 					);
 
-					$created  = get_the_time( 'U' );
-					$modified = get_the_modified_time( 'U' );
-					if ( get_theme_mod( 'neve_show_last_updated_date', false ) && $created !== $modified ) {
-						$date_meta_classes[] = 'last-up';
+					$created           = get_the_time( 'U' );
+					$modified          = get_the_modified_time( 'U' );
+					$has_updated_time  = $created !== $modified;
+					$show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
+					if ( $show_updated_time && $has_updated_time ) {
+						$date_meta_classes[] = 'nv-show-updated';
 					}
 
 					$markup .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . '">';
@@ -207,9 +209,11 @@ class Post_Meta extends Base_View {
 	 * @return string
 	 */
 	public static function get_time_tags() {
-		$created  = get_the_time( 'U' );
-		$format   = get_option( 'date_format' );
-		$modified = get_the_modified_time( 'U' );
+		$created           = get_the_time( 'U' );
+		$modified          = get_the_modified_time( 'U' );
+		$has_updated_time  = $created !== $modified;
+		$show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
+		$format            = get_option( 'date_format' );
 
 		$prefixes = array(
 			'published' => '',
@@ -228,18 +232,32 @@ class Post_Meta extends Base_View {
 		 *
 		 * @since 2.11
 		 */
-		$prefixes         = apply_filters( 'neve_meta_date_prefix', $prefixes );
-		$published_prefix = array_key_exists( 'published', $prefixes ) ? $prefixes['published'] : '';
-		$updated_prefix   = array_key_exists( 'updated', $prefixes ) ? $prefixes['updated'] : '';
+		$prefixes = apply_filters( 'neve_meta_date_prefix', $prefixes );
 
-		$time = '<time class="entry-date published" datetime="' . esc_attr( date_i18n( 'c', $created ) ) . '" content="' . esc_attr( date_i18n( 'Y-m-d', $created ) ) . '">' . wp_kses_post( $published_prefix ) . esc_html( date_i18n( $format, $created ) ) . '</time>';
-		if ( $created === $modified ) {
+		$updated_time_markup = '<time class="updated" datetime="' . esc_attr( date_i18n( 'c', $modified ) ) . '">';
+		if ( array_key_exists( 'updated', $prefixes ) && ! empty( $prefixes['updated'] ) ) {
+			$updated_time_markup .= wp_kses_post( $prefixes['updated'] );
+		}
+		$updated_time_markup .= esc_html( date_i18n( $format, $modified ) ) . '</time>';
+
+		if ( $show_updated_time && $has_updated_time ) {
+			return $updated_time_markup;
+		}
+
+		$time = '<time class="entry-date published" datetime="' . esc_attr( date_i18n( 'c', $created ) ) . '" content="' . esc_attr( date_i18n( 'Y-m-d', $created ) ) . '">';
+		if ( array_key_exists( 'published', $prefixes ) && ! empty( $prefixes['published'] ) ) {
+			$time .= wp_kses_post( $prefixes['published'] );
+		}
+		$time .= esc_html( date_i18n( $format, $created ) ) . '</time>';
+
+		if ( ! $has_updated_time ) {
 			return $time;
 		}
-		$time .= '<time class="updated" datetime="' . esc_attr( date_i18n( 'c', $modified ) ) . '">' . wp_kses_post( $updated_prefix ) . esc_html( date_i18n( $format, $modified ) ) . '</time>';
+		$time .= $updated_time_markup;
 
 		return $time;
 	}
+
 	/**
 	 * Get the comments with a link.
 	 *

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -78,10 +78,10 @@ class Post_Meta extends Base_View {
 						'posted-on',
 					);
 
-					$created = get_the_time( 'U' );
+					$created  = get_the_time( 'U' );
 					$modified = get_the_modified_time( 'U' );
 					if ( get_theme_mod( 'neve_show_last_updated_date', false ) && $created !== $modified ) {
-						$date_meta_classes[] = 'updated-time';
+						$date_meta_classes[] = 'last-up';
 					}
 
 					$markup .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . '">';

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -891,7 +891,7 @@ msgstr ""
 
 #: header-footer-grid/Core/Magic_Tags.php:543
 #: inc/customizer/options/layout_blog.php:390
-#: inc/views/partials/post_meta.php:139
+#: inc/views/partials/post_meta.php:141
 msgid "Author"
 msgstr ""
 
@@ -1469,18 +1469,18 @@ msgstr ""
 
 #: inc/customizer/options/layout_blog.php:391
 #: inc/customizer/options/layout_single_product.php:107
-#: inc/views/partials/post_meta.php:140
+#: inc/views/partials/post_meta.php:142
 msgid "Category"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:392
-#: inc/views/partials/post_meta.php:141
+#: inc/views/partials/post_meta.php:143
 msgid "Date"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:393
 #: inc/customizer/options/layout_single_post.php:72
-#: inc/views/partials/post_meta.php:142
+#: inc/views/partials/post_meta.php:144
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:319
 msgid "Comments"
 msgstr ""
@@ -1583,7 +1583,7 @@ msgid "Content"
 msgstr ""
 
 #: inc/customizer/options/layout_single_post.php:70
-#: inc/views/partials/post_meta.php:275
+#: inc/views/partials/post_meta.php:277
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:318
 msgid "Tags"
 msgstr ""
@@ -1789,17 +1789,17 @@ msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/partials/post_meta.php:184
+#: inc/views/partials/post_meta.php:186
 msgid "by"
 msgstr ""
 
 #. translators: %s: Author's display name.
-#: inc/views/partials/post_meta.php:191
+#: inc/views/partials/post_meta.php:193
 msgid "Posts by %s"
 msgstr ""
 
 #. translators: %s: number of comments
-#: inc/views/partials/post_meta.php:261
+#: inc/views/partials/post_meta.php:263
 msgid "%s Comment"
 msgid_plural "%s Comments"
 msgstr[0] ""

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -891,7 +891,7 @@ msgstr ""
 
 #: header-footer-grid/Core/Magic_Tags.php:543
 #: inc/customizer/options/layout_blog.php:390
-#: inc/views/partials/post_meta.php:129
+#: inc/views/partials/post_meta.php:143
 msgid "Author"
 msgstr ""
 
@@ -1469,18 +1469,18 @@ msgstr ""
 
 #: inc/customizer/options/layout_blog.php:391
 #: inc/customizer/options/layout_single_product.php:107
-#: inc/views/partials/post_meta.php:130
+#: inc/views/partials/post_meta.php:144
 msgid "Category"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:392
-#: inc/views/partials/post_meta.php:131
+#: inc/views/partials/post_meta.php:145
 msgid "Date"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:393
 #: inc/customizer/options/layout_single_post.php:72
-#: inc/views/partials/post_meta.php:132
+#: inc/views/partials/post_meta.php:146
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:319
 msgid "Comments"
 msgstr ""
@@ -1493,11 +1493,15 @@ msgstr ""
 msgid "Show Author Avatar"
 msgstr ""
 
-#: inc/customizer/options/layout_blog.php:585
+#: inc/customizer/options/layout_blog.php:439
+msgid "Use last updated date instead of the published one"
+msgstr ""
+
+#: inc/customizer/options/layout_blog.php:601
 msgid "Customize Typography for the Archive page"
 msgstr ""
 
-#: inc/customizer/options/layout_blog.php:587
+#: inc/customizer/options/layout_blog.php:603
 msgid "here"
 msgstr ""
 
@@ -1579,7 +1583,7 @@ msgid "Content"
 msgstr ""
 
 #: inc/customizer/options/layout_single_post.php:70
-#: inc/views/partials/post_meta.php:243
+#: inc/views/partials/post_meta.php:279
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:318
 msgid "Tags"
 msgstr ""
@@ -1785,17 +1789,17 @@ msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/partials/post_meta.php:174
+#: inc/views/partials/post_meta.php:188
 msgid "by"
 msgstr ""
 
 #. translators: %s: Author's display name.
-#: inc/views/partials/post_meta.php:181
+#: inc/views/partials/post_meta.php:195
 msgid "Posts by %s"
 msgstr ""
 
 #. translators: %s: number of comments
-#: inc/views/partials/post_meta.php:229
+#: inc/views/partials/post_meta.php:265
 msgid "%s Comment"
 msgid_plural "%s Comments"
 msgstr[0] ""

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -891,7 +891,7 @@ msgstr ""
 
 #: header-footer-grid/Core/Magic_Tags.php:543
 #: inc/customizer/options/layout_blog.php:390
-#: inc/views/partials/post_meta.php:142
+#: inc/views/partials/post_meta.php:143
 msgid "Author"
 msgstr ""
 
@@ -1469,18 +1469,18 @@ msgstr ""
 
 #: inc/customizer/options/layout_blog.php:391
 #: inc/customizer/options/layout_single_product.php:107
-#: inc/views/partials/post_meta.php:143
+#: inc/views/partials/post_meta.php:144
 msgid "Category"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:392
-#: inc/views/partials/post_meta.php:144
+#: inc/views/partials/post_meta.php:145
 msgid "Date"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:393
 #: inc/customizer/options/layout_single_post.php:72
-#: inc/views/partials/post_meta.php:145
+#: inc/views/partials/post_meta.php:146
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:319
 msgid "Comments"
 msgstr ""
@@ -1583,7 +1583,7 @@ msgid "Content"
 msgstr ""
 
 #: inc/customizer/options/layout_single_post.php:70
-#: inc/views/partials/post_meta.php:284
+#: inc/views/partials/post_meta.php:295
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:318
 msgid "Tags"
 msgstr ""
@@ -1789,17 +1789,17 @@ msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/partials/post_meta.php:187
+#: inc/views/partials/post_meta.php:188
 msgid "by"
 msgstr ""
 
 #. translators: %s: Author's display name.
-#: inc/views/partials/post_meta.php:194
+#: inc/views/partials/post_meta.php:195
 msgid "Posts by %s"
 msgstr ""
 
 #. translators: %s: number of comments
-#: inc/views/partials/post_meta.php:270
+#: inc/views/partials/post_meta.php:281
 msgid "%s Comment"
 msgid_plural "%s Comments"
 msgstr[0] ""

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -891,7 +891,7 @@ msgstr ""
 
 #: header-footer-grid/Core/Magic_Tags.php:543
 #: inc/customizer/options/layout_blog.php:390
-#: inc/views/partials/post_meta.php:143
+#: inc/views/partials/post_meta.php:139
 msgid "Author"
 msgstr ""
 
@@ -1469,18 +1469,18 @@ msgstr ""
 
 #: inc/customizer/options/layout_blog.php:391
 #: inc/customizer/options/layout_single_product.php:107
-#: inc/views/partials/post_meta.php:144
+#: inc/views/partials/post_meta.php:140
 msgid "Category"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:392
-#: inc/views/partials/post_meta.php:145
+#: inc/views/partials/post_meta.php:141
 msgid "Date"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:393
 #: inc/customizer/options/layout_single_post.php:72
-#: inc/views/partials/post_meta.php:146
+#: inc/views/partials/post_meta.php:142
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:319
 msgid "Comments"
 msgstr ""
@@ -1583,7 +1583,7 @@ msgid "Content"
 msgstr ""
 
 #: inc/customizer/options/layout_single_post.php:70
-#: inc/views/partials/post_meta.php:279
+#: inc/views/partials/post_meta.php:275
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:318
 msgid "Tags"
 msgstr ""
@@ -1789,17 +1789,17 @@ msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/partials/post_meta.php:188
+#: inc/views/partials/post_meta.php:184
 msgid "by"
 msgstr ""
 
 #. translators: %s: Author's display name.
-#: inc/views/partials/post_meta.php:195
+#: inc/views/partials/post_meta.php:191
 msgid "Posts by %s"
 msgstr ""
 
 #. translators: %s: number of comments
-#: inc/views/partials/post_meta.php:265
+#: inc/views/partials/post_meta.php:261
 msgid "%s Comment"
 msgid_plural "%s Comments"
 msgstr[0] ""

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -891,7 +891,7 @@ msgstr ""
 
 #: header-footer-grid/Core/Magic_Tags.php:543
 #: inc/customizer/options/layout_blog.php:390
-#: inc/views/partials/post_meta.php:141
+#: inc/views/partials/post_meta.php:142
 msgid "Author"
 msgstr ""
 
@@ -1469,18 +1469,18 @@ msgstr ""
 
 #: inc/customizer/options/layout_blog.php:391
 #: inc/customizer/options/layout_single_product.php:107
-#: inc/views/partials/post_meta.php:142
+#: inc/views/partials/post_meta.php:143
 msgid "Category"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:392
-#: inc/views/partials/post_meta.php:143
+#: inc/views/partials/post_meta.php:144
 msgid "Date"
 msgstr ""
 
 #: inc/customizer/options/layout_blog.php:393
 #: inc/customizer/options/layout_single_post.php:72
-#: inc/views/partials/post_meta.php:144
+#: inc/views/partials/post_meta.php:145
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:319
 msgid "Comments"
 msgstr ""
@@ -1583,7 +1583,7 @@ msgid "Content"
 msgstr ""
 
 #: inc/customizer/options/layout_single_post.php:70
-#: inc/views/partials/post_meta.php:277
+#: inc/views/partials/post_meta.php:284
 #: inc/admin/metabox/src/components/MetaFieldsManager.js:318
 msgid "Tags"
 msgstr ""
@@ -1789,17 +1789,17 @@ msgid_plural "%1$s thoughts on &ldquo;%2$s&rdquo;"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/partials/post_meta.php:186
+#: inc/views/partials/post_meta.php:187
 msgid "by"
 msgstr ""
 
 #. translators: %s: Author's display name.
-#: inc/views/partials/post_meta.php:193
+#: inc/views/partials/post_meta.php:194
 msgid "Posts by %s"
 msgstr ""
 
 #. translators: %s: number of comments
-#: inc/views/partials/post_meta.php:263
+#: inc/views/partials/post_meta.php:270
 msgid "%s Comment"
 msgid_plural "%s Comments"
 msgstr[0] ""


### PR DESCRIPTION
### Summary
- Added a toggle in the customizer to switch between created post date and the last updated date.
- Added the `neve_meta_date_prefix` filter to add a prefix before those dates.

### Will affect visual aspect of the product
NO

### Test instructions
- Go to Customizer -> Layout -> Blog/Archive -> Post meta and enable the toggle that says `Use last updated date instead of the published one`. Also, make sure the date is enabled in the Meta Order control.
- Edit a post and press publish so the post would have an updated date.
- Check on blog/single/archive if the post is displaying the updated date and not the one that it was created.
- Check a post that was not updated. It should display the published date.
- In a child theme, add the following function in `functions.php`:
```
function neve_post_date_prefix( $prefix_array ) {
   $prefix_array['published'] = 'This post was published on ';
   $prefix_array['updated'] = 'This post was updated on ';
   return $prefix_array;
}
add_filter( 'neve_meta_date_prefix' , 'neve_post_date_prefix' );
```
- Check if the posted/updated date has the prefix in front of the displaying date.

<!-- Issues that this pull request closes. -->
Closes #1804.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
