### PR TITLE
fix: blog custom layout inside loop with masonry

### DIFF
--- a/inc/views/pluggable/masonry.php
+++ b/inc/views/pluggable/masonry.php
@@ -12,13 +12,14 @@ namespace Neve\Views\Pluggable;
 
 use Neve\Customizer\Defaults\Layout;
 use Neve\Views\Base_View;
+use Neve\Views\Template_Parts;
 
 /**
  * Class Masonry
  *
  * @package Neve\Views\Pluggable
  */
-class Masonry extends Base_View {
+class Masonry extends Template_Parts {
 	use Layout;
 	/**
 	 * Function that is run after instantiation.
@@ -28,6 +29,35 @@ class Masonry extends Base_View {
 	public function init() {
 		add_filter( 'neve_filter_main_script_localization', array( $this, 'filter_localization' ) );
 		add_filter( 'neve_filter_main_script_dependencies', array( $this, 'filter_dependencies' ) );
+		add_filter( 'neve_custom_layout_magic_tags', array( $this, 'maybe_wrap_custom_layout' ), PHP_INT_MAX, 2 );
+	}
+
+	/**
+	 * Filter to maybe wrap custom layout in loop when using masonry.
+	 *
+	 * @param string  $content The custom layout content.
+	 * @param integer $post_id The custom post ID.
+	 *
+	 * @return string
+	 */
+	public function maybe_wrap_custom_layout( $content, $post_id ) {
+		if ( ! $this->is_blog() ) {
+			return $content;
+		}
+		if ( ! $this->is_masonry_enabled() ) {
+			return $content;
+		}
+
+		return '<article class="' . $this->post_class() . '">' . $content . '</article>';
+	}
+
+	/**
+	 * Check that the page is in blog context.
+	 *
+	 * @return bool
+	 */
+	private function is_blog() {
+		return ( is_archive() || is_author() || is_category() || is_home() || is_single() || is_tag() );
 	}
 
 	/**

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -43,7 +43,7 @@ class Template_Parts extends Base_View {
 	/**
 	 * Echo the post class.
 	 */
-	private function post_class() {
+	protected function post_class() {
 		$class  = join( ' ', get_post_class() );
 		$layout = $this->get_layout();
 		$class .= ' layout-' . $layout;


### PR DESCRIPTION
### Summary
Wrap Custom Layouts used inside the Post Loop so that they are added to the masonry when this is being used.

### Will affect visual aspect of the product
YES

### Test instructions
1. Create a custom layout, set it to **Hooks** and select **loop entry before/loop entry after/middle posts loop**
2. In **Customizer > Layout > Blog/Archive** set the blog layout to **covers** or **grid**
3. Enable masonry
4. Check the blog page

Closes Codeinwp/neve-pro-addon#1471.