### PR TITLE
fix: sidebar behaviour #2838

### DIFF
--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -117,7 +117,7 @@ class Metabox_Settings {
 			! is_single() &&
 			! is_page() &&
 			! $this->is_blog_static() &&
-			( class_exists( 'WooCommerce', false ) && ! is_shop() )
+			$this->is_not_woo_shop()
 		) {
 			return false;
 		}
@@ -395,6 +395,18 @@ class Metabox_Settings {
 	}
 
 	/**
+	 * If WooCommerce does not exist or if ir exists and page is not shop
+	 * This also touches the following issues:
+	 * Codeinwp/neve-pro-addon/issues/999
+	 * Codeinwp/neve/issues/2790
+	 *
+	 * @return bool
+	 */
+	private function is_not_woo_shop() {
+		return ( ! class_exists( 'WooCommerce', false ) || ( class_exists( 'WooCommerce', false ) && ! is_shop() ) );
+	}
+
+	/**
 	 * Change sidebar position based on meta.
 	 *
 	 * @param string $position sidebar position coming from filter.
@@ -403,10 +415,11 @@ class Metabox_Settings {
 	 */
 	public function filter_sidebar_position( $position ) {
 		if (
-			! is_single()
-			&& ! is_page()
-			&& ( class_exists( 'WooCommerce', false ) && ! is_shop() )
-			&& ! $this->is_blog_static() ) {
+			! is_single() &&
+			! is_page() &&
+			! $this->is_blog_static() &&
+			$this->is_not_woo_shop()
+		) {
 			return $position;
 		}
 
@@ -437,8 +450,8 @@ class Metabox_Settings {
 		if (
 			! is_single() &&
 			! is_page() &&
-			! $this->is_blog_static()
-			&& ( class_exists( 'WooCommerce', false ) && ! is_shop() )
+			! $this->is_blog_static() &&
+			$this->is_not_woo_shop()
 		) {
 			return $class;
 		}


### PR DESCRIPTION
### Summary
Modified the check for the sidebar so that it does not conflict with the individual post settings

### Will affect visual aspect of the product
NO

### Test instructions
1. In Customizer set both single post and blog/archive pages to have sidebars https://vertis.d.pr/5cifRE
2. Create some test categories and assign a post or multiple posts to that test category.
3. Then, disable sidebar for that post(-s) assigned to a category manually with Neve options
4. Open the archive/category page of those posts - you should see that sidebar rendered on the category/archive page

### Regression testing
This changes might affect the following issues also:

Codeinwp/neve-pro-addon#999
For this one check that the header on the Shop page is still hidden if `Disable Header` is enabled:
![image](https://user-images.githubusercontent.com/23024731/120783629-e1f70b80-c533-11eb-9db6-27de7161d877.png)

I tested this and it should work as before.

Codeinwp/neve#2790
For this one I would need some help from @selul on how this can be tested.

Closes #2838.
