### PR TITLE
Fix issue with scripts appearing next to single product buttons

### DIFF
--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -33,6 +33,9 @@
 	  .quantity, .single_add_to_cart_button {
 		display: flex;
 	  }
+	  .single_add_to_cart_button {
+		align-items: center;
+	  }
 	}
 }
 

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -38,7 +38,7 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-		> .quantity:not(.hidden), > .single_add_to_cart_button, > .wc-forward {
+		.quantity:not(.hidden), .single_add_to_cart_button, .wc-forward {
 		  display: flex;
 		  margin-right: 2px;
 		  margin-left: 2px;

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -1,7 +1,3 @@
-.woocommerce.single .nv-woo-filters {
-	display: none;
-}
-
 .woocommerce.single {
 	.entry-summary, #tab-description {
 		ul {
@@ -30,32 +26,13 @@
 	  line-height: normal;
 	}
 
-	.woocommerce-variation-add-to-cart,
-	.entry-summary > form.cart {
+	.nv-single-product-actions-wrap {
+	  display: flex;
+	  flex-basis: 100%;
+	  .quantity, .single_add_to_cart_button {
 		display: flex;
-		flex-wrap: wrap;
-		align-items: stretch;
-		margin-right: -2px;
-		margin-left: -2px;
-
-		.quantity:not(.hidden), .single_add_to_cart_button, .wc-forward {
-		  display: flex;
-		  margin-right: 2px;
-		  margin-left: 2px;
-		  margin-top: 4px!important;
-		  justify-content: center;
-		  align-items: center;
-		}
-
-		.quantity input {
-		  align-self: normal;
-		}
+	  }
 	}
-}
-
-.single_add_to_cart_button {
-	width: auto;
-	flex-grow: 1;
 }
 
 .nv-wl-product-wrap .add-to-wl {
@@ -260,10 +237,6 @@
 		padding: 5px;
 	}
 }
-
-//</editor-fold>
-
-//</editor-fold>
 
 @mixin product--tablet() {
 	.single_add_to_cart_button {

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -38,14 +38,11 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-		> .quantity, > .single_add_to_cart_button, > .wc-forward, > .nv-wl-wrap {
+		> .quantity, > .single_add_to_cart_button, > .wc-forward {
 		  display: flex;
 		  margin-right: 2px;
 		  margin-left: 2px;
 		  margin-top: 4px!important;
-		}
-
-		> .quantity, > .single_add_to_cart_button, > .wc-forward {
 		  justify-content: center;
 		  align-items: center;
 		}

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -18,19 +18,19 @@
 		}
 	}
 
-  .entry-summary .quantity {
-	margin-left: 2px !important;
-	margin-right: 2px !important;
-  }
+	.entry-summary .quantity {
+	  margin-left: 2px !important;
+	  margin-right: 2px !important;
+	}
 
-  .quantity input {
-	padding-right: 4px !important;
-	padding-left: 4px !important;
-	box-sizing: border-box;
-	line-height: normal;
-  }
+	.quantity input {
+	  padding-right: 4px !important;
+	  padding-left: 4px !important;
+	  box-sizing: border-box;
+	  line-height: normal;
+	}
 
-  	.woocommerce-variation-add-to-cart,
+	.woocommerce-variation-add-to-cart,
 	.entry-summary > form.cart {
 		display: flex;
 		flex-wrap: wrap;
@@ -38,19 +38,19 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-	    > .quantity, > .single_add_to_cart_button, > .wc-forward, > .nv-wl-wrap {
+		> .quantity, > .single_add_to_cart_button, > .wc-forward, > .nv-wl-wrap {
 		  display: flex;
 		  margin-right: 2px;
 		  margin-left: 2px;
 		  margin-top: 4px!important;
 		}
 
-	  	> .quantity, > .single_add_to_cart_button, > .wc-forward {
+		> .quantity, > .single_add_to_cart_button, > .wc-forward {
 		  justify-content: center;
 		  align-items: center;
 		}
 
-	  	.quantity input {
+		.quantity input {
 		  align-self: normal;
 		}
 	}

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -38,7 +38,7 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-		> .quantity, > .single_add_to_cart_button, > .wc-forward {
+		> .quantity:not(.hidden), > .single_add_to_cart_button, > .wc-forward {
 		  display: flex;
 		  margin-right: 2px;
 		  margin-left: 2px;

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -28,6 +28,7 @@
 
 	.nv-single-product-actions-wrap {
 	  display: flex;
+	  flex-wrap: wrap;
 	  flex-basis: 100%;
 	  .quantity, .single_add_to_cart_button {
 		display: flex;

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -38,38 +38,20 @@
 		margin-right: -2px;
 		margin-left: -2px;
 
-	  	> * {
+	    > .quantity, > .single_add_to_cart_button, > .wc-forward, > .nv-wl-wrap {
+		  display: flex;
 		  margin-right: 2px;
 		  margin-left: 2px;
-		  display: flex;
-		  align-self: normal;
+		  margin-top: 4px!important;
+		}
+
+	  	> .quantity, > .single_add_to_cart_button, > .wc-forward {
+		  justify-content: center;
 		  align-items: center;
 		}
 
 	  	.quantity input {
-		  align-self: inherit;
-		}
-	}
-
-  	.single_variation_wrap {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: stretch;
-		margin-right: -1px;
-		margin-left: -1px;
-
-		> * {
-		  margin-right: 1px;
-		  margin-left: 1px;
-		  display: flex;
 		  align-self: normal;
-		  align-items: center;
-		}
-
-		.woocommerce-variation {
-		  display: flex;
-		  flex-wrap: wrap;
-		  flex: 0 0 100%;
 		}
 	}
 }

--- a/bin/envs/theme-check/start.sh
+++ b/bin/envs/theme-check/start.sh
@@ -1,3 +1,3 @@
-php -d memory_limit=1024M "$(which wp)" package install anhskohbo/wp-cli-themecheck --allow-root
+php -d memory_limit=1024M "$(which wp)" package install Codeinwp/wp-cli-themecheck --allow-root
 wp plugin install theme-check --activate --allow-root
 wp themecheck --theme=neve --no-interactive --allow-root

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -193,8 +193,13 @@ class Woocommerce {
 		$this->wrap_action_buttons();
 	}
 
+	/**
+	 * Wrap quantity and add to cart button in a div.
+	 *
+	 * @return bool
+	 */
 	public function wrap_action_buttons() {
-		if ( ! is_product() ){
+		if ( ! is_product() ) {
 			return false;
 		}
 
@@ -206,20 +211,25 @@ class Woocommerce {
 		$product_type = $product->get_type();
 
 		$opening_hook = 'woocommerce_before_add_to_cart_quantity';
-		if ( $product_type === 'grouped' || $product_type === 'external' ){
+		if ( $product_type === 'grouped' || $product_type === 'external' ) {
 			$opening_hook = 'woocommerce_before_add_to_cart_button';
 		}
 
-		add_action( $opening_hook, array( $this, 'open_actions_wrapper' ) );
-		add_action( 'woocommerce_after_add_to_cart_button', array( $this, 'close_actions_wrapper') );
-	}
+		add_action(
+			$opening_hook,
+			function () {
+				echo '<div class="nv-single-product-actions-wrap">';
+			} 
+		);
 
-	public function open_actions_wrapper() {
-		echo '<div class="nv-single-product-actions-wrap">';
-	}
+		add_action(
+			'woocommerce_after_add_to_cart_button',
+			function () {
+				echo '</div>';
+			} 
+		);
 
-	public function close_actions_wrapper() {
-		echo '</div>';
+		return true;
 	}
 
 	/**

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -190,6 +190,15 @@ class Woocommerce {
 		$this->add_inline_selectors();
 		add_action( 'wp', [ $this, 'setup_form_buttons' ] );
 
+		add_filter(
+			'nv_product_types_without_quantity',
+			function( $types ) {
+				// Compatibility with WooCommerce Appointments plugin.
+				$types[] = 'appointment';
+				return $types;
+			} 
+		);
+
 		$this->wrap_action_buttons();
 	}
 
@@ -210,8 +219,16 @@ class Woocommerce {
 
 		$product_type = $product->get_type();
 
-		$opening_hook = 'woocommerce_before_add_to_cart_quantity';
-		if ( $product_type === 'grouped' || $product_type === 'external' ) {
+		/**
+		 * Filters the product types that doesn't contain a quantity field.
+		 *
+		 * @since 2.11.7
+		 *
+		 * @param array $types Product types.
+		 */
+		$types_without_quantity = apply_filters( 'nv_product_types_without_quantity', [ 'grouped', 'external' ] );
+		$opening_hook           = 'woocommerce_before_add_to_cart_quantity';
+		if ( in_array( $product_type, $types_without_quantity, true ) ) {
 			$opening_hook = 'woocommerce_before_add_to_cart_button';
 		}
 
@@ -219,14 +236,14 @@ class Woocommerce {
 			$opening_hook,
 			function () {
 				echo '<div class="nv-single-product-actions-wrap">';
-			} 
+			}
 		);
 
 		add_action(
 			'woocommerce_after_add_to_cart_button',
 			function () {
 				echo '</div>';
-			} 
+			}
 		);
 
 		return true;

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -101,7 +101,7 @@ class Woocommerce {
 		add_action( 'wp', array( $this, 'register_hooks' ), 11 );
 		add_action( 'neve_react_controls_localization', array( $this, 'add_customizer_options' ) );
 	}
-	
+
 	/**
 	 * Add params to specify if the site has elementor templates.
 	 *
@@ -113,7 +113,7 @@ class Woocommerce {
 		$options['elementor']['hasElementorProductTemplate'] = Elementor::has_template( 'product' );
 		return $options;
 	}
-	
+
 	/**
 	 * Should module load?
 	 *
@@ -129,7 +129,7 @@ class Woocommerce {
 
 		return ! ( $is_shop_template || $is_product_template );
 	}
-	
+
 	/**
 	 * Register hooks
 	 *
@@ -585,8 +585,7 @@ class Woocommerce {
 			.woocommerce .actions > button[type=submit],
 			.woocommerce button#place_order,
 			.woocommerce .return-to-shop > .button,
-			.woocommerce .button.woocommerce-form-login__submit,
-			.woocommerce.single .quantity input' );
+			.woocommerce .button.woocommerce-form-login__submit' );
 	}
 
 	/**

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -189,6 +189,37 @@ class Woocommerce {
 		$this->move_checkout_coupon();
 		$this->add_inline_selectors();
 		add_action( 'wp', [ $this, 'setup_form_buttons' ] );
+
+		$this->wrap_action_buttons();
+	}
+
+	public function wrap_action_buttons() {
+		if ( ! is_product() ){
+			return false;
+		}
+
+		$product = wc_get_product( get_the_ID() );
+		if ( empty( $product ) ) {
+			return false;
+		}
+
+		$product_type = $product->get_type();
+
+		$opening_hook = 'woocommerce_before_add_to_cart_quantity';
+		if ( $product_type === 'grouped' || $product_type === 'external' ){
+			$opening_hook = 'woocommerce_before_add_to_cart_button';
+		}
+
+		add_action( $opening_hook, array( $this, 'open_actions_wrapper' ) );
+		add_action( 'woocommerce_after_add_to_cart_button', array( $this, 'close_actions_wrapper') );
+	}
+
+	public function open_actions_wrapper() {
+		echo '<div class="nv-single-product-actions-wrap">';
+	}
+
+	public function close_actions_wrapper() {
+		echo '</div>';
 	}
 
 	/**

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1271,7 +1271,7 @@ msgctxt "Theme starter content"
 msgid "Blog"
 msgstr ""
 
-#: inc/compatibility/woocommerce.php:380
+#: inc/compatibility/woocommerce.php:411
 msgid "Filter"
 msgstr ""
 

--- a/languages/neve.pot
+++ b/languages/neve.pot
@@ -1271,7 +1271,7 @@ msgctxt "Theme starter content"
 msgid "Blog"
 msgstr ""
 
-#: inc/compatibility/woocommerce.php:411
+#: inc/compatibility/woocommerce.php:421
 msgid "Filter"
 msgstr ""
 


### PR DESCRIPTION
### Summary
- The issue here was that we targeted all elements in that div with `> *`. If a plugin come and add a script there, the script tag would have `display: flex;`
- Fixed an issue for grouped products. The padding of the primary button was applying on inputs for grouped products.

**NOTE**: @preda-bogdan also tried a fix [here](https://github.com/Codeinwp/neve/pull/2918) which was just fixing the issue for noscript and script tags. What I did is to directly target the elements that we have there.

### Will affect visual aspect of the product
NO

### Screenshots

https://prnt.sc/15otb1h

### Test instructions
- Import test data from woocommerce https://github.com/woocommerce/woocommerce/tree/master/sample-data
- check that buttons and quantity input has the same height
- Check on normal, variable, grouped products
- Test with seamless add to cart
- Test with and without Neve Pro

<!-- Issues that this pull request closes. -->
Closes #2903, Closes #2901, Closes #2915, Closes codeinwp/neve-pro-addon#1414
<!-- Should look like this: `Closes #1, #2, #3.` . -->
