### PR TITLE
Fix/bug 2793

### DIFF
--- a/dashboard/inc/Changelog_Handler.php
+++ b/dashboard/inc/Changelog_Handler.php
@@ -68,14 +68,14 @@ class Changelog_Handler {
 				);
 				continue;
 			}
-			if ( preg_match( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', $changelog_line ) ) {
-				$changelog_line                        = preg_replace( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?\b/', '', $changelog_line );
+			if ( preg_match( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?(\b|(?=\[))/', $changelog_line ) ) {
+				$changelog_line                        = preg_replace( '/[*|-]?\s?(\[fix]|\[Fix]|fix|Fix)[:]?\s?(\b|(?=\[))/', '', $changelog_line );
 				$releases[ $release_count ]['fixes'][] = $this->parse_md_and_clean( $changelog_line );
 				continue;
 			}
 
-			if ( preg_match( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', $changelog_line ) ) {
-				$changelog_line                           = preg_replace( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?\b/', '', $changelog_line );
+			if ( preg_match( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?(\b|(?=\[))/', $changelog_line ) ) {
+				$changelog_line                           = preg_replace( '/[*|-]?\s?(\[feat]|\[Feat]|feat|Feat)[:]?\s?(\b|(?=\[))/', '', $changelog_line );
 				$releases[ $release_count ]['features'][] = $this->parse_md_and_clean( $changelog_line );
 				continue;
 			}

--- a/dashboard/inc/Changelog_Handler.php
+++ b/dashboard/inc/Changelog_Handler.php
@@ -106,7 +106,7 @@ class Changelog_Handler {
 		$string = preg_replace_callback(
 			'/\[(.*?)]\((.*?)\)/',
 			function ( $matches ) {
-				return '<a href="' . $matches[2] . '"><i class="dashicons dashicons-external"></i>' . $matches[1] . '</a>';
+				return '<a href="' . $matches[2] . '" target="_blank" rel="noopener"><i class="dashicons dashicons-external"></i>' . $matches[1] . '</a>';
 			},
 			htmlspecialchars( $string )
 		);


### PR DESCRIPTION
### Summary
Changed the regex to account for `[` as a followup to `[Fix|Feat]` instead of only a word boundary `/b`

### Will affect visual aspect of the product
NO

![image](https://user-images.githubusercontent.com/23024731/119646284-aa97a900-be27-11eb-92b3-d289fa301b01.png)


### Test instructions
Use this line inside the CHANGELOG.md
```
- [Fix] [Color Picker Modal remains open even after switching Color Palettes](https://github.com/Codeinwp/neve/issues/2628)
```
Check that is being parsed correctly

Closes #2793
