### PR TITLE
fix: customizer live refresh selector for header menu sidebar

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -441,7 +441,7 @@ abstract class Abstract_Builder implements Builder {
 				'live_refresh_css_prop' => [
 					'cssVar'  => [
 						'vars'     => '--color',
-						'selector' => $row_class,
+						'selector' => $row_id === 'sidebar' ? '.header-menu-sidebar-bg' : '.' . $this->get_id() . '-' . $row_id,
 					],
 					'partial' => $row_id === 'sidebar' ? 'hfg_header_layout_partial' : $row_setting_id . '_partial',
 				],


### PR DESCRIPTION
### Summary
Fixes customizer live refresh selector for header menu sidebar text color. It previously didn't work. 
The default value for the primary menu color is empty on the new skin, so this control should also change that on a new site.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure you set up a fresh instance and that you don't import the starter content
- Set up a basic primary menu and make sure it's both in the sidebar and on one of the desktop rows
- Go to the mobile sidebar controls inside the customizer
- The text color control should control the primary menu color as well as other components' text color
- The changes should properly reflect on the front end

<!-- Issues that this pull request closes. -->
Closes #2958.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
