### PR TITLE
fix: add back spacing for woocommerce standard pages and fieldset 

### DIFF
--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -78,3 +78,9 @@ main .nv-shop {
 .woocommerce form .form-row textarea:focus {
   box-shadow: 0 0 3px 0 var(--nv-secondary-accent);
 }
+
+.woocommerce-cart,.woocommerce-checkout, .woocommerce-account {
+	.nv-single-page-wrap {
+		margin-bottom: $spacing-aired;
+	}
+}

--- a/assets/scss/components/elements/form-elements/_inputs.scss
+++ b/assets/scss/components/elements/form-elements/_inputs.scss
@@ -52,6 +52,7 @@ label {
 
 fieldset {
   padding: $spacing-lg - 10px $spacing-lg;
+  margin-bottom: $spacing-md;
   border: 2px solid var(--nv-light-bg);
 
   legend {


### PR DESCRIPTION
### Summary

Adds bottom margin to the WooCommerce pages (My account, Checkout, Cart);
Adds bottom margin to `fieldset` tag (that can be visible on the My Account page); 

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

<!-- Issues that this pull request closes. -->
Closes #3002.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
