### PR TITLE
fix: hfb not scrolling to header/footer on panel expansion

### DIFF
--- a/inc/customizer/controls/react/src/builder/components/Builder.tsx
+++ b/inc/customizer/controls/react/src/builder/components/Builder.tsx
@@ -71,16 +71,18 @@ const Builder: React.FC<Props> = ({ value, hidden, portalMount }) => {
 	// Offset preview to make space for builder.
 	useEffect(() => {
 		setTimeout(() => {
-			adaptPreviewHeight();
+			adaptPreviewHeight(true);
 		}, 100);
+	}, [hidden]);
 
+	useEffect(() => {
 		window.wp.customize.previewer.bind(
 			'selective-refresh-setting-validities',
 			() => {
-				adaptPreviewHeight(false);
+				adaptPreviewHeight();
 			}
 		);
-	}, [hidden]);
+	}, []);
 
 	const builderClasses = classnames('neve-builder', {
 		hide: hidden,


### PR DESCRIPTION
### Summary
- Fixes the auto-scroll functionality for the header/footer builder;
- Fixes event binding done wrongly - it was running more than once;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go into the customizer
- Open the header or footer panel
- The header panel should scroll the preview to top
- The footer panel should scroll the preview to the footer

<!-- Issues that this pull request closes. -->
// Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
