### PR TITLE
Fix/bug 2585

### DIFF
--- a/assets/js/src/frontend/blog.js
+++ b/assets/js/src/frontend/blog.js
@@ -1,5 +1,5 @@
 /* global NeveProperties,_wpCustomizeSettings,parent,Masonry,imagesLoaded */
-import { httpGetAsync, isInView } from '../utils';
+import { httpGetAsync, isInView, addEvent, neveEach } from '../utils';
 
 let masonryContainer = null,
 	page = 2;
@@ -50,6 +50,34 @@ const infiniteScroll = () => {
 
 	if (document.querySelector(postWrapSelector) === null) {
 		return;
+	}
+
+	if ('scrollRestoration' in window.history) {
+		const lsNamespace = 'neveInfiniteScrollPos';
+		const body = document.querySelector('body');
+		const getScrollPos = function () {
+			return document.documentElement.scrollTop;
+		};
+		const savedScrollPos = window.localStorage.getItem(lsNamespace);
+		window.history.scrollRestoration = 'manual';
+		const scrollInterval = setInterval(function () {
+			window.scrollTo({ top: savedScrollPos });
+			const currentScrollPos = getScrollPos();
+			if (currentScrollPos >= savedScrollPos) {
+				window.localStorage.removeItem(lsNamespace);
+				clearInterval(scrollInterval);
+			}
+		}, 15);
+		const onPostClick = function (event) {
+			const elements = document.querySelectorAll('a[rel="bookmark"]');
+			neveEach(elements, function (item) {
+				if (item === event.target) {
+					const currentScrollPos = getScrollPos();
+					window.localStorage.setItem(lsNamespace, currentScrollPos);
+				}
+			});
+		};
+		addEvent(body, 'click', onPostClick);
 	}
 
 	isInView(document.querySelector('.infinite-scroll-trigger'), () => {

--- a/e2e-tests/cypress/integration/editor/modern/page-meta-sidebar.spec.ts
+++ b/e2e-tests/cypress/integration/editor/modern/page-meta-sidebar.spec.ts
@@ -40,7 +40,7 @@ describe('Single page sidebar', function () {
 		cy.get('.nv-content-wrap').should('contain', pageSetup.content);
 	});
 
-	it.only('Check sidebar layout', function () {
+	it('Check sidebar layout', function () {
 		cy.loginWithRequest(pageSetup.url);
 		const pageId = window.localStorage.getItem('pageId');
 		cy.clearWelcome();

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		{
 			"gzip": false,
 			"running": false,
-			"limit": "6 KB",
+			"limit": "6.6 KB",
 			"path": "assets/js/build/modern/frontend.js"
 		},
 		{
@@ -47,7 +47,7 @@
 		{
 			"gzip": false,
 			"running": false,
-			"limit": "6.5 KB",
+			"limit": "6.7 KB",
 			"path": "assets/js/build/all/frontend.js"
 		},
 		{

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		{
 			"gzip": false,
 			"running": false,
-			"limit": "6.6 KB",
+			"limit": "6 KB",
 			"path": "assets/js/build/modern/frontend.js"
 		},
 		{
@@ -47,7 +47,7 @@
 		{
 			"gzip": false,
 			"running": false,
-			"limit": "6.7 KB",
+			"limit": "6.5 KB",
 			"path": "assets/js/build/all/frontend.js"
 		},
 		{


### PR DESCRIPTION
### Summary
Fixed back behavior on infinite scroll for chromium browsers.
It now stores the scroll position and will scroll back to that position if the browser uses `history.scrollRestoration` introduced by Chrome.

Firefox and other browsers should not be affected.

### Will affect visual aspect of the product
NO

### Test instructions
1. Activate the infinite scroll with Enable Masonry -> On Chrome
2. Go to the blog page, click on a post
3. Click on the back button
4. This should bring you back at the post you were looking at, previously it was scrolling top

### Additional Notes:
I had to increase the size limit for the compiled frontend scripts.
I could not reduce the size further the minimum I can bring this changes at is `6.55 kb` for the `modern` version and `6.66 kb` for the `all` version

Closes #2585.
