### PR TITLE
fix: comment reply markup

### DIFF
--- a/assets/scss/components/elements/blog/_comments.scss
+++ b/assets/scss/components/elements/blog/_comments.scss
@@ -34,10 +34,6 @@
 
   ol {
 	list-style: none;
-
-	ol li {
-	  padding-left: $spacing-xl
-	}
   }
 
   textarea {
@@ -106,6 +102,10 @@
 
 .nv-comments-list {
   margin-bottom: $spacing-xxl;
+
+	.children li:not(.children) {
+		padding-left: $spacing-xl
+	}
 }
 
 @mixin comments--tablet() {

--- a/assets/scss/elements/blog/_comments.scss
+++ b/assets/scss/elements/blog/_comments.scss
@@ -148,8 +148,12 @@
       margin-top: $spacing-sm;
     }
 
-    ol > ol {
+    ol > .children {
       padding-left: $spacing-sm;
+    }
+
+    .children {
+      margin-top: $spacing-sm;
     }
 
     .comment-form {

--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -159,7 +159,7 @@ class Comments extends Base_View {
 	public function end_comment_list_callback( $comment, $args, $depth ) {
 		if ( $this->is_tag_open && $comment->comment_parent == 0 ) {
 			$this->is_tag_open = false;
-			echo '</ol></div><!-- close children div -->';
+			echo '</ol></li><!-- close children li -->';
 		}
 	}
 
@@ -251,7 +251,7 @@ class Comments extends Base_View {
 		}
 		if ( $args['has_children'] === true ) {
 			$this->is_tag_open = true;
-			echo '<div class="children" role="listitem"><ol>';
+			echo '<li class="children" role="listitem"><ol>';
 		}
 	}
 

--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -16,6 +16,14 @@ use Neve\Views\Base_View;
  * @package Neve\Views\Partials
  */
 class Comments extends Base_View {
+
+	/**
+	 * Holds if an open children tag is opened for replies.
+	 *
+	 * @var bool
+	 */
+	private $is_tag_open = false;
+
 	/**
 	 * Add in functionality.
 	 */
@@ -61,8 +69,9 @@ class Comments extends Base_View {
 					<?php
 					wp_list_comments(
 						array(
-							'callback' => array( $this, 'comment_list_callback' ),
-							'style'    => 'ol',
+							'callback'     => array( $this, 'comment_list_callback' ),
+							'end-callback' => array( $this, 'end_comment_list_callback' ),
+							'style'        => 'div',
 						)
 					);
 					?>
@@ -138,6 +147,20 @@ class Comments extends Base_View {
 			</div>
 		</nav>
 		<?php
+	}
+
+	/**
+	 * Comment list end callback.
+	 *
+	 * @param string $comment comment.
+	 * @param array  $args    arguments.
+	 * @param int    $depth   the comments depth.
+	 */
+	public function end_comment_list_callback( $comment, $args, $depth ) {
+		if ( $this->is_tag_open && $comment->comment_parent == 0 ) {
+			$this->is_tag_open = false;
+			echo '</ol></div><!-- close children div -->';
+		}
 	}
 
 	/**
@@ -225,6 +248,10 @@ class Comments extends Base_View {
 				</li>
 				<?php
 				break;
+		}
+		if ( $args['has_children'] === true ) {
+			$this->is_tag_open = true;
+			echo '<div class="children" role="listitem"><ol>';
 		}
 	}
 


### PR DESCRIPTION
### Summary
Wrap the children of comments (replies) with a list role and open a new list for them.
This should make it compatible with the correct usage of ARIA roles, and Improve lighthouse compatibility.

### Will affect visual aspect of the product
NO

### Test instructions
1. Post a comment on a blog post.
2. Reply to that comment.
3. Generate the Lighthouse report and check this accessibility audit.

### Notes:
@abaicus Can you let me know if the CSS changes I made are ok, or if you see any issues with the current changes to the HTML structure?

Closes #2974.
