### PR TITLE
Headings should inherit from body when set as default

### DIFF
--- a/assets/scss/main/_typography.scss
+++ b/assets/scss/main/_typography.scss
@@ -18,7 +18,6 @@ body {
 h1, h2, h3, h4, h5, h6 {
   text-transform: none;
   letter-spacing: 0;
-  font-family: $default-font-family;
   line-height: $line-height-base;
   margin-bottom: $headings-margin-bottom;
   font-weight: $headings-font-weight;

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -247,7 +247,7 @@ class Typography extends Base_Customizer {
 					'priority'              => 10,
 					'type'                  => 'neve_font_family_control',
 					'live_refresh_selector' => apply_filters( 'neve_headings_font_family_selectors', 'h1:not(.site-title), .single h1.entry-title, h2, h3, .woocommerce-checkout h3, h4, h5, h6' ),
-					'input_attrs' => [
+					'input_attrs'           => [
 						'default_is_inherit' => true,
 					],
 				),

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -247,6 +247,9 @@ class Typography extends Base_Customizer {
 					'priority'              => 10,
 					'type'                  => 'neve_font_family_control',
 					'live_refresh_selector' => apply_filters( 'neve_headings_font_family_selectors', 'h1:not(.site-title), .single h1.entry-title, h2, h3, .woocommerce-checkout h3, h4, h5, h6' ),
+					'input_attrs' => [
+						'default_is_inherit' => true,
+					],
 				),
 				'\Neve\Customizer\Controls\React\Font_Family'
 			)

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1539,7 +1539,7 @@ msgstr ""
 
 #: inc/customizer/options/layout_sidebar.php:164
 #: inc/customizer/options/layout_single_post.php:42
-#: inc/customizer/options/typography.php:335
+#: inc/customizer/options/typography.php:338
 msgid "Single Post"
 msgstr ""
 
@@ -1631,25 +1631,25 @@ msgstr ""
 msgid "Learn more about fallback fonts"
 msgstr ""
 
-#: inc/customizer/options/typography.php:318
-#: inc/customizer/options/typography.php:334
+#: inc/customizer/options/typography.php:321
+#: inc/customizer/options/typography.php:337
 msgid "Post title"
 msgstr ""
 
-#: inc/customizer/options/typography.php:319
+#: inc/customizer/options/typography.php:322
 msgid "Blog Archive"
 msgstr ""
 
-#: inc/customizer/options/typography.php:324
+#: inc/customizer/options/typography.php:327
 msgid "Post excerpt"
 msgstr ""
 
-#: inc/customizer/options/typography.php:329
-#: inc/customizer/options/typography.php:340
+#: inc/customizer/options/typography.php:332
+#: inc/customizer/options/typography.php:343
 msgid "Post meta"
 msgstr ""
 
-#: inc/customizer/options/typography.php:345
+#: inc/customizer/options/typography.php:348
 msgid "Comments reply title"
 msgstr ""
 


### PR DESCRIPTION
### Summary
- Removed the font-family property in _typography.scss because it was overwriting what's on the body.
- Mark the font control as 'default_is_inherit' to inherit from the body when it is set as default.

### Will affect visual aspect of the product
YES will produce visual changes if the body font is set and the headings font is not.


### Test instructions
- Test if it works well when:
1. none of them are set ( headings and body font should have the same value, and the value is a default font )
2. body is set, but headings are not ( headings should have the same font as the body font )
3. body is not set, headings are set ( headings should have their value and body should have the default value )
4. both are set ( body have its font, headings have its font )

- Check if there is the correct font in both the front-end and editor.
<!-- Issues that this pull request closes. -->
Closes #2560.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
