### PR TITLE
fix: editor text color not working as expected [closes #2824]

### DIFF
--- a/assets/scss/gutenberg-editor/_typography.scss
+++ b/assets/scss/gutenberg-editor/_typography.scss
@@ -53,17 +53,17 @@ h6 {
 	font-size: 16px;
 	font-weight: normal;
 	font-family: $default-font-family;
-	line-height: $line-height-base;
+  	color: var(--nv-text-color);
+  	line-height: $line-height-base;
 	text-transform: none;
 	letter-spacing: normal;
 
+	&.has-text-color .wp-block {
+	  color: inherit;
+	}
+
   	&.wp-block-group.has-background {
 	  padding: 0;
-	}
-	&:not(.wp-block-group.has-text-color){
-	  .wp-block{
-		color: var(--nv-text-color);
-	  }
 	}
 
   	&.components-placeholder {


### PR DESCRIPTION
### Summary
- Fixes issue where color inside the editor wasn't properly set;
- Fixes issue where group blocks/columns blocks / other blocks where you could set the color and has inner-blocks 
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/15010186/117650399-5212ab80-b199-11eb-923e-da06022bc017.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Change the text color inside the Customizer under Colors, inside the global colors;
- Create a new post and add content inside it;
- The text inside the editor should be inheriting the proper color. This is the main thing this PR is aimed to fix;
- Add a group block and some other blocks inside it;
- The blocks inside the group should be inheriting its text color;
- Same goes for the columns block. Anything inside it should inherit its color if that is set;

<!-- Issues that this pull request closes. -->
Closes #2824.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
