### PR TITLE
[do not merge] Refactor/select input arrow style

### DIFF
--- a/assets/scss/elements/form-elements/_inputs.scss
+++ b/assets/scss/elements/form-elements/_inputs.scss
@@ -53,6 +53,11 @@ input, textarea, select, button {
 
 select {
   min-height: 35px;
+  appearance: none;
+  -moz-appearance: none;
+  -webkit-appearance: none;
+  padding: 3px 48px 3px 10px;
+  background: no-repeat url('/wp-includes/images/down_arrow.gif') 95% 50%;
 }
 
 label {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The select input was redesigned to add padding between arrow and input border.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
#### Before the PR:
<img width="375" alt="Screen Shot 2021-05-11 at 18 49 12" src="https://user-images.githubusercontent.com/25361626/117846232-e9572c00-b289-11eb-8504-9aab2179f455.png">
<img width="368" alt="Screen Shot 2021-05-11 at 18 49 02" src="https://user-images.githubusercontent.com/25361626/117846239-ea885900-b289-11eb-936d-7ca1ba2b922f.png">

#### After the PR:
<img width="375" alt="Screen Shot 2021-05-11 at 18 52 29" src="https://user-images.githubusercontent.com/25361626/117846384-0e4b9f00-b28a-11eb-902d-9b434fa3f4ee.png">
<img width="366" alt="Screen Shot 2021-05-11 at 18 52 23" src="https://user-images.githubusercontent.com/25361626/117846389-0f7ccc00-b28a-11eb-9f4f-36dc85de436b.png">


### Test instructions
<!-- Describe how this pull request can be tested. -->
Note: The PR changes all **select inputs** in the theme scope.

* Select inputs should be tested on different browsers.

<!-- Issues that this pull request closes. -->
Closes #2580  .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
