### PR TITLE
style: remove caret-wrap focus [closes #2979]

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -127,6 +127,10 @@
 	  &.dropdown-open .caret {
 		transform: rotateX(180deg);
 	  }
+
+	  &:focus {
+		outline: none
+	  }
 	}
 
 	.sub-menu {

--- a/assets/scss/elements/navigation/_nav-menu.scss
+++ b/assets/scss/elements/navigation/_nav-menu.scss
@@ -247,6 +247,10 @@
 	}
 }
 
+.carte-wrap:focus {
+	outline: none;
+}
+
 @mixin nav-menu--tablet-sm() {
 	.header-menu-sidebar-inner {
 		.tablet-center {


### PR DESCRIPTION
### Summary
Removes caret focus inside the primary menu.

I checked with other popular themes and it seems that all of them lack a focus outline on the dropdowns.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add a menu with dropdowns inside the mobile sidebar; 
- There should be no outline on tap the dropdown caret;

<!-- Issues that this pull request closes. -->
Closes #2979.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
