### PR TITLE
Fix woo account login form

### DIFF
--- a/assets/scss/components/compat/woocommerce/_account.scss
+++ b/assets/scss/components/compat/woocommerce/_account.scss
@@ -18,10 +18,10 @@ body.woocommerce-account {
   }
 
   .woocommerce-form-login .form-row:nth-child(3) {
-	float: left;
-	display: flex;
 	flex-direction: row-reverse;
 	align-items: center;
+	display: flex;
+	justify-content: flex-end;
   }
 
   .woocommerce-form__label-for-checkbox {
@@ -40,7 +40,8 @@ body.woocommerce-account {
 
   .woocommerce-LostPassword {
 	margin: 0;
-	float: right;
+	display: flex;
+	justify-content: flex-end;
   }
 
   h2 {


### PR DESCRIPTION
### Summary
There were some float options on the login button and on the forgot password that were breaking the layout of the form.

### Will affect visual aspect of the product
YES

### Screenshots <!-- if applicable -->
https://vertis.d.pr/uDZMrm

### Test instructions
- Import a starter site with WooCommerce
- Log out and go to the my account page
- Check that the form is not looking bad

<!-- Issues that this pull request closes. -->
Closes #3022.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
