### PR TITLE
fix: dropdown calculation

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -109,6 +109,7 @@ window.addEventListener('load', function () {
 		if (e.detail.partial_id === 'hfg_header_layout_partial') {
 			window.HFG.init();
 			window.HFG.initSearch();
+			repositionDropdowns();
 			return false;
 		}
 		if (e.detail.partial_id === 'primary-menu_partial') {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -45,22 +45,55 @@ export const repositionDropdowns = () => {
 
 	const windowWidth = window.innerWidth;
 	neveEach(dropDowns, (dropDown) => {
-		const bounding = dropDown.getBoundingClientRect(),
-			rightDist = bounding.left;
+		dropDown.style.right = '';
+		dropDown.style.left = '';
+		// const bounding = dropDown.getBoundingClientRect(),
+		// 	rightDist = bounding.left;
 
-		if (rightDist < 0) {
-			left = isRTL ? 'auto' : 0;
-			right = isRTL ? '-100%' : 'auto';
-			dropDown.style.right = right;
-			dropDown.style.left = left;
+		let count = 0;
+		let add = 0;
+		let newBounding = dropDown.getBoundingClientRect();
+		while (newBounding.left < 0 || newBounding.right > windowWidth) {
+			if (count > 50) {
+				// if we can not determine a proper position by the middle of the viewport abort
+				break;
+			}
+
+			if (newBounding.left < 0) {
+				left = isRTL ? 'auto' : 'calc( 0% - ' + add + 'vw )';
+				right = isRTL ? 'calc( -100% + ' + add + 'vw )' : 'auto';
+				dropDown.style.right = right;
+				dropDown.style.left = left;
+			}
+			newBounding = dropDown.getBoundingClientRect();
+
+			if (newBounding.left + newBounding.width >= windowWidth) {
+				right = isRTL ? 0 : 'calc( 100% - ' + add + 'vw )';
+				left = 'auto';
+				dropDown.style.right = right;
+				dropDown.style.left = left;
+			}
+
+			newBounding = dropDown.getBoundingClientRect();
+			count++;
+			add++;
 		}
 
-		if (rightDist + bounding.width >= windowWidth) {
-			right = isRTL ? 0 : '100%';
-			left = 'auto';
-			dropDown.style.right = right;
-			dropDown.style.left = left;
-		}
+		// if (rightDist < 0) {
+		// 	left = isRTL ? 'auto' : 0;
+		// 	right = isRTL ? '-100%' : 'auto';
+		// 	dropDown.style.right = right;
+		// 	dropDown.style.left = left;
+		// }
+		//
+		// if (rightDist + bounding.width >= windowWidth) {
+		// 	right = isRTL ? 0 : '100%';
+		// 	left = 'auto';
+		// 	dropDown.style.right = right;
+		// 	dropDown.style.left = left;
+		// }
+		// let newBounding = dropDown.getBoundingClientRect();
+		// console.log( newBounding );
 	});
 };
 

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -71,7 +71,7 @@ export const repositionDropdowns = () => {
 		) {
 			dropDown.style.left = 'auto';
 			dropDown.style.right =
-				'calc( 100% - ' + bounding.width / 2 + 'px )';
+				'calc( 100% - ' + ( windowWidth - parentBounding.right + ( parentBounding.width/2 ) ) + 'px )';
 		}
 	});
 };

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -46,14 +46,23 @@ export const repositionDropdowns = () => {
 	neveEach(dropDowns, (dropDown) => {
 		const bounding = dropDown.getBoundingClientRect();
 		const parentBounding = dropDown.parentElement.getBoundingClientRect();
+		dropDown.style.left = isRTL ? 'auto' : '0';
+		dropDown.style.right = isRTL ? '0' : 'auto';
+		const secondHalf = isRTL
+			? parentBounding.left < windowWidth / 2
+			: parentBounding.left > windowWidth / 2;
+		if (secondHalf) {
+			dropDown.style.left = isRTL ? '0' : 'auto';
+			dropDown.style.right = isRTL ? 'auto' : '0';
+		}
 
 		if (bounding.left < 0) {
-			dropDown.style.left = isRTL ? '0' : '100%';
+			dropDown.style.left = '0';
 			dropDown.style.right = 'auto';
 		}
 		if (parentBounding.left + bounding.width >= windowWidth) {
 			dropDown.style.left = 'auto';
-			dropDown.style.right = '-100%';
+			dropDown.style.right = '0';
 		}
 
 		if (

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -36,45 +36,33 @@ export const initNavigation = () => {
  */
 export const repositionDropdowns = () => {
 	const { isRTL } = NeveProperties;
-	let left, right;
 	const dropDowns = document.querySelectorAll(
-		'.sub-menu, .minimal .nv-nav-search'
+		'.neve-mega-menu > .sub-menu, .minimal .nv-nav-search'
 	);
 
 	if (dropDowns.length === 0) return;
 
 	const windowWidth = window.innerWidth;
 	neveEach(dropDowns, (dropDown) => {
-		dropDown.style.right = '';
-		dropDown.style.left = '';
+		const bounding = dropDown.getBoundingClientRect();
+		const parentBounding = dropDown.parentElement.getBoundingClientRect();
 
-		let count = 0;
-		let add = 0;
-		let newBounding = dropDown.getBoundingClientRect();
-		while (newBounding.left < 0 || newBounding.right > windowWidth) {
-			if (count > 50) {
-				// if we can not determine a proper position by the middle of the viewport abort
-				break;
-			}
+		if (bounding.left < 0) {
+			dropDown.style.left = isRTL ? '0' : '100%';
+			dropDown.style.right = 'auto';
+		}
+		if (parentBounding.left + bounding.width >= windowWidth) {
+			dropDown.style.left = 'auto';
+			dropDown.style.right = '-100%';
+		}
 
-			if (newBounding.left < 0) {
-				left = isRTL ? 'auto' : 'calc( 0% - ' + add + 'vw )';
-				right = isRTL ? 'calc( -100% + ' + add + 'vw )' : 'auto';
-				dropDown.style.right = right;
-				dropDown.style.left = left;
-			}
-			newBounding = dropDown.getBoundingClientRect();
-
-			if (newBounding.left + newBounding.width >= windowWidth) {
-				right = isRTL ? 0 : 'calc( 100% - ' + add + 'vw )';
-				left = 'auto';
-				dropDown.style.right = right;
-				dropDown.style.left = left;
-			}
-
-			newBounding = dropDown.getBoundingClientRect();
-			count++;
-			add++;
+		if (
+			parentBounding.left - bounding.width < 0 &&
+			parentBounding.left + bounding.width >= windowWidth
+		) {
+			dropDown.style.left = 'auto';
+			dropDown.style.right =
+				'calc( 100% - ' + bounding.width / 2 + 'px )';
 		}
 	});
 };

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -47,8 +47,6 @@ export const repositionDropdowns = () => {
 	neveEach(dropDowns, (dropDown) => {
 		dropDown.style.right = '';
 		dropDown.style.left = '';
-		// const bounding = dropDown.getBoundingClientRect(),
-		// 	rightDist = bounding.left;
 
 		let count = 0;
 		let add = 0;
@@ -78,22 +76,6 @@ export const repositionDropdowns = () => {
 			count++;
 			add++;
 		}
-
-		// if (rightDist < 0) {
-		// 	left = isRTL ? 'auto' : 0;
-		// 	right = isRTL ? '-100%' : 'auto';
-		// 	dropDown.style.right = right;
-		// 	dropDown.style.left = left;
-		// }
-		//
-		// if (rightDist + bounding.width >= windowWidth) {
-		// 	right = isRTL ? 0 : '100%';
-		// 	left = 'auto';
-		// 	dropDown.style.right = right;
-		// 	dropDown.style.left = left;
-		// }
-		// let newBounding = dropDown.getBoundingClientRect();
-		// console.log( newBounding );
 	});
 };
 


### PR DESCRIPTION
### Summary
Should address problems with https://github.com/Codeinwp/neve/pull/2739#issuecomment-847081874
and: https://github.com/Codeinwp/neve/pull/2739#issuecomment-845850430
References: https://github.com/Codeinwp/neve/pull/2739

### Will affect visual aspect of the product
YES on some edge cases

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/121175909-4bdd2100-c864-11eb-8c1f-00a42fa696dc.png)
![image](https://user-images.githubusercontent.com/23024731/121175960-5a2b3d00-c864-11eb-8135-631b4c2a1870.png)


### Test instructions
1.  Add the search icon on the middle inside mobile header
2. Set to minimal
3. Check it does not go off-screen
4. Do the same for RTL

Same should apply for all dropdowns ( mega-menu )



### Other Notes
The changes go over the `size-limit` for `modern` by `186 B`
Increases the compile size from `5.99 KB` to `6.18 KB` the available space by the size limit is of `10 B`
