### PR TITLE
fix: items in customizer panel don't adjust when changing presets

### DIFF
--- a/inc/customizer/controls/react/src/builder/HFGBuilderComponent.tsx
+++ b/inc/customizer/controls/react/src/builder/HFGBuilderComponent.tsx
@@ -108,26 +108,6 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 		bindShowOnExpand();
 		bindOverlayNotificationHiding();
 		bindHideOnPaneCollapse();
-
-		document.addEventListener(
-			'neve-changed-builder-value',
-			(e: BuilderChangeEvent) => {
-				const { detail } = e;
-				if (!detail) return false;
-				const { id, value: builderValue } = detail;
-				let actualValue = builderValue;
-
-				if (!actualValue) {
-					actualValue = { ...value };
-				}
-
-				if (!id || `hfg_${id}_layout_v2` !== control.id) return false;
-				onChange(
-					maybeParseJson(actualValue) as BuilderContentInterface
-				);
-				return false;
-			}
-		);
 	}, []);
 
 	return (

--- a/inc/customizer/controls/react/src/builder/components/Slot.tsx
+++ b/inc/customizer/controls/react/src/builder/components/Slot.tsx
@@ -25,7 +25,7 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 		sidebarItems,
 	} = useContext(BuilderContext);
 
-	const { updateLayout, onDragStart } = actions;
+	const { updateLayout, onDragStart, updateSidebarItems } = actions;
 	const [popupOpen, setPopupOpen] = useState<boolean>(false);
 	const [searchQuery, setSearchQuery] = useState<string>('');
 	const slotClasses = classnames('droppable-wrap', slotId, className, {
@@ -41,6 +41,7 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 		nextItems.push({ id: itemId });
 		updateLayout(rowId, slotId, nextItems);
 		setPopupOpen(false);
+		updateSidebarItems();
 	};
 
 	const runSearch = (e: ChangeEvent<HTMLInputElement>) => {


### PR DESCRIPTION
### Summary
Fixes issue where changing header presets wasn't updating the unused items.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
 
- Test that the header preset changes affect the unused items properly;
- This should work flawlessly with the conditional headers from the Pro version;

<!-- Issues that this pull request closes. -->
Closes #3000.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
