### PR TITLE
fix: footer one widget not showing up on 5.7.2 [closes #3013]

### DIFF
--- a/header-footer-grid/Core/Components/FooterWidgetOne.php
+++ b/header-footer-grid/Core/Components/FooterWidgetOne.php
@@ -55,7 +55,7 @@ class FooterWidgetOne extends Abstract_FooterWidget {
 				self::COMPONENT_ID,
 				array(
 					SettingsManager::TAB_GENERAL => array(
-						'sidebar_widgets-footer-one-widgets' => array(),
+						'sidebars_widgets-footer-one-widgets' => array(),
 					),
 				)
 			);


### PR DESCRIPTION
### Summary
Fixes issue where footer widgets one component was not showing widgets controls in WordPress version 5.7.2
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install core version 5.7.2 (you can do that via WP-CLI using `wp core update --version=5.7.2 --force`);
- Footer Widgets One footer component should show the widget control;
- Everything should work fine on 5.8;

<!-- Issues that this pull request closes. -->
Closes #3013.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
