### PR TITLE
Fix archive shop description

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -322,10 +322,6 @@ class Woocommerce {
 	 * Change functions hooked into woocommerce header.
 	 */
 	private function edit_woocommerce_header() {
-		remove_action( 'woocommerce_archive_description', 'woocommerce_taxonomy_archive_description', 10 );
-		remove_action( 'woocommerce_archive_description', 'woocommerce_product_archive_description', 10 );
-		add_action( 'neve_before_shop_loop_content', 'woocommerce_product_archive_description', 0 );
-		add_action( 'neve_before_shop_loop_content', 'woocommerce_taxonomy_archive_description', 0 );
 		remove_action( 'woocommerce_before_main_content', 'woocommerce_breadcrumb', 20 );
 		remove_action( 'woocommerce_before_shop_loop', 'woocommerce_result_count', 20 );
 		remove_action( 'woocommerce_before_shop_loop', 'woocommerce_catalog_ordering', 30 );


### PR DESCRIPTION
### Summary
Removed the code that changes the category description and shops content position.

### Will affect visual aspect of the product
YES


### Test instructions
- Go to woo category in wp dashboard and add a description
- Add page content on shop page
- Check the shop and the category page


<!-- Issues that this pull request closes. -->
Closes #3004 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
