### PR TITLE
Adds a test for woocommerce single product

### DIFF
--- a/e2e-tests/cypress/fixtures/woocommerce/single-product-setup.json
+++ b/e2e-tests/cypress/fixtures/woocommerce/single-product-setup.json
@@ -1,0 +1,7 @@
+{
+    "custom_css_post_id": -1,
+    "nav_menu_locations": [],
+    "neve_migrated_hfg_colors": true,
+    "neve_exclusive_products_title": "Exclusive Products",
+    "neve_exclusive_products_category": "all"
+}

--- a/e2e-tests/cypress/integration/woocommerce/single-product.spec.ts
+++ b/e2e-tests/cypress/integration/woocommerce/single-product.spec.ts
@@ -1,0 +1,13 @@
+describe('Single product - Exclusive products', function () {
+	before('Sets up the customizer', function () {
+		cy.fixture('woocommerce/single-product-setup').then((componentSetup) => {
+			cy.setCustomizeSettings(componentSetup);
+		});
+	});
+	it('Checks up frontend', function () {
+		cy.visit('/product/beanie/');
+		cy.get('h2').contains('Exclusive Products');
+		cy.get('.exclusive').should('be.visible');
+		cy.get('.dots-nav').should('be.visible');
+	});
+});


### PR DESCRIPTION
### Summary
Adds a test for woocommerce single product that uses Exclusive products

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- All tests should pass the pipeline

<!-- Issues that this pull request closes. -->
Closes #2780 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
