### PR TITLE
fix: solve issue with multy worded google fonts #2970

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -553,7 +553,7 @@ window.addEventListener('load', function () {
 
 		if (source.toLowerCase() === 'google') {
 			const linkNode = document.querySelector('#' + id),
-				fontValue = data.value.replace(' ', '+'),
+				fontValue = data.value.split(' ').join('+').split('"').join(''),
 				url =
 					'//fonts.googleapis.com/css?family=' +
 					fontValue +

--- a/inc/customizer/controls/react/src/font-family/FontFamilyComponent.js
+++ b/inc/customizer/controls/react/src/font-family/FontFamilyComponent.js
@@ -60,8 +60,21 @@ const TypefaceComponent = ({ control }) => {
 		return typekitSlugs[font];
 	};
 
+	const wrapFonts = (font) => {
+		const list = font.split(',');
+		const formatList = list.map((fontName) => {
+			if (fontName.includes('serif')) {
+				return fontName.trim();
+			}
+			return '"' + fontName.trim() + '"';
+		});
+		const newFont = formatList.join(', ');
+		return newFont;
+	};
+
 	const onChoseFont = (fontSource, font) => {
 		setFontFamily(font);
+		font = wrapFonts(font);
 		updateControl(font, fontSource);
 	};
 

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -85,6 +85,8 @@ class Font_Manager extends Base_View {
 		// Get list of all Google Fonts.
 		$google_fonts = neve_get_google_fonts();
 
+		$font = str_replace( '"', '', $font );
+
 		// Make sure font is in our list of fonts.
 		if ( ! $google_fonts || ! in_array( $font, $google_fonts, true ) ) {
 			return;


### PR DESCRIPTION
### Summary
Wrapped the Font names in quotes, sanitized the URL request for google fonts API.

### Will affect visual aspect of the product
YES

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/128029046-ea785b48-26db-482a-8a3e-2babfecce0c1.png)
![image](https://user-images.githubusercontent.com/23024731/128029135-938d0578-7a63-4370-9d5f-46420a6025c6.png)


### Test instructions
1. Set any font with a stand-alone number in the name from Customizer -> Typography -> General -> Font family
2. It should be visible on the site.

Closes #2970.
