### PR TITLE
Fix issue with scripts appearing next to single product buttons

### DIFF
--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -285,17 +285,6 @@
 	body.single-product .neve-main > .container > .row {
 	  flex-wrap: wrap;
 	}
-
-	//.woocommerce.single {
-	//	.entry-summary > form.cart {
-	//		.wc-forward {
-	//			flex-basis: auto;
-	//		}
-	//	}
-	//}
-	//.variations select {
-	//	height: 35px;
-	//}
 }
 
 .woocommerce ul.products.exclusive-products li.product,

--- a/assets/scss/woocommerce/_product.scss
+++ b/assets/scss/woocommerce/_product.scss
@@ -18,11 +18,6 @@
 		}
 	}
 
-  .entry-summary .quantity {
-	margin-left: 2px !important;
-	margin-right: 2px !important;
-  }
-
   .quantity input {
 	padding-right: 4px !important;
 	padding-left: 4px !important;
@@ -30,48 +25,26 @@
 	line-height: normal;
   }
 
-  	.woocommerce-variation-add-to-cart,
-	.entry-summary > form.cart {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: stretch;
-		margin-right: -2px;
-		margin-left: -2px;
-
-	  	> * {
-		  margin-right: 2px;
-		  margin-left: 2px;
-		  display: flex;
-		  align-self: normal;
-		  align-items: center;
-		}
-
-	  	.quantity input {
-		  align-self: inherit;
-		}
+  .woocommerce-variation-add-to-cart,
+  .entry-summary > form.cart {
+	display: flex !important;
+	flex-wrap: wrap;
+	margin-left: -2px;
+	margin-right: -2px;
+	> * {
+	  flex-basis: 100%;
+	  margin-left: 2px;
+	  margin-right: 2px;
+	  margin-top: 4px!important;
 	}
-
-  	.single_variation_wrap {
-		display: flex;
-		flex-wrap: wrap;
-		align-items: stretch;
-		margin-right: -1px;
-		margin-left: -1px;
-
-		> * {
-		  margin-right: 1px;
-		  margin-left: 1px;
-		  display: flex;
-		  align-self: normal;
-		  align-items: center;
-		}
-
-		.woocommerce-variation {
-		  display: flex;
-		  flex-wrap: wrap;
-		  flex: 0 0 100%;
-		}
+	.quantity, .single_add_to_cart_button {
+	  display: flex;
+	  flex-basis: initial;
 	}
+	.single_add_to_cart_button {
+	  align-items: center;
+	}
+  }
 }
 
 .single_add_to_cart_button {
@@ -313,13 +286,13 @@
 	  flex-wrap: wrap;
 	}
 
-	.woocommerce.single {
-		.entry-summary > form.cart {
-			.wc-forward {
-				flex-basis: auto;
-			}
-		}
-	}
+	//.woocommerce.single {
+	//	.entry-summary > form.cart {
+	//		.wc-forward {
+	//			flex-basis: auto;
+	//		}
+	//	}
+	//}
 	//.variations select {
 	//	height: 35px;
 	//}

--- a/bin/envs/theme-check/start.sh
+++ b/bin/envs/theme-check/start.sh
@@ -1,3 +1,3 @@
-php -d memory_limit=1024M "$(which wp)" package install Codeinwp/wp-cli-themecheck --allow-root
+php -d memory_limit=1024M "$(which wp)" package install anhskohbo/wp-cli-themecheck --allow-root
 wp plugin install theme-check --activate --allow-root
 wp themecheck --theme=neve --no-interactive --allow-root

--- a/bin/envs/theme-check/start.sh
+++ b/bin/envs/theme-check/start.sh
@@ -1,3 +1,3 @@
-php -d memory_limit=1024M "$(which wp)" package install anhskohbo/wp-cli-themecheck --allow-root
+php -d memory_limit=1024M "$(which wp)" package install Codeinwp/wp-cli-themecheck --allow-root
 wp plugin install theme-check --activate --allow-root
 wp themecheck --theme=neve --no-interactive --allow-root

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -101,7 +101,7 @@ class Woocommerce {
 		add_action( 'wp', array( $this, 'register_hooks' ), 11 );
 		add_action( 'neve_react_controls_localization', array( $this, 'add_customizer_options' ) );
 	}
-	
+
 	/**
 	 * Add params to specify if the site has elementor templates.
 	 *
@@ -113,7 +113,7 @@ class Woocommerce {
 		$options['elementor']['hasElementorProductTemplate'] = Elementor::has_template( 'product' );
 		return $options;
 	}
-	
+
 	/**
 	 * Should module load?
 	 *
@@ -129,7 +129,7 @@ class Woocommerce {
 
 		return ! ( $is_shop_template || $is_product_template );
 	}
-	
+
 	/**
 	 * Register hooks
 	 *
@@ -585,8 +585,7 @@ class Woocommerce {
 			.woocommerce .actions > button[type=submit],
 			.woocommerce button#place_order,
 			.woocommerce .return-to-shop > .button,
-			.woocommerce .button.woocommerce-form-login__submit,
-			.woocommerce.single .quantity input' );
+			.woocommerce .button.woocommerce-form-login__submit' );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
- The issue here was that we targeted all elements in that div with `> *`. If a plugin come and add a script there, the script tag would have `display: flex;`
- Fixed an issue for grouped products. The padding of the primary button was applying to inputs for grouped products.

**NOTE**: You need to have https://github.com/Codeinwp/neve-pro-addon/pull/1431

### Will affect visual aspect of the product
NO

### Screenshots

https://prnt.sc/15otb1h

### Test instructions
- Import test data from WooCommerce https://github.com/woocommerce/woocommerce/tree/master/sample-data
- check that buttons and quantity input has the same height
- Check on normal, variable, grouped, and external products
- Test with seamless add to cart
- Test with quick view modal
- Test with and without Neve Pro

<!-- Issues that this pull request closes. -->
Closes #2903, Closes #2901, Closes #2915, Closes codeinwp/neve-pro-addon#1414
<!-- Should look like this: `Closes #1, #2, #3.` . -->
