### PR TITLE
Independent Elementor WooCommerce Templates

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -298,7 +298,7 @@ class Elementor extends Page_Builder_Base {
 	 * @param  string $cond Template showing condition it can be product_archive, product etc.
 	 * @return bool
 	 */
-	public function is_elementor_template( $location, $cond ) {
+	public static function is_elementor_template( $location, $cond ) {
 		if ( ! did_action( 'elementor_pro/init' ) ) {
 			return false;
 		}

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -292,7 +292,7 @@ class Elementor extends Page_Builder_Base {
 	}
 	
 	/**
-	 * Is the page has an elementor template
+	 * Is the current page has an elementor template
 	 *
 	 * @param  string $location that location of the template such as single, archive etc.
 	 * @param  string $cond Template showing condition it can be product_archive, product etc.

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -290,4 +290,28 @@ class Elementor extends Page_Builder_Base {
 	private function get_global_color_prefix() {
 		return ( apply_filters( 'ti_wl_theme_is_localized', false ) ? __( 'Theme', 'neve' ) : 'Neve' ) . ' - ';
 	}
+	
+	/**
+	 * Check if there is an elementor template for shop.
+	 */
+	public function is_elementor_template( $location, $cond ) {
+		if ( ! did_action( 'elementor_pro/init' ) ) {
+			return false;
+		}
+		if ( ! class_exists( '\ElementorPro\Plugin', false ) ) {
+			return false;
+		}
+		
+		$conditions_manager = \ElementorPro\Plugin::instance()->modules_manager->get_modules( 'theme-builder' )->get_conditions_manager();
+		$documents          = $conditions_manager->get_documents_for_location( $location );
+		foreach ( $documents as $document ) {
+			$conditions = $conditions_manager->get_document_conditions( $document );
+			foreach ( $conditions as $condition ) {
+				if ( 'include' === $condition['type'] && $cond === $condition['name'] ) {
+					return true;
+				}
+			}
+		}
+		return false;
+	}
 }

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -296,10 +296,9 @@ class Elementor extends Page_Builder_Base {
 	 *
 	 * @param  string $location that location of the template such as single, archive etc.
 	 * @param  string $cond Template showing condition it can be product_archive, product etc.
-	 * @param  int    $post_id Optional. The parameter uses to check if the specific page has an elementor template. If this parameter is not used, the method returns value of the current page.
 	 * @return bool
 	 */
-	public function is_elementor_template( $location, $cond, $post_id = 0 ) {
+	public function is_elementor_template( $location, $cond ) {
 		if ( ! did_action( 'elementor_pro/init' ) ) {
 			return false;
 		}
@@ -308,19 +307,7 @@ class Elementor extends Page_Builder_Base {
 		}
 		$conditions_manager = \ElementorPro\Plugin::instance()->modules_manager->get_modules( 'theme-builder' )->get_conditions_manager();
 
-		// to manipulate get_the_ID usage of get_documents_for_location method (to check if specific page has an elementor template)
-		if ( $post_id ) {
-			global $post;
-			$original_post_id = $post->ID;
-			$post->ID         = $post_id;
-		}
-
 		$documents = $conditions_manager->get_documents_for_location( $location );
-
-		// revert the post ID to original value
-		if ( $post_id ) {
-			$post->ID = $original_post_id;
-		}
 
 		foreach ( $documents as $document ) {
 			$conditions = $conditions_manager->get_document_conditions( $document );

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -327,6 +327,7 @@ class Elementor extends Page_Builder_Base {
 	 * @return array that contains post IDs.
 	 */
 	private function get_elementor_template_post_ids( $template_type ) {
+		// TODO: find an alternative way to check the site has Elementor template [it should be work on customizer side]
 		$args = array(
 			'fields'      => 'ids',
 			'post_type'   => 'elementor_library',

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -292,18 +292,36 @@ class Elementor extends Page_Builder_Base {
 	}
 	
 	/**
-	 * Check if there is an elementor template for shop.
+	 * Is the page has an elementor template
+	 *
+	 * @param  string $location that location of the template such as single, archive etc.
+	 * @param  string $cond Template showing condition it can be product_archive, product etc.
+	 * @param  int    $post_id Optional. The parameter uses to check if the specific page has an elementor template. If this parameter is not used, the method returns value of the current page.
+	 * @return bool
 	 */
-	public function is_elementor_template( $location, $cond ) {
+	public function is_elementor_template( $location, $cond, $post_id = 0 ) {
 		if ( ! did_action( 'elementor_pro/init' ) ) {
 			return false;
 		}
 		if ( ! class_exists( '\ElementorPro\Plugin', false ) ) {
 			return false;
 		}
-		
 		$conditions_manager = \ElementorPro\Plugin::instance()->modules_manager->get_modules( 'theme-builder' )->get_conditions_manager();
-		$documents          = $conditions_manager->get_documents_for_location( $location );
+
+		// to manipulate get_the_ID usage of get_documents_for_location method (to check if specific page has an elementor template)
+		if ( $post_id ) {
+			global $post;
+			$original_post_id = $post->ID;
+			$post->ID         = $post_id;
+		}
+
+		$documents = $conditions_manager->get_documents_for_location( $location );
+
+		// revert the post ID to original value
+		if ( $post_id ) {
+			$post->ID = $original_post_id;
+		}
+
 		foreach ( $documents as $document ) {
 			$conditions = $conditions_manager->get_document_conditions( $document );
 			foreach ( $conditions as $condition ) {

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -373,19 +373,13 @@ class Elementor extends Page_Builder_Base {
 
 		$query = new \WP_Query( $args );
 
-		if ( $query->posts ) {
-			foreach ( $query->posts as $post_id ) {
-				$conditions = get_post_meta( $post_id, '_elementor_conditions', true );
-
-				// if have any condition (not specific condition such as category etc.)
-				if ( $conditions ) {
-					set_transient( $transient_key, 1, $transient_expiry_sec );
-					return true;
-				}
-			}   
+		// if elementor template not found
+		if ( empty( $query->posts ) ) {
+			set_transient( $transient_key, 0, $transient_expiry_sec );
+			return false;
 		}
 
-		set_transient( $transient_key, 0, $transient_expiry_sec );
-		return false;
+		set_transient( $transient_key, 1, $transient_expiry_sec );
+		return true;
 	}
 }

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -326,7 +326,7 @@ class Elementor extends Page_Builder_Base {
 	 * @param  string $template_type such as product-archive.
 	 * @return array that contains post IDs.
 	 */
-	private function get_elementor_template_post_ids( $template_type ) {
+	private static function get_elementor_template_post_ids( $template_type ) {
 		// TODO: find an alternative way to check the site has Elementor template, this method can be slow. [it should be work on customizer side]
 		$args = array(
 			'fields'      => 'ids',
@@ -352,8 +352,8 @@ class Elementor extends Page_Builder_Base {
 	 * @param  string $elementor_template_type that is template type such as page,product-archive,product,kit etc.
 	 * @return bool
 	 */
-	public function has_template( $elementor_template_type ) {
-		$template_ids = $this->get_elementor_template_post_ids( $elementor_template_type );
+	public static function has_template( $elementor_template_type ) {
+		$template_ids = self::get_elementor_template_post_ids( $elementor_template_type );
 
 		// check if there is a condition to show in products
 		foreach ( $template_ids as $template_id ) {

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -327,7 +327,7 @@ class Elementor extends Page_Builder_Base {
 	 * @return array that contains post IDs.
 	 */
 	private function get_elementor_template_post_ids( $template_type ) {
-		// TODO: find an alternative way to check the site has Elementor template [it should be work on customizer side]
+		// TODO: find an alternative way to check the site has Elementor template, this method can be slow. [it should be work on customizer side]
 		$args = array(
 			'fields'      => 'ids',
 			'post_type'   => 'elementor_library',

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -319,4 +319,51 @@ class Elementor extends Page_Builder_Base {
 		}
 		return false;
 	}
+	
+	/**
+	 * Get post IDs of elementor templates.
+	 *
+	 * @param  string $template_type such as product-archive.
+	 * @return array that contains post IDs.
+	 */
+	private function get_elementor_template_post_ids( $template_type ) {
+		$args = array(
+			'fields'      => 'ids',
+			'post_type'   => 'elementor_library',
+			'post_status' => 'publish',
+			// phpcs:disable
+			'meta_query'  => array(
+				array(
+					'key'   => '_elementor_template_type',
+					'value' => $template_type,
+				),
+			),
+			// phpcs:enable
+		);
+
+		// return template post ids.
+		return get_posts( $args );
+	}
+		
+	/**
+	 * Has Elementor template? The method checks if the site has specific Elementor template by template name.
+	 *
+	 * @param  string $elementor_template_type that is template type such as page,product-archive,product,kit etc.
+	 * @return bool
+	 */
+	public function has_template( $elementor_template_type ) {
+		$template_ids = $this->get_elementor_template_post_ids( $elementor_template_type );
+
+		// check if there is a condition to show in products
+		foreach ( $template_ids as $template_id ) {
+			$conditions = get_post_meta( $template_id, '_elementor_conditions', true );
+
+			// if have any condition (not specific condition such as category etc.)
+			if ( $conditions ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
 }

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -110,7 +110,7 @@ class Woocommerce {
 	 */
 	public function add_customizer_options( $options ) {
 		$options['elementor']['hasElementorShopTemplate']    = Elementor::has_template( 'product-archive' );
-		$options['elementor']['hasElementorProductTemplate'] = (bool) Elementor::has_template( 'product' );
+		$options['elementor']['hasElementorProductTemplate'] = Elementor::has_template( 'product' );
 		return $options;
 	}
 	

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -111,8 +111,8 @@ class Woocommerce {
 			return false;
 		}
 
-		$is_shop_template    = ( new Elementor() )->is_elementor_template( 'archive', 'product_archive' );
-		$is_product_template = ( new Elementor() )->is_elementor_template( 'single', 'product' );
+		$is_shop_template    = Elementor::is_elementor_template( 'archive', 'product_archive' );
+		$is_product_template = Elementor::is_elementor_template( 'single', 'product' );
 
 		return ! ( $is_shop_template || $is_product_template );
 	}

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -99,6 +99,19 @@ class Woocommerce {
 	 */
 	public function init() {
 		add_action( 'wp', array( $this, 'register_hooks' ), 11 );
+		add_action( 'neve_react_controls_localization', array( $this, 'add_customizer_options' ) );
+	}
+	
+	/**
+	 * Add params to specify if the site has elementor templates.
+	 *
+	 * @param  array $options current options.
+	 * @return array
+	 */
+	public function add_customizer_options( $options ) {
+		$options['elementor']['hasElementorShopTemplate']    = Elementor::has_template( 'product-archive' );
+		$options['elementor']['hasElementorProductTemplate'] = (bool) Elementor::has_template( 'product' );
+		return $options;
 	}
 	
 	/**

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -98,11 +98,36 @@ class Woocommerce {
 	 * Initialize the module.
 	 */
 	public function init() {
+		add_action( 'wp', array( $this, 'register_hooks' ), 11 );
+	}
+	
+	/**
+	 * Should module load?
+	 *
+	 * @return bool
+	 */
+	public function should_load() {
 		if ( ! class_exists( 'WooCommerce', false ) ) {
+			return false;
+		}
+
+		$is_shop_template    = ( new Elementor() )->is_elementor_template( 'archive', 'product_archive' );
+		$is_product_template = ( new Elementor() )->is_elementor_template( 'single', 'product' );
+
+		return ! ( $is_shop_template || $is_product_template );
+	}
+	
+	/**
+	 * Register hooks
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		if ( ! $this->should_load() ) {
 			return;
 		}
-		$this->sidebar_manager = new Layout_Sidebar();
 
+		$this->sidebar_manager = new Layout_Sidebar();
 
 		add_action( 'admin_init', array( $this, 'set_update_woo_width_flag' ), 9 );
 		add_action( 'admin_footer', array( $this, 'update_woo_width' ) );

--- a/inc/customizer/controls/react/src/controls.js
+++ b/inc/customizer/controls/react/src/controls.js
@@ -78,6 +78,38 @@ const initBlogPageFocus = () => {
 	});
 };
 
+const checkHasElementorTemplates = () => {
+	if (NeveReactCustomize.elementor.hasElementorShopTemplate) {
+		window.wp.customize
+			.section('woocommerce_product_catalog')
+			.notifications.add(
+				new window.wp.customize.Notification(
+					'neve-custom-elementor-shop-template',
+					{
+						type: 'warning',
+						message:
+							'Some of the settings might not work as expected because you are using a custom shop template made in Elementor.',
+					}
+				)
+			);
+	}
+
+	if (NeveReactCustomize.elementor.hasElementorProductTemplate) {
+		window.wp.customize
+			.section('neve_single_product_layout')
+			.notifications.add(
+				new window.wp.customize.Notification(
+					'neve-custom-elementor-product-template',
+					{
+						type: 'warning',
+						message:
+							'Some of the settings might not work as expected because you are using a custom product template made in Elementor.',
+					}
+				)
+			);
+	}
+};
+
 domReady(() => {
 	initDeviceSwitchers();
 	initBlogPageFocus();
@@ -85,6 +117,7 @@ domReady(() => {
 
 wp.customize.bind('ready', () => {
 	initDynamicFields();
+	checkHasElementorTemplates();
 });
 
 window.HFG = {

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1270,7 +1270,7 @@ msgctxt "Theme starter content"
 msgid "Blog"
 msgstr ""
 
-#: inc/compatibility/woocommerce.php:367
+#: inc/compatibility/woocommerce.php:380
 msgid "Filter"
 msgstr ""
 

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -318,7 +318,7 @@ msgstr ""
 #: header-footer-grid/Core/Components/Copyright.php:84
 #: header-footer-grid/Core/Components/CustomHtml.php:163
 #: header-footer-grid/Core/Components/Logo.php:205
-#: inc/compatibility/elementor.php:116
+#: inc/compatibility/elementor.php:117
 #: inc/core/front_end.php:115
 #: inc/customizer/options/layout_blog.php:183
 #: inc/customizer/controls/react/src/common/common.js:77
@@ -1175,55 +1175,55 @@ msgstr ""
 msgid "Two columns with text"
 msgstr ""
 
-#: inc/compatibility/elementor.php:111
+#: inc/compatibility/elementor.php:112
 #: inc/core/front_end.php:95
 #: inc/customizer/controls/react/src/common/common.js:72
 msgid "Primary Accent"
 msgstr ""
 
-#: inc/compatibility/elementor.php:112
+#: inc/compatibility/elementor.php:113
 #: inc/core/front_end.php:99
 #: inc/customizer/controls/react/src/common/common.js:73
 msgid "Secondary Accent"
 msgstr ""
 
-#: inc/compatibility/elementor.php:113
+#: inc/compatibility/elementor.php:114
 #: inc/core/front_end.php:103
 #: inc/customizer/controls/react/src/common/common.js:74
 msgid "Site Background"
 msgstr ""
 
-#: inc/compatibility/elementor.php:114
+#: inc/compatibility/elementor.php:115
 #: inc/core/front_end.php:107
 #: inc/customizer/controls/react/src/common/common.js:75
 msgid "Light Background"
 msgstr ""
 
-#: inc/compatibility/elementor.php:115
+#: inc/compatibility/elementor.php:116
 #: inc/core/front_end.php:111
 #: inc/customizer/controls/react/src/common/common.js:76
 msgid "Dark Background"
 msgstr ""
 
-#: inc/compatibility/elementor.php:117
+#: inc/compatibility/elementor.php:118
 #: inc/core/front_end.php:119
 #: inc/customizer/controls/react/src/common/common.js:78
 msgid "Text Dark Background"
 msgstr ""
 
-#: inc/compatibility/elementor.php:118
+#: inc/compatibility/elementor.php:119
 #: inc/core/front_end.php:123
 #: inc/customizer/controls/react/src/common/common.js:79
 msgid "Extra Color 1"
 msgstr ""
 
-#: inc/compatibility/elementor.php:119
+#: inc/compatibility/elementor.php:120
 #: inc/core/front_end.php:127
 #: inc/customizer/controls/react/src/common/common.js:80
 msgid "Extra Color 2"
 msgstr ""
 
-#: inc/compatibility/elementor.php:291
+#: inc/compatibility/elementor.php:292
 #: inc/core/front_end.php:90
 msgid "Theme"
 msgstr ""

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1270,7 +1270,7 @@ msgctxt "Theme starter content"
 msgid "Blog"
 msgstr ""
 
-#: inc/compatibility/woocommerce.php:342
+#: inc/compatibility/woocommerce.php:367
 msgid "Filter"
 msgstr ""
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Currently, if there are custom Elementor Woo Template ( shop or single product ), they don't work like expected. Neve dynamic styles and customizations are affecting to the user's custom Elementor Templates.

With this PR, we left users free about their custom WooCommerce Elementor Templates.

**How is working?**
If user has an custom Elementor shop or single product template, our custom Elementor class is bypassed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![Screen Shot 2021-06-07 at 10 17 20](https://user-images.githubusercontent.com/25361626/120975140-92a21c80-c779-11eb-8036-4345c51836d8.png)
![Screen Shot 2021-06-07 at 10 17 09](https://user-images.githubusercontent.com/25361626/120975145-946be000-c779-11eb-98e3-1499ffdfbdee.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install Neve, WooCommerce, Elementor, Elementor Pro
2. Create a new **Products Archive** Elementor template on WP Admin -> templates. When publish the template, set a condition for "all product archives"
3. Create a new **Single Product** Elementor template on WP Admin -> templates. When publish, set a condition for "Products"


### Test Cases
- If user has custom Elementor products archive page; Neve's catalog page customizations should not affect the user's shop page AND customizer -> WooCommerce -> Product catalog should contains a notice like that: _"Some of the settings might not work as expected because you are using a custom shop template made in Elementor."_
- If user has custom Elementor single product page, Neve's single product page customizations should not affect the user's single product page and customizer -> WooCommerce -> Single Product should contains a notice like that:  _"Some of the settings might not work as expected because you are using a custom product template made in Elementor."_
- Be sure Elementor widget options work well such as "Allow Order (in archive widget)". As summary, be sure fixed of #2775 
- Custom Elementor Shop Template should look well. Please compare template look with other themes. User should able control all template options on Elementor.
- Custom Elementor Single Product Template should look well. Please compare template look with other themes. User should able control all template options on Elementor.

<!-- Issues that this pull request closes. -->
Closes #2894,#2858,#2775.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
