### PR TITLE
Fix/issue 2849

### DIFF
--- a/.github/workflows/pr_verify_linked_issue.yml
+++ b/.github/workflows/pr_verify_linked_issue.yml
@@ -5,7 +5,6 @@ on:
     types: [ edited, synchronize, opened, reopened ]
     branches:
       - development
-  check_run:
 
 jobs:
   verify_linked_issue:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+##### [Version 2.11.3](https://github.com/Codeinwp/neve/compare/v2.11.2...v2.11.3) (2021-05-12)
+
+- [Fix] Editor text color not working as expected
+- [Fix] Editor group block and columns block child blocks not inheriting text color
+- Restyle post date styling inside latest posts widget
+
 ##### [Version 2.11.2](https://github.com/Codeinwp/neve/compare/v2.11.1...v2.11.2) (2021-04-28)
 
 - [Fix] Dropdowns (input select) in specific widgets do not respect global form styles

--- a/assets/scss/main/_gutenberg.scss
+++ b/assets/scss/main/_gutenberg.scss
@@ -1,13 +1,13 @@
 //<editor-fold desc="Gutenberg alignments">
 
-#content .alignfull {
+.alignfull {
   width: 100vw;
   max-width: 100vw;
   margin-left: calc(50% - 50vw);
   padding: 0 15px;
 }
 
-#content .alignwide {
+.alignwide {
   width: 70vw;
   max-width: 70vw;
   margin-left: calc(50% - 35vw);
@@ -16,12 +16,10 @@
 body {
   &.nv-sidebar-left,
   &.nv-sidebar-right {
-	#content {
 	  .alignfull, .alignwide {
 		max-width: 100%;
 		margin-left: auto;
 	  }
-	}
   }
 }
 

--- a/assets/scss/main/_gutenberg.scss
+++ b/assets/scss/main/_gutenberg.scss
@@ -1,13 +1,13 @@
 //<editor-fold desc="Gutenberg alignments">
 
-.alignfull {
+#content .alignfull {
   width: 100vw;
   max-width: 100vw;
   margin-left: calc(50% - 50vw);
   padding: 0 15px;
 }
 
-.alignwide {
+#content .alignwide {
   width: 70vw;
   max-width: 70vw;
   margin-left: calc(50% - 35vw);
@@ -16,9 +16,11 @@
 body {
   &.nv-sidebar-left,
   &.nv-sidebar-right {
-	.alignfull, .alignwide {
-	  max-width: 100%;
-	  margin-left: auto;
+	#content {
+	  .alignfull, .alignwide {
+		max-width: 100%;
+		margin-left: auto;
+	  }
 	}
   }
 }

--- a/functions.php
+++ b/functions.php
@@ -8,7 +8,7 @@
  * @package Neve
  */
 
-define( 'NEVE_VERSION', '2.11.2' );
+define( 'NEVE_VERSION', '2.11.3' );
 define( 'NEVE_INC_DIR', trailingslashit( get_template_directory() ) . 'inc/' );
 define( 'NEVE_ASSETS_URL', trailingslashit( get_template_directory_uri() ) . 'assets/' );
 define( 'NEVE_MAIN_DIR', get_template_directory() . '/' );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "neve",
 	"nicename": "Neve",
-	"version": "2.11.2",
+	"version": "2.11.3",
 	"description": "Neve theme by ThemeIsle",
 	"category": "themes",
 	"author": "ThemeIsle <friends@themeisle.com>",

--- a/readme.md
+++ b/readme.md
@@ -19,6 +19,15 @@ Neve is distributed under the terms of the GNU GPLv2 or later
 
 ## Changelog ##
 
+##### [Version 2.11.3](https://github.com/Codeinwp/neve/compare/v2.11.2...v2.11.3) (2021-05-12)
+
+- [Fix] Editor text color not working as expected
+- [Fix] Editor group block and columns block child blocks not inheriting text color
+- Restyle post date styling inside latest posts widget
+
+
+
+
 ##### [Version 2.11.2](https://github.com/Codeinwp/neve/compare/v2.11.1...v2.11.2) (2021-04-28)
 
 - [Fix] Dropdowns (input select) in specific widgets do not respect global form styles  - https://github.com/Codeinwp/neve/issues/2581

--- a/readme.txt
+++ b/readme.txt
@@ -19,6 +19,15 @@ Neve is distributed under the terms of the GNU GPLv2 or later
 
 == Changelog ==
 
+##### [Version 2.11.3](https://github.com/Codeinwp/neve/compare/v2.11.2...v2.11.3) (2021-05-12)
+
+- [Fix] Editor text color not working as expected
+- [Fix] Editor group block and columns block child blocks not inheriting text color
+- Restyle post date styling inside latest posts widget
+
+
+
+
 ##### [Version 2.11.2](https://github.com/Codeinwp/neve/compare/v2.11.1...v2.11.2) (2021-04-28)
 
 - [Fix] Dropdowns (input select) in specific widgets do not respect global form styles  - https://github.com/Codeinwp/neve/issues/2581

--- a/style.css
+++ b/style.css
@@ -6,7 +6,7 @@ Author URI:     https://themeisle.com
 Tested up to:   5.6
 Requires PHP:   5.4.0
 Description:    Neve is a super fast, easily customizable, multi-purpose theme. It’s perfect for blogs, small business, startups, agencies, firms, e-commerce shops (WooCommerce storefront) as well as personal portfolio sites and most types of projects. A fully AMP optimized and responsive theme, Neve will load in mere seconds and adapt perfectly on any viewing device. While it is lightweight and has a minimalist design, the theme is highly extendable, it has a highly SEO optimized code, resulting in top rankings in Google search results. Neve works perfectly with Gutenberg and the most popular page builders (Elementor, Brizy, Beaver Builder, Visual Composer, SiteOrigin, Divi). Neve is also WooCommerce ready, responsive, RTL & translation ready. Look no further. Neve is the perfect theme for you!
-Version:        2.11.2
+Version:        2.11.3
 License:        GNU General Public License v2 or later
 License URI:    http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain:    neve


### PR DESCRIPTION
### Summary
Revert accidental commit which tried to fix the alignment issue on alignwide/alignful classes on latest Gutenberg plugin version. 
### Will affect visual aspect of the product
No


### Test instructions
When trying to work on [this](  https://github.com/Codeinwp/neve/issues/2794 ) I accidentally pushed the change on main branch using a workflow update in this [commit](https://github.com/Codeinwp/neve/commit/5a75dc9c8c18e5f29c2f01d98ec495e51b01f6f1) which should have not contain the CSS change. 

Due to this the most recent release included this change and broke some alignment issues on some starter sites.

Closes #2849 
