### PR TITLE
fix: tag spacing for posts [closes #3041]

### DIFF
--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -90,13 +90,14 @@
 }
 
 .nv-tags-list,
+.wp-block-tag-cloud,
 .tagcloud {
 
 	a {
-		margin-left: $spacing-xs;
+		margin: 0 $spacing-xs $spacing-xs 0;
 		font-weight: 700;
 		text-transform: uppercase;
-		color: #fff;
+		color: #fff !important;
 		padding: 10px;
 		border-radius: 4px;
 		background: var(--nv-primary-accent);
@@ -104,16 +105,15 @@
 		font-size: 0.75em !important;
 		display: inline-block;
 	}
+
+	span {
+		margin-right: $spacing-xs;
+	}
 }
 
 .tagcloud {
 	display: flex;
 	flex-wrap: wrap;
-
-	a {
-		margin: 0 $spacing-xs $spacing-xs 0;
-		color: #fff !important;
-	}
 }
 
 .nv-post-cover {


### PR DESCRIPTION
### Summary
- fixes tag spacing for posts mentioned in #3041 
- styles the tags block inside sidebars
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/15010186/131474882-cba22d3a-fb3d-47c9-af9a-38946622b360.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- add a lot of tags to a post so they go on two rows. spacing should be ok
- add tag blocks inside the sidebar. these should be properly styled

<!-- Issues that this pull request closes. -->
Closes #3041.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
