### PR TITLE
Fix group block color

### DIFF
--- a/assets/scss/gutenberg-editor/_typography.scss
+++ b/assets/scss/gutenberg-editor/_typography.scss
@@ -53,10 +53,15 @@ h6 {
 	font-size: 16px;
 	font-weight: normal;
 	font-family: $default-font-family;
-	color: var(--nv-text-color);
 	line-height: $line-height-base;
 	text-transform: none;
 	letter-spacing: normal;
+
+	&:not(.wp-block-group.has-text-color){
+	  .wp-block{
+		color: var(--nv-text-color);
+	  }
+	}
 
   	&.components-placeholder {
 	  color: initial;

--- a/assets/scss/gutenberg-editor/_typography.scss
+++ b/assets/scss/gutenberg-editor/_typography.scss
@@ -57,6 +57,9 @@ h6 {
 	text-transform: none;
 	letter-spacing: normal;
 
+  	&.wp-block-group.has-background {
+	  padding: 0;
+	}
 	&:not(.wp-block-group.has-text-color){
 	  .wp-block{
 		color: var(--nv-text-color);


### PR DESCRIPTION
### Summary
- Fix text color for blocks inside a group block with color applied.
- Removed the padding of a group block that has a background in the editor so it matches the front-end.

### Will affect visual aspect of the product
NO

### Test instructions
The scenario is like this:
1. Have a group block
2. Insert in it two paragraphs

You can either add text color to each paragraph or add text color on the global block.

How it should behave:
1. If the group block has a text color set and the paragraphs don't, the paragraphs should inherit the text color from the group block.
2. If the group block has a text color set and the paragraphs have their own color set, the color of the paragraph should overwrite the group block color.

- Maybe try with some other blocks inside the group block too.


<!-- Issues that this pull request closes. -->
Closes #2540.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
