### PR TITLE
Fix button secondary color

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -78,7 +78,7 @@ class Woocommerce {
 			.woocommerce .button.button-secondary.more-details,
 			.woocommerce-checkout #neve-checkout-coupon .woocommerce-form-coupon .form-row-last button.button',
 		'hover'   => '
-			.woocommerce-cart table.cart td.actions .coupon > .input-text + .button:hover,
+			,.woocommerce-cart table.cart td.actions .coupon > .input-text + .button:hover,
 			.woocommerce-checkout #neve-checkout-coupon .woocommerce-form-coupon .form-row-last button:hover,
 			.woocommerce button.button:not(.single_add_to_cart_button):hover,
 			.woocommerce a.added_to_cart:hover,


### PR DESCRIPTION
### Summary
Seems like the selectors for the hover button added in WooCommerce didn't have a comma before them and they were concatenated to the selectors from neve, breaking them as well.

### Will affect visual aspect of the product
NO


### Test instructions
- Check if hover color for secondary buttons from customizer works

<!-- Issues that this pull request closes. -->
Closes #2678 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
