### PR TITLE
Add skip-lazy class

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,16 +17,6 @@ if ( ! defined( 'NEVE_DEBUG' ) ) {
 	define( 'NEVE_DEBUG', false );
 }
 define( 'NEVE_NEW_DYNAMIC_STYLE', true );
-
-/**
- * Flag to decide if the 'skip-lazy' class should be added in post loop.
- *
- * @var bool $neve_thumbnail_skip_lazy_added
- */
-global $neve_thumbnail_skip_lazy_added;
-
-$neve_thumbnail_skip_lazy_added = false;
-
 /**
  * Buffer which holds errors during theme inititalization.
  *

--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,16 @@ if ( ! defined( 'NEVE_DEBUG' ) ) {
 	define( 'NEVE_DEBUG', false );
 }
 define( 'NEVE_NEW_DYNAMIC_STYLE', true );
+
+/**
+ * Flag to decide if the 'skip-lazy' class should be added in post loop.
+ *
+ * @var bool $neve_thumbnail_skip_lazy_added
+ */
+global $neve_thumbnail_skip_lazy_added;
+
+$neve_thumbnail_skip_lazy_added = false;
+
 /**
  * Buffer which holds errors during theme inititalization.
  *

--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -60,7 +60,7 @@ $logo_settings = array();
  *
  * @since 2.11
  */
-$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', true );
 if ( $should_add_skip_lazy ) {
 	$logo_settings['class'] = 'skip-lazy';
 }

--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -50,7 +50,7 @@ if ( $is_not_link ) {
 }
 
 do_action( 'hfg_before_wp_get_attachment_image', $custom_logo_id );
-$image = wp_get_attachment_image( $custom_logo_id, apply_filters( 'hfg_logo_image_size', 'full' ) );
+$image = wp_get_attachment_image( $custom_logo_id, apply_filters( 'hfg_logo_image_size', 'full' ), false, array( 'class' => 'skip-lazy' ) );
 do_action( 'hfg_after_wp_get_attachment_image', $custom_logo_id, $image );
 ?>
 <div class="site-logo">

--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -50,7 +50,22 @@ if ( $is_not_link ) {
 }
 
 do_action( 'hfg_before_wp_get_attachment_image', $custom_logo_id );
-$image = wp_get_attachment_image( $custom_logo_id, apply_filters( 'hfg_logo_image_size', 'full' ), false, array( 'class' => 'skip-lazy' ) );
+
+$logo_settings = array();
+
+/**
+ * Filters whether the skip lazy class should be added.
+ *
+ * @param bool $enable_skip_lazy Whether the skip lazy class should be added. Default value is true.
+ *
+ * @since 2.11
+ */
+$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+if ( $should_add_skip_lazy ) {
+	$logo_settings['class'] = 'skip-lazy';
+}
+
+$image = wp_get_attachment_image( $custom_logo_id, apply_filters( 'hfg_logo_image_size', 'full' ), false, $logo_settings );
 do_action( 'hfg_after_wp_get_attachment_image', $custom_logo_id, $image );
 ?>
 <div class="site-logo">

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -68,7 +68,7 @@ class Post_Layout extends Base_View {
 
 
 		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
-		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', true );
 		$skip_lazy_class      = '';
 		if ( $should_add_skip_lazy ) {
 			$thumbnail_index = array_search( 'thumbnail', $content_order );

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -66,6 +66,11 @@ class Post_Layout extends Base_View {
 
 		$content_order = apply_filters( 'neve_layout_single_post_elements_order', $content_order );
 
+
+		$thumbnail_index = array_search( 'thumbnail', $content_order );
+		$content_index   = array_search( 'content', $content_order );
+		$skip_lazy_class = $thumbnail_index < $content_index ? 'skip-lazy' : '';
+
 		if ( empty( $content_order ) ) {
 			return;
 		}
@@ -80,7 +85,8 @@ class Post_Layout extends Base_View {
 					echo '<div class="nv-thumb-wrap">';
 					echo get_the_post_thumbnail(
 						null,
-						'neve-blog'
+						'neve-blog',
+						array( 'class' => $skip_lazy_class )
 					);
 					echo '</div>';
 					break;

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -67,9 +67,16 @@ class Post_Layout extends Base_View {
 		$content_order = apply_filters( 'neve_layout_single_post_elements_order', $content_order );
 
 
-		$thumbnail_index = array_search( 'thumbnail', $content_order );
-		$content_index   = array_search( 'content', $content_order );
-		$skip_lazy_class = $thumbnail_index < $content_index ? 'skip-lazy' : '';
+		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
+		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+		$skip_lazy_class      = '';
+		if ( $should_add_skip_lazy ) {
+			$thumbnail_index = array_search( 'thumbnail', $content_order );
+			$content_index   = array_search( 'content', $content_order );
+			if ( $thumbnail_index < $content_index ) {
+				$skip_lazy_class = 'skip-lazy';
+			}
+		}
 
 		if ( empty( $content_order ) ) {
 			return;

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -106,14 +106,14 @@ class Template_Parts extends Base_View {
 			return '';
 		}
 
-		global $wp_query;
+		global $neve_thumbnail_skip_lazy_added;
 
 		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
 		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', true );
 		$image_class          = '';
-		if ( $should_add_skip_lazy && ! property_exists( $wp_query, 'nv_should_load_lazy' ) ) {
-			$image_class                   = 'skip-lazy';
-			$wp_query->nv_should_load_lazy = false;
+		if ( $should_add_skip_lazy && $neve_thumbnail_skip_lazy_added !== true ) {
+			$image_class                    = 'skip-lazy';
+			$neve_thumbnail_skip_lazy_added = true;
 		}
 
 		$markup = '<div class="nv-post-thumbnail-wrap">';

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -108,8 +108,13 @@ class Template_Parts extends Base_View {
 
 		global $wp_query;
 
-		$image_class = ! property_exists( $wp_query, 'nv_should_load_lazy' ) ? 'skip-lazy' : '';
-		$wp_query->nv_should_load_lazy = false;
+		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
+		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+		$image_class          = '';
+		if ( $should_add_skip_lazy && ! property_exists( $wp_query, 'nv_should_load_lazy' ) ) {
+			$image_class                   = 'skip-lazy';
+			$wp_query->nv_should_load_lazy = false;
+		}
 
 		$markup = '<div class="nv-post-thumbnail-wrap">';
 

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -109,7 +109,7 @@ class Template_Parts extends Base_View {
 		global $wp_query;
 
 		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
-		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', ture );
+		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', true );
 		$image_class          = '';
 		if ( $should_add_skip_lazy && ! property_exists( $wp_query, 'nv_should_load_lazy' ) ) {
 			$image_class                   = 'skip-lazy';

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -105,6 +105,12 @@ class Template_Parts extends Base_View {
 		if ( ! has_post_thumbnail() ) {
 			return '';
 		}
+
+		global $wp_query;
+
+		$image_class = ! property_exists( $wp_query, 'nv_should_load_lazy' ) ? 'skip-lazy' : '';
+		$wp_query->nv_should_load_lazy = false;
+
 		$markup = '<div class="nv-post-thumbnail-wrap">';
 
 		$markup .= '<a href="' . esc_url( get_the_permalink() ) . '" rel="bookmark" title="' . the_title_attribute(
@@ -112,9 +118,11 @@ class Template_Parts extends Base_View {
 				'echo' => false,
 			)
 		) . '">';
+
 		$markup .= get_the_post_thumbnail(
 			get_the_ID(),
-			'neve-blog'
+			'neve-blog',
+			array( 'class' => $image_class )
 		);
 		$markup .= '</a>';
 		$markup .= '</div>';

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -111,7 +111,7 @@ class Template_Parts extends Base_View {
 		/** This filter is documented in header-footer-grid/templates/components/component-logo.php */
 		$should_add_skip_lazy = apply_filters( 'neve_skip_lazy', true );
 		$image_class          = '';
-		if ( $should_add_skip_lazy && $neve_thumbnail_skip_lazy_added !== true ) {
+		if ( $should_add_skip_lazy && ! isset( $neve_thumbnail_skip_lazy_added ) ) {
 			$image_class                    = 'skip-lazy';
 			$neve_thumbnail_skip_lazy_added = true;
 		}

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1806,7 +1806,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: inc/views/pluggable/pagination.php:146
-#: inc/views/template_parts.php:309
+#: inc/views/template_parts.php:322
 msgid "Pages:"
 msgstr ""
 
@@ -1822,7 +1822,7 @@ msgstr ""
 msgid "Out of stock"
 msgstr ""
 
-#: inc/views/template_parts.php:251
+#: inc/views/template_parts.php:264
 msgid "Read More"
 msgstr ""
 


### PR DESCRIPTION
### Summary
- Added skip lazy class for logo, single thumbnail if it's before content, and the first image of the blog archive

### Will affect visual aspect of the product
NO


### Test instructions
- Check if skip-lazy class is where I said it would be

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1249.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
