### PR TITLE
fix: display scripts on woocomerce #2901

### DIFF
--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -38,7 +38,7 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-	  	> * {
+	  	> *:not(script):not(noscript) {
 		  margin-right: 2px;
 		  margin-left: 2px;
 		  display: flex;
@@ -58,7 +58,7 @@
 		margin-right: -1px;
 		margin-left: -1px;
 
-		> * {
+		> *:not(script):not(noscript) {
 		  margin-right: 1px;
 		  margin-left: 1px;
 		  display: flex;


### PR DESCRIPTION
### Summary
Don't target elements that should be hidden by default.

### Will affect visual aspect of the product
NO

### Test instructions
https://github.com/Codeinwp/neve/issues/2901

Closes #2901.
