### PR TITLE
Fix/wpml infinite scroll

### DIFF
--- a/assets/js/src/frontend/blog.js
+++ b/assets/js/src/frontend/blog.js
@@ -44,7 +44,7 @@ const masonry = () => {
  * Infinite scroll.
  */
 const infiniteScroll = () => {
-	if (NeveProperties.infiniteScroll !== 'enabled') {
+	if (NeveProperties.infScroll !== 'enabled') {
 		return;
 	}
 
@@ -72,16 +72,16 @@ const requestMorePosts = () => {
 		return;
 	}
 	document.querySelector('.nv-loader').style.display = 'block';
-	if (page > NeveProperties.infiniteScrollMaxPages) {
+	if (page > NeveProperties.maxPages) {
 		trigger.parentNode.removeChild(trigger);
 		document.querySelector('.nv-loader').style.display = 'none';
 		return;
 	}
-
 	const blog = document.querySelector(postWrapSelector);
-	const requestUrl = maybeParseUrlForCustomizer(
-		NeveProperties.infiniteScrollEndpoint + page
-	);
+	const lang = NeveProperties.lang;
+	const baseUrl = NeveProperties.endpoint + page;
+	const url = lang ? baseUrl + '/' + lang : baseUrl;
+	const requestUrl = maybeParseUrlForCustomizer(url);
 	page++;
 
 	httpGetAsync(
@@ -94,7 +94,7 @@ const requestMorePosts = () => {
 			window.nvMasonry.reloadItems();
 			window.nvMasonry.layout();
 		},
-		NeveProperties.infiniteScrollQuery
+		NeveProperties.query
 	);
 };
 

--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -64,6 +64,10 @@ class Pagination extends Base_View {
 		$args['ignore_sticky_posts'] = 1;
 		$args['post_status']         = 'publish';
 
+		if ( ! empty( $request['lang'] ) ) {
+			$args['lang'] = $request['lang'];
+		}
+
 		$output = '';
 
 		global $sitepress;
@@ -104,7 +108,9 @@ class Pagination extends Base_View {
 		$data['maxPages']  = $max_pages;
 		$data['endpoint']  = rest_url( 'nv/v1/posts/page/' );
 		$data['query']     = wp_json_encode( $wp_query->query );
+		$data['lang']      = get_locale();
 
+		// WPML language parameter
 		$current_lang = apply_filters( 'wpml_current_language', null );
 		if ( ! empty( $current_lang ) ) {
 			$data['lang'] = $current_lang;

--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -34,7 +34,7 @@ class Pagination extends Base_View {
 	public function register_endpoints() {
 		register_rest_route(
 			'nv/v1/posts',
-			'/page/(?P<page_number>\d+)(?:/(?P<lang>[a-zA-Z0-9-]+))?',
+			'/page/(?P<page_number>\d+)(?:/(?P<lang>[a-zA-Z0-9-_]+))?',
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_posts' ),
@@ -65,15 +65,19 @@ class Pagination extends Base_View {
 		$args['post_status']         = 'publish';
 
 		if ( ! empty( $request['lang'] ) ) {
-			$args['lang'] = $request['lang'];
+			if ( defined( 'POLYLANG_VERSION' ) ) {
+				$args['lang'] = $request['lang'];
+			}
+
+			if ( defined( 'ICL_SITEPRESS_VERSION' ) ) {
+				global $sitepress;
+				if ( gettype( $sitepress ) === 'object' && method_exists( $sitepress, 'switch_lang' ) ) {
+					$sitepress->switch_lang( $request['lang'] );
+				}
+			}
 		}
 
 		$output = '';
-
-		global $sitepress;
-		if ( ! empty( $request['lang'] ) && gettype( $sitepress ) === 'object' && method_exists( $sitepress, 'switch_lang' ) ) {
-			$sitepress->switch_lang( $request['lang'] );
-		}
 
 		$query = new \WP_Query( $args );
 		if ( $query->have_posts() ) {

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1812,16 +1812,16 @@ msgid_plural "%s Comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/pluggable/pagination.php:152
+#: inc/views/pluggable/pagination.php:162
 #: inc/views/template_parts.php:322
 msgid "Pages:"
 msgstr ""
 
-#: inc/views/pluggable/pagination.php:169
+#: inc/views/pluggable/pagination.php:179
 msgid "previous"
 msgstr ""
 
-#: inc/views/pluggable/pagination.php:174
+#: inc/views/pluggable/pagination.php:184
 msgid "next"
 msgstr ""
 

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1812,16 +1812,16 @@ msgid_plural "%s Comments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: inc/views/pluggable/pagination.php:162
+#: inc/views/pluggable/pagination.php:172
 #: inc/views/template_parts.php:322
 msgid "Pages:"
 msgstr ""
 
-#: inc/views/pluggable/pagination.php:179
+#: inc/views/pluggable/pagination.php:189
 msgid "previous"
 msgstr ""
 
-#: inc/views/pluggable/pagination.php:184
+#: inc/views/pluggable/pagination.php:194
 msgid "next"
 msgstr ""
 


### PR DESCRIPTION
### Summary
- Fix the infinite scroll loading wrong posts in WPML
- Fix the infinite scroll loading wrong posts in Polylang
- Checked infinite scroll in weglot and translatepress

### Will affect visual aspect of the product
NO


### Test instructions
- Check the infinite scroll with Polylang and WPML
- You can check the handbook for the WPML credentials or ask Urihas 
- Weglot and TranslatePress are not able to load posts from a specific language, they are implemented differently. You can check and see if you get any errors with them too but you will not be able to reproduce wpml or polylang functionality

<!-- Issues that this pull request closes. -->
Closes #2696 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
