### PR TITLE
fix: solve accessibility issues search icon #2897

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -175,7 +175,7 @@ function neve_search_icon( $is_link = false, $echo = false, $size = 15, $amp_rea
 	if ( $amp_ready ) {
 		$amp_state = 'on="tap:AMP.setState({visible: !visible})" role="button" tabindex="0" ';
 	}
-	$start_tag = $is_link ? 'a href="#"' : 'div';
+	$start_tag = $is_link ? 'a aria-label="' . __( 'Search', 'neve' ) . '" href="#"' : 'div';
 	$end_tag   = $is_link ? 'a' : 'div';
 	$svg       = '<' . $start_tag . ' class="nv-icon nv-search" ' . $amp_state . '>
 				<svg width="' . $size . '" height="' . $size . '" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1216 832q0-185-131.5-316.5t-316.5-131.5-316.5 131.5-131.5 316.5 131.5 316.5 316.5 131.5 316.5-131.5 131.5-316.5zm512 832q0 52-38 90t-90 38q-54 0-90-38l-343-342q-179 124-399 124-143 0-273.5-55.5t-225-150-150-225-55.5-273.5 55.5-273.5 150-225 225-150 273.5-55.5 273.5 55.5 225 150 150 225 55.5 273.5q0 220-124 399l343 343q37 37 37 90z"/></svg>

--- a/header-footer-grid/templates/components/component-search-responsive.php
+++ b/header-footer-grid/templates/components/component-search-responsive.php
@@ -32,7 +32,7 @@ if ( neve_is_amp() ) {
 }
 ?>
 <div class="nv-search-icon-component" <?php echo wp_kses_post( $component_styles ); ?>>
-	<div [class]="visible ? 'menu-item-nav-search active <?php echo esc_attr( $open ); ?>' : 'menu-item-nav-search <?php echo esc_attr( $open ); ?>'" class="menu-item-nav-search <?php echo esc_attr( $open ); ?>" id="nv-search-icon-responsive" tabindex="0">
+	<div [class]="visible ? 'menu-item-nav-search active <?php echo esc_attr( $open ); ?>' : 'menu-item-nav-search <?php echo esc_attr( $open ); ?>'" class="menu-item-nav-search <?php echo esc_attr( $open ); ?>" tabindex="0">
 		<?php neve_search_icon( true, true, 15, ! empty( $amp_state ) ); ?>
 		<div class="nv-nav-search" aria-label="search">
 			<div class="form-wrap <?php echo $open === 'canvas' ? 'container' : ''; ?>">

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -275,6 +275,12 @@ msgstr ""
 msgid "You appear to be running the Neve theme from source code. Please finish installation by running %s."
 msgstr ""
 
+#: globals/utilities.php:178
+#: header-footer-grid/Core/Components/Nav.php:177
+#: inc/customizer/controls/react/src/font-family/FontFamilySelector.js:125
+msgid "Search"
+msgstr ""
+
 #: globals/utilities.php:1350
 msgid "Base"
 msgstr ""
@@ -674,11 +680,6 @@ msgstr ""
 #: header-footer-grid/Core/Components/NavFooter.php:108
 #: header-footer-grid/Core/Components/SecondNav.php:109
 msgid "Items Hover Color"
-msgstr ""
-
-#: header-footer-grid/Core/Components/Nav.php:177
-#: inc/customizer/controls/react/src/font-family/FontFamilySelector.js:125
-msgid "Search"
 msgstr ""
 
 #: header-footer-grid/Core/Components/Nav.php:182


### PR DESCRIPTION
### Summary
Removed the id from the search icon as it is not used by the theme or the plugin and is not required.
Added `aria-label` to link.

### Will affect visual aspect of the product
NO

### Test instructions
1.  Import some starter site of Neve like Web Agency
2. Add Search Icon component to both desktop and mobile headers
3. Analyse the website with Google Chrome Lighthouse
4. No accessibility issues should be reported for this component.


Closes #2897.
