### PR TITLE
fix: palette auto default to false and no customizer auto

### DIFF
--- a/header-footer-grid/Core/Components/PaletteSwitch.php
+++ b/header-footer-grid/Core/Components/PaletteSwitch.php
@@ -174,7 +174,7 @@ class PaletteSwitch extends Abstract_Component {
 		$default_light = 'base';
 		$default_dark  = 'darkMode';
 
-		$auto_adjust = Mods::get( $this->get_id() . '_' . self::AUTO_ADJUST, 1 );
+		$auto_adjust = Mods::get( $this->get_id() . '_' . self::AUTO_ADJUST, 0 );
 
 		$customizer       = Mods::get( 'neve_global_colors', neve_get_global_colors_default( true ) );
 		$defined_palettes = $customizer['palettes'];
@@ -199,7 +199,7 @@ class PaletteSwitch extends Abstract_Component {
 			$dark_css .= '--' . $slug . ':' . $color . ';';
 		}
 
-		if ( $auto_adjust ) {
+		if ( $auto_adjust && ! is_customize_preview() ) {
 			$css .= '
 				/* Light mode */
 				@media (prefers-color-scheme: light) {
@@ -362,9 +362,9 @@ class PaletteSwitch extends Abstract_Component {
 				'tab'                => SettingsManager::TAB_GENERAL,
 				'transport'          => 'refresh',
 				'sanitize_callback'  => 'absint',
-				'default'            => 1,
+				'default'            => 0,
 				'label'              => __( 'Automatically adjust color scheme', 'neve' ),
-				/* translators: %s: Link to Learn More page. TODO: add link  */
+				/* translators: %s: Link to Learn More page. */
 				'description'        => sprintf( __( 'Adjust default color scheme based on the user device preferences. %1$sLearn More%2$s.', 'neve' ), '<a target="_blank" rel="external noreferrer noopener" href="https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme">', '<span class="components-visually-hidden">(opens in a new tab)</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>' ),
 				'type'               => 'neve_toggle_control',
 				'section'            => $this->section,

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Automatically adjust color scheme"
 msgstr ""
 
-#. translators: %s: Link to Learn More page. TODO: add link
+#. translators: %s: Link to Learn More page.
 #: header-footer-grid/Core/Components/PaletteSwitch.php:368
 msgid "Adjust default color scheme based on the user device preferences. %1$sLearn More%2$s."
 msgstr ""


### PR DESCRIPTION
### Summary
Set the default for auto adjust color to `false`
Don't adjust the colors automatically inside customizer

### Will affect visual aspect of the product
NO

### Test instructions
When adding the palette switcher inside customizer the colors should not auto adjust even if the automatically adjust option is enabled. Only on the frontpage this should work as before.
