### PR TITLE
adds ability to self heal theme mods in case of corupted value.

### DIFF
--- a/e2e-tests/cypress/fixtures/customizer/layout/sidebar-settings.json
+++ b/e2e-tests/cypress/fixtures/customizer/layout/sidebar-settings.json
@@ -1,5 +1,9 @@
 {
 	"advanced": {
+		"custom_css_post_id": -1,
+		"nav_menu_locations": {
+			"primary": 176
+		},
 		"neve_ran_builder_migration": true,
 		"neve_migrated_builders": true,
 		"neve_migrated_hfg_colors": true,
@@ -12,11 +16,12 @@
 		"neve_other_pages_content_width": 70
 	},
 	"site_wide": {
-		"neve_ran_builder_migration": true,
-		"neve_migrated_builders": true,
+		"custom_css_post_id": -1,
+		"nav_menu_locations": {
+			"primary": 176
+		},
 		"neve_migrated_hfg_colors": true,
 		"neve_default_sidebar_layout": "left",
-		"neve_sitewide_content_width": 50,
-		"neve_advanced_layout_options": false
+		"neve_sitewide_content_width": 50
 	}
 }

--- a/e2e-tests/cypress/integration/customizer/layout/sidebar-settings.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/layout/sidebar-settings.spec.ts
@@ -1,10 +1,11 @@
 describe('Sidebar/Content Settings', function () {
 	it('Sidebar site wide on front end.', function () {
 		cy.fixture('customizer/layout/sidebar-settings').then((sidebarSetup) => {
-			cy.setCustomizeSettings(sidebarSetup.site_wide);
+			cy.setCustomizeSettings(sidebarSetup.site_wide).then(() => {
+				cy.visit('/');
+			});
 		});
 		//Index
-		cy.visit('/');
 		cy.get('.nv-sidebar-wrap').should('have.css', 'max-width', '50%');
 		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
 		cy.get('.nv-index-posts').should('have.css', 'max-width', '50%');
@@ -30,10 +31,11 @@ describe('Sidebar/Content Settings', function () {
 
 	it('Sidebar advanced on front end.', function () {
 		cy.fixture('customizer/layout/sidebar-settings').then((sidebarSetup) => {
-			cy.setCustomizeSettings(sidebarSetup.advanced);
+			cy.setCustomizeSettings(sidebarSetup.advanced).then(() => {
+				cy.visit('/');
+			});
 		});
 		//Index
-		cy.visit('/');
 		cy.get('.nv-sidebar-wrap').should('have.css', 'max-width', '80%');
 		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
 		cy.get('.nv-index-posts').should('have.css', 'max-width', '20%');

--- a/e2e-tests/cypress/integration/customizer/typography/blog-typography.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/typography/blog-typography.spec.ts
@@ -58,10 +58,12 @@ describe('Blog Typography', function () {
 		},
 	};
 
-	before('Sets up blog typography in customizer', function () {
-		cy.loginWithRequest();
+	beforeEach('Sets up blog typography in customizer', function () {
+		
 		cy.fixture('customizer/typography/blog-typography').then((typoSetup) => {
-			cy.setCustomizeSettings(typoSetup);
+			cy.setCustomizeSettings(typoSetup).then(() => {
+        cy.loginWithRequest();
+      })
 		});
 	});
 

--- a/e2e-tests/cypress/integration/customizer/typography/blog-typography.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/typography/blog-typography.spec.ts
@@ -59,11 +59,10 @@ describe('Blog Typography', function () {
 	};
 
 	beforeEach('Sets up blog typography in customizer', function () {
-		
 		cy.fixture('customizer/typography/blog-typography').then((typoSetup) => {
 			cy.setCustomizeSettings(typoSetup).then(() => {
-        cy.loginWithRequest();
-      })
+				cy.loginWithRequest();
+			});
 		});
 	});
 

--- a/e2e-tests/cypress/integration/dashboard/auto-heal.spec.ts
+++ b/e2e-tests/cypress/integration/dashboard/auto-heal.spec.ts
@@ -1,0 +1,14 @@
+describe('Checks the auto-heal capability of the theme', function () {
+	before(function () {
+		cy.loginWithRequest();
+		cy.exec(
+			'docker-compose -f ../docker-compose.ci.yml run --rm -u root cli wp --allow-root option update theme_mods_neve 1',
+		);
+	});
+	it('Verify if the theme is able to self heal', function () {
+		cy.visit('/wp-admin');
+		cy.contains('Warning: Illegal').should('not.exist');
+		cy.visit('/');
+		cy.contains('Warning: Illegal').should('not.exist');
+	});
+});

--- a/e2e-tests/cypress/integration/editor/classic/page.spec.ts
+++ b/e2e-tests/cypress/integration/editor/classic/page.spec.ts
@@ -8,6 +8,12 @@ describe('Page meta box settings', function () {
 	before('Create new page named "' + pageSetup.title + '".', function () {
 		cy.insertPost(pageSetup.title, pageSetup.content, 'page');
 
+		cy.setCustomizeSettings({
+			neve_migrated_hfg_colors: true,
+			nav_menu_locations: [],
+			custom_css_post_id: -1,
+		});
+
 		cy.get('.post-publish-panel__postpublish-header a')
 			.contains(pageSetup.title)
 			.should('have.attr', 'href')
@@ -16,72 +22,74 @@ describe('Page meta box settings', function () {
 			});
 	});
 
-	it('Default page should not have sidebar and use 100% width.', function () {
-		cy.visit(pageSetup.url);
-		cy.get('.nv-sidebar-wrap').should('not.exist');
-		cy.get('.single-page-container').should('not.have.class', 'container-fluid').and('be.visible');
-		cy.get('.nv-single-page-wrap').should('have.css', 'max-width').and('eq', '100%');
-		cy.get('.nv-page-title').should('exist').and('contain', pageSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-content-wrap').should('contain', pageSetup.content);
+	context('Deactivated plugin', function () {
+		it('Default page should not have sidebar and use 100% width.', function () {
+			cy.visit(pageSetup.url);
+			cy.get('.nv-sidebar-wrap').should('not.exist');
+			cy.get('.single-page-container')
+				.should('not.have.class', 'container-fluid')
+				.and('be.visible');
+			cy.get('.nv-single-page-wrap').should('have.css', 'max-width').and('eq', '100%');
+			cy.get('.nv-page-title').should('exist').and('contain', pageSetup.title);
+			cy.get('.hfg_header').should('exist');
+			cy.get('footer.site-footer').should('exist');
+			cy.get('.nv-content-wrap').should('contain', pageSetup.content);
+		});
+
+		it('Content default width should be preserved', function () {
+			const defaultWidth = 1170;
+			cy.get('.single-page-container').should('have.css', 'max-width', defaultWidth + 'px');
+			cy.get('#wp-admin-bar-edit a').click();
+			cy.get('.wp-block').should('have.css', 'max-width', '1170px');
+			cy.clearWelcome();
+			cy.insertCoverBlock();
+			cy.visit(pageSetup.url);
+			matchContentWidth(defaultWidth);
+		});
 	});
 
-	it('Content default width should be preserved', function () {
-		const defaultWidth = 1170;
-		cy.get('.single-page-container').should('have.css', 'max-width', defaultWidth + 'px');
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('.wp-block').should('have.css', 'max-width', '1170px');
-		cy.clearWelcome();
-		cy.insertCoverBlock();
-		cy.visit(pageSetup.url);
-		matchContentWidth(defaultWidth);
-	});
+	context('Activated plugin', function () {
+		before('Activates Classic Editor', function () {
+			cy.activateClassicEditorPlugin();
+		});
+		after('Deactivates Classic Editor', function () {
+			cy.deactivateClassicEditorPlugin();
+		});
+		it('Edit meta box content width "' + pageSetup.title + '".', function () {
+			cy.loginWithRequest(pageSetup.url);
 
-	it('Activates Classic Editor', function () {
-		cy.activateClassicEditorPlugin();
-	});
+			cy.get('#wp-admin-bar-edit a').click();
+			cy.get('#neve_meta_content_width-range').invoke('val', 70).trigger('change');
+			cy.get('#publish').contains('Update').click();
 
-	it('Edit meta box content width "' + pageSetup.title + '".', function () {
-		cy.loginWithRequest(pageSetup.url);
+			cy.visit(pageSetup.url);
+			cy.get('.single-page-container .nv-content-wrap')
+				.invoke('width')
+				.should('be.eq', 0.7 * 1170 - 30); //we substract the padding.
+		});
 
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('#neve_meta_content_width-range').invoke('val', 70).trigger('change');
-		cy.get('#publish').contains('Update').click();
+		it('Edit meta box settings "' + pageSetup.title + '".', function () {
+			cy.loginWithRequest(pageSetup.url);
+			cy.get('#wp-admin-bar-edit a').click();
+			cy.get('label[for="neve_meta_container_full-width"]').click();
+			cy.get('label[for="neve_meta_sidebar_left"]').click();
+			cy.get('label[for="neve_meta_disable_title"]').click();
+			cy.get('label[for="neve_meta_disable_header"]').click();
+			cy.get('label[for="neve_meta_disable_footer"]').click();
+			cy.get('#neve_meta_content_width-range').invoke('val', 70).trigger('change');
 
-		cy.visit(pageSetup.url);
-		cy.get('.single-page-container .nv-content-wrap')
-			.invoke('width')
-			.should('be.eq', 0.7 * 1170 - 30); //we substract the padding.
-	});
+			cy.get('#publish').contains('Update').click();
 
-	it('Edit meta box settings "' + pageSetup.title + '".', function () {
-		cy.loginWithRequest(pageSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
-		cy.get('label[for="neve_meta_container_full-width"]').click();
-		cy.get('label[for="neve_meta_sidebar_left"]').click();
-		cy.get('label[for="neve_meta_disable_title"]').click();
-		cy.get('label[for="neve_meta_disable_header"]').click();
-		cy.get('label[for="neve_meta_disable_footer"]').click();
-		cy.get('#neve_meta_content_width-range').invoke('val', 70).trigger('change');
-
-		cy.get('#publish').contains('Update').click();
-	});
-
-	it('Edited meta box settings on front end.', function () {
-		cy.visit(pageSetup.url);
-		cy.reload();
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left').and('be.visible');
-		cy.get('.single-page-container').should('have.class', 'container-fluid').and('be.visible');
-		cy.get('.nv-single-page-wrap').should('have.css', 'max-width').and('eq', '70%');
-		cy.get('.nv-page-title').should('not.exist');
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('footer.site-footer').should('not.exist');
-		cy.get('.nv-content-wrap').should('not.contain', pageSetup.content);
-	});
-
-	it('Deactivate Classic Editor', function () {
-		cy.deactivateClassicEditorPlugin();
+			cy.visit(pageSetup.url);
+			cy.reload();
+			cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left').and('be.visible');
+			cy.get('.single-page-container').should('have.class', 'container-fluid').and('be.visible');
+			cy.get('.nv-single-page-wrap').should('have.css', 'max-width').and('eq', '70%');
+			cy.get('.nv-page-title').should('not.exist');
+			cy.get('.hfg_header').should('not.exist');
+			cy.get('footer.site-footer').should('not.exist');
+			cy.get('.nv-content-wrap').should('not.contain', pageSetup.content);
+		});
 	});
 });
 

--- a/e2e-tests/cypress/integration/editor/classic/post.spec.ts
+++ b/e2e-tests/cypress/integration/editor/classic/post.spec.ts
@@ -6,6 +6,13 @@ describe('Posts meta box default settings', function () {
 	};
 	before('Create new post named "' + postSetup.title + '".', function () {
 		cy.insertPost(postSetup.title, postSetup.content, 'post', true);
+
+		cy.setCustomizeSettings({
+			neve_migrated_hfg_colors: true,
+			nav_menu_locations: [],
+			custom_css_post_id: -1,
+		});
+
 		cy.get('.post-publish-panel__postpublish-header a')
 			.contains(postSetup.title)
 			.should('have.attr', 'href')
@@ -13,59 +20,62 @@ describe('Posts meta box default settings', function () {
 				postSetup.url = href;
 			});
 	});
-	it('Default meta box settings on front end.', function () {
-		cy.visit(postSetup.url);
+	context('Deactivated Plugin', function () {
+		it('Default meta box settings on front end.', function () {
+			cy.visit(postSetup.url);
 
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-right').and('be.visible');
-		cy.get('.single-post-container').should('not.have.class', 'container-fluid').and('be.visible');
-		cy.get('.nv-single-post-wrap').should('have.css', 'max-width').and('eq', '70%');
-		cy.get('.entry-title').should('exist').and('contain', postSetup.title);
-		cy.get('.hfg_header').should('exist');
-		cy.get('footer.site-footer').should('exist');
-		cy.get('.nv-thumb-wrap > img')
-			.should('exist')
-			.and('be.visible')
-			.and('have.attr', 'src')
-			.then(($href) => {
-				expect($href).to.contain('/wp-content/uploads/');
-			});
-		cy.get('.nv-content-wrap').should('contain', postSetup.content);
+			cy.get('.nv-sidebar-wrap').should('have.class', 'nv-right').and('be.visible');
+			cy.get('.single-post-container')
+				.should('not.have.class', 'container-fluid')
+				.and('be.visible');
+			cy.get('.nv-single-post-wrap').should('have.css', 'max-width').and('eq', '70%');
+			cy.get('.entry-title').should('exist').and('contain', postSetup.title);
+			cy.get('.hfg_header').should('exist');
+			cy.get('footer.site-footer').should('exist');
+			cy.get('.nv-thumb-wrap > img')
+				.should('exist')
+				.and('be.visible')
+				.and('have.attr', 'src')
+				.then(($href) => {
+					expect($href).to.contain('/wp-content/uploads/');
+				});
+			cy.get('.nv-content-wrap').should('contain', postSetup.content);
+		});
 	});
 
-	it('Activates Classic Editor', function () {
-		cy.activateClassicEditorPlugin();
-	});
+	context('Activated Plugin', function () {
+		before('Activates Classic Editor', function () {
+			cy.activateClassicEditorPlugin();
+		});
 
-	it('Edit meta box settings "' + postSetup.title + '".', function () {
-		cy.loginWithRequest(postSetup.url);
-		cy.get('#wp-admin-bar-edit a').click();
+		after('Deactivates Classic Editor', function () {
+			cy.deactivateClassicEditorPlugin();
+		});
+		it('Edit meta box settings "' + postSetup.title + '".', function () {
+			cy.loginWithRequest(postSetup.url);
+			cy.get('#wp-admin-bar-edit a').click();
 
-		cy.get('label[for="neve_meta_container_full-width"]').click();
-		cy.get('label[for="neve_meta_sidebar_left"]').click();
-		cy.get('label[for="neve_meta_disable_title"]').click();
-		cy.get('label[for="neve_meta_disable_header"]').click();
-		cy.get('label[for="neve_meta_disable_featured_image"]').click();
-		cy.get('label[for="neve_meta_disable_footer"]').click();
-		cy.get('label[for="neve_meta_enable_content_width"]').click();
-		cy.get('#neve_meta_content_width-range').invoke('val', 50).trigger('change');
-		cy.wait(1000);
-		cy.get('#publish').contains('Update').click();
-	});
+			cy.get('label[for="neve_meta_container_full-width"]').click();
+			cy.get('label[for="neve_meta_sidebar_left"]').click();
+			cy.get('label[for="neve_meta_disable_title"]').click();
+			cy.get('label[for="neve_meta_disable_header"]').click();
+			cy.get('label[for="neve_meta_disable_featured_image"]').click();
+			cy.get('label[for="neve_meta_disable_footer"]').click();
+			cy.get('label[for="neve_meta_enable_content_width"]').click();
+			cy.get('#neve_meta_content_width-range').invoke('val', 50).trigger('change');
+			cy.wait(1000);
+			cy.get('#publish').contains('Update').click();
 
-	it('Edited meta box settings on front end.', function () {
-		cy.visit(postSetup.url);
-		cy.reload();
-		cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left').and('be.visible');
-		cy.get('.single-post-container').should('have.class', 'container-fluid').and('be.visible');
-		cy.get('.nv-single-post-wrap').should('have.css', 'max-width').and('eq', '50%');
-		cy.get('.entry-title').should('not.exist');
-		cy.get('.hfg_header').should('not.exist');
-		cy.get('footer.site-footer').should('not.exist');
-		cy.get('.nv-thumb-wrap').should('not.exist');
-		cy.get('.nv-content-wrap').should('contain', postSetup.content);
-	});
-
-	it('Deactivates Classic Editor', function () {
-		cy.deactivateClassicEditorPlugin();
+			cy.visit(postSetup.url);
+			cy.reload();
+			cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left').and('be.visible');
+			cy.get('.single-post-container').should('have.class', 'container-fluid').and('be.visible');
+			cy.get('.nv-single-post-wrap').should('have.css', 'max-width').and('eq', '50%');
+			cy.get('.entry-title').should('not.exist');
+			cy.get('.hfg_header').should('not.exist');
+			cy.get('footer.site-footer').should('not.exist');
+			cy.get('.nv-thumb-wrap').should('not.exist');
+			cy.get('.nv-content-wrap').should('contain', postSetup.content);
+		});
 	});
 });

--- a/e2e-tests/cypress/integration/editor/modern/page-meta-sidebar.spec.ts
+++ b/e2e-tests/cypress/integration/editor/modern/page-meta-sidebar.spec.ts
@@ -8,6 +8,11 @@ describe('Single page sidebar', function () {
 	before('Create new page named "' + pageSetup.title + '".', function () {
 		cy.insertPost(pageSetup.title, pageSetup.content, 'page');
 
+		cy.setCustomizeSettings({
+			neve_migrated_hfg_colors: true,
+			nav_menu_locations: [],
+			custom_css_post_id: -1,
+		});
 		cy.get('.post-publish-panel__postpublish-header a')
 			.contains(pageSetup.title)
 			.should('have.attr', 'href')
@@ -40,36 +45,40 @@ describe('Single page sidebar', function () {
 		cy.get('.nv-content-wrap').should('contain', pageSetup.content);
 	});
 
-	it('Check sidebar layout', function () {
-		cy.loginWithRequest(pageSetup.url);
-		const pageId = window.localStorage.getItem('pageId');
-		cy.clearWelcome();
-
-		cy.updatePageOrPostByRequest(pageId, 'pages', {
-			meta: {
-				neve_meta_sidebar: 'full-width',
-			},
-		}).then(() => {
-			cy.visit(pageSetup.url);
-			cy.get('.nv-sidebar-wrap').should('not.exist');
-			cy.get('#wp-admin-bar-edit a').click();
+	context('Check sidebar layout', function () {
+		beforeEach(function () {
+			cy.loginWithRequest(pageSetup.url);
+			cy.clearWelcome();
 		});
 
-		cy.updatePageOrPostByRequest(pageId, 'pages', {
-			meta: {
-				neve_meta_sidebar: 'left',
-			},
-		}).then(() => {
-			cy.visit(pageSetup.url);
+		it('Full-width', function () {
+			cy.updatePageOrPostByRequest(window.localStorage.getItem('pageId'), 'pages', {
+				meta: {
+					neve_meta_sidebar: 'full-width',
+				},
+			}).then(() => {
+				cy.visit(pageSetup.url);
+			});
+			cy.get('.nv-sidebar-wrap').should('not.exist');
+		});
+		it('Left', function () {
+			cy.updatePageOrPostByRequest(window.localStorage.getItem('pageId'), 'pages', {
+				meta: {
+					neve_meta_sidebar: 'left',
+				},
+			}).then(() => {
+				cy.visit(pageSetup.url);
+			});
 			cy.get('.nv-sidebar-wrap').should('have.class', 'nv-left');
 		});
-
-		cy.updatePageOrPostByRequest(pageId, 'pages', {
-			meta: {
-				neve_meta_sidebar: 'right',
-			},
-		}).then(() => {
-			cy.visit(pageSetup.url);
+		it('Right', function () {
+			cy.updatePageOrPostByRequest(window.localStorage.getItem('pageId'), 'pages', {
+				meta: {
+					neve_meta_sidebar: 'right',
+				},
+			}).then(() => {
+				cy.visit(pageSetup.url);
+			});
 			cy.get('.nv-sidebar-wrap').should('have.class', 'nv-right');
 		});
 	});

--- a/e2e-tests/cypress/integration/editor/modern/post-meta-sidebar.spec.ts
+++ b/e2e-tests/cypress/integration/editor/modern/post-meta-sidebar.spec.ts
@@ -7,6 +7,13 @@ describe('Single post meta sidebar', function () {
 
 	before('Create new post named "' + postSetup.title + '".', function () {
 		cy.insertPost(postSetup.title, postSetup.content, 'post', true, true);
+
+		cy.setCustomizeSettings({
+			neve_migrated_hfg_colors: true,
+			nav_menu_locations: [],
+			custom_css_post_id: -1,
+		});
+
 		cy.get('.post-publish-panel__postpublish-header a')
 			.contains(postSetup.title)
 			.should('have.attr', 'href')

--- a/header-footer-grid/functions-migration.php
+++ b/header-footer-grid/functions-migration.php
@@ -87,9 +87,24 @@ function neve_hfg_migrate_skin_to_bg_color() {
 	set_theme_mod( $flag, true );
 }
 
+
 add_action( 'init', 'neve_hfg_migrate_skin_to_bg_color' );
+/**
+ * Function to self heal theme mods option, in case of corrupted value.
+ */
+function neve_self_heal_mods() {
+	$all_mods = get_theme_mods();
+	if ( $all_mods === false ) {
+		return;
+	}
+	if ( is_array( $all_mods ) ) {
+		return;
+	}
+	$theme_slug = get_option( 'stylesheet' );
+	delete_option( "theme_mods_$theme_slug" );
+}
 
-
+add_action( 'init', 'neve_self_heal_mods', 1 );
 /**
  * Define migration logic for footer.
  *
@@ -110,7 +125,7 @@ function neve_hfg_footer_settings() {
 		'footer-three-widgets',
 		'footer-four-widgets',
 	);
-	for ( $i = 0; $i < $sidebars; $i++ ) {
+	for ( $i = 0; $i < $sidebars; $i ++ ) {
 		$builder['desktop']['top'][ $sidebars_names[ $i ] ] = [
 			'id'    => $sidebars_names[ $i ],
 			'width' => 12 / $sidebars,


### PR DESCRIPTION
### Summary
In strange cases when the theme mods options are using a corrupted value, we need to self heal them in order to avoid errors when setting the theme mods. 

### Will affect visual aspect of the product
NO
### Test instructions
- Add a corrupted value for theme mods, you can use wp cli as `wp option update theme_mods_neve 1`
- Before it was throwing an error, now it should work just fine. 

<!-- Issues that this pull request closes. -->
Closes #2893
