### PR TITLE
[do not merge] Fix/issue 2834

### DIFF
--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -179,7 +179,7 @@ class Css_Prop {
 					Font_Manager::add_google_font( $font, strval( $value ) );
 				}
 
-				$value = ( $value > 0 ) ? intval( $value ) : 'normal';
+				$value = ( intval($value) > 0 ) ? intval( $value ) : 'normal';
 
 				return sprintf( ' %s: %s;', $css_prop, $value );
 				break;

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -179,7 +179,9 @@ class Css_Prop {
 					Font_Manager::add_google_font( $font, strval( $value ) );
 				}
 
-				return sprintf( ' %s: %s;', $css_prop, intval( $value ) );
+				$value = ( $value > 0 ) ? intval( $value ) : 'normal';
+
+				return sprintf( ' %s: %s;', $css_prop, $value );
 				break;
 			case Config::CSS_PROP_FONT_FAMILY:
 				if ( $value === 'default' ) {

--- a/inc/core/styles/dynamic_selector.php
+++ b/inc/core/styles/dynamic_selector.php
@@ -213,7 +213,11 @@ class Dynamic_Selector {
 			foreach ( $props as $css_prop => $meta ) {
 				$value = $this->get_value( $meta );
 				if ( $value === false || $value === null || $value === '' ) {
-					continue;
+					if ( $css_prop === 'font-weight' ) {
+						$value = 'normal';
+					} else {
+						continue;
+					}
 				}
 				$rules_selector .= Css_Prop::transform( $css_prop, $value, $meta, $this->get_device() );
 			}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
In dynamic styles:
* if **font-weight** value selected as **none**, it renders as **font-weight:0** and it causes invalid property.
* if **font-weight** value is false, empty or null, it's adds as **font-weight:0**.
 
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES (**! It's affecting lots of fonts in starter themes, we should discuss it.**)

### Screenshots <!-- if applicable -->
An example from 'Proceed to checkout' button
<img width="308" alt="Screen Shot 2021-05-07 at 13 32 02" src="https://user-images.githubusercontent.com/25361626/117443982-85f39400-af41-11eb-875a-095f9e99dc06.png">

### Test instructions
<!-- Describe how this pull request can be tested. -->
Test Case 1
- Fresh WP installation with Neve, Neve Pro, WC.
- Enable Stepped Checkout on Customizer
- Change **font-weight** value of **Secondary Button** on  **Customizer -> Buttons -> Secondary**
- Make sure if the font-weight change should not affect the 'Proceed to Order review' button style.

Test Case 2
- Enable Stepped Checkout on Customizer
- Set **font-weight** value of **Primary Button** as **none** on  **Customizer -> Buttons -> Primary**
- Change **font-weight** value of **Secondary Button** on  **Customizer -> Buttons -> Secondary**
- Make sure if the font-weight change of secondary button should not affect the 'Proceed to Order review' button style.

Test Case 3
- Set any **font-weight** value as **none** in customizer.
- It should be rendered as **font-weight:normal**

<!-- Issues that this pull request closes. -->
Closes #2834, codeinwp/neve-pro-addon#1111
<!-- Should look like this: `Closes #1, #2, #3.` . -->
