### PR TITLE
style: apply typography style in a more generic way inside the editor

### DIFF
--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -1,7 +1,8 @@
 @import "../main/global-colors";
 @import "../main/variables";
 
-.wp-block {
+body &,
+body & p {
 	color: var(--nv-text-color);
 	font-size: var(--bodyFontSize);
 	line-height: var(--bodyLineHeight);
@@ -9,7 +10,9 @@
 	font-family: var(--bodyFontFamily);
 	text-transform: var(--bodyTextTransform);
 	font-weight: var(--bodyFontWeight);
+}
 
+.wp-block {
 	// Group colors
 	&.has-text-color .wp-block {
 		color: inherit;


### PR DESCRIPTION
### Summary
Fixes social icons block appearance inside the editor. 
Previously we added the typography and colors to all `.wp-block` elements. Now we do it in a more generic way by styling the following selectors:

```
body .editor-styles-wrapper,
body .editor-styles-wrapper p 
```
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
- Add a social icons block inside the editor. It should look fine, as opposed to what is described in the issue;
- All typography settings from the customizer should still apply as expected inside the editor;
<!-- Describe how this pull request can be tested. -->

<!-- Issues that this pull request closes. -->
Closes #3031.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
