### PR TITLE
chore: fix post date styling inside widgets [closes #2582]

### DIFF
--- a/assets/scss/elements/_sidebar.scss
+++ b/assets/scss/elements/_sidebar.scss
@@ -63,6 +63,11 @@
     margin: 0;
     padding: 0;
   }
+  .post-date {
+	display: block;
+	font-size: .9em;
+	opacity: .7;
+  }
 }
 
 .widget ul {


### PR DESCRIPTION
### Summary
Changes post date style inside sidebar widgets according to #2582.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/15010186/117655929-5ee6cd80-b1a0-11eb-9cab-4279ca7da939.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add the recent posts widget and make sure to turn on the show post date option;
- The styling should look like in #2582

<!-- Issues that this pull request closes. -->
Closes #2582.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
