### PR TITLE
fix: font weights not getting properly enqueued when some font families are set to inherit

### DIFF
--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -31,7 +31,11 @@ class Font_Manager extends Base_View {
 	 */
 	final public static function add_google_font( $font_family, $font_weight = '400' ) {
 		if ( empty( $font_family ) ) {
-			return;
+			$body_font = get_theme_mod( 'neve_body_font_family' );
+			if ( empty( $body_font ) ) {
+				return;
+			}
+			$font_family = $body_font;
 		}
 		if ( ! in_array( $font_weight, [ '100', '200', '300', '400', '500', '600', '700', '800', '900' ], true ) ) {
 			$font_weight = '400';


### PR DESCRIPTION
### Summary
If a font family is set to inherit, but it uses font weights not shared by the body font, those are not enqueued outside the customizer.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Set the body font to a google font. `Inter` would work great.
- Set the heading font weights to 700;
- The font weights should work fine on the front end;

<!-- Issues that this pull request closes. -->
Closes #2843.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
