### PR TITLE
Fix round sale tag

### DIFF
--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -10,11 +10,13 @@ main .nv-shop {
 	span.onsale {
 		background-color: $success;
 		border-radius: 0;
-		line-height: inherit;
-		min-height: auto;
 		left: 0;
 		top: 0;
 		font-weight: 500;
+		min-height: 3em;
+		min-width: 3em;
+		line-height: calc( 3em - 10px )!important;
+		padding: 5px;
 	}
 
 	ul.products li.product .onsale {
@@ -22,11 +24,6 @@ main .nv-shop {
 		left: 0;
 		right: auto;
 		margin: 0;
-		min-height: 3em;
-		min-width: 3em;
-		line-height: calc( 3em - 10px );
-	  	font-size: 1em;
-		padding: 5px;
 	}
 }
 

--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -15,8 +15,8 @@ main .nv-shop {
 		font-weight: 500;
 		min-height: 3em;
 		min-width: 3em;
-		line-height: calc( 3em - 10px )!important;
-		padding: 5px;
+		line-height: 3!important;
+		padding: 0 5px;
 	}
 
 	ul.products li.product .onsale {

--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -22,6 +22,11 @@ main .nv-shop {
 		left: 0;
 		right: auto;
 		margin: 0;
+		min-height: 3em;
+		min-width: 3em;
+		line-height: calc( 3em - 10px );
+	  	font-size: 1em;
+		padding: 5px;
 	}
 }
 

--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -15,7 +15,7 @@ main .nv-shop {
 		font-weight: 500;
 		min-height: 3em;
 		min-width: 3em;
-		line-height: 3!important;
+		line-height: 3 !important;
 		padding: 0 5px;
 	}
 


### PR DESCRIPTION
### Summary
The solution that I've chosen for this is to have the sale tag square as long as the content is small enough.

### Will affect visual aspect of the product
YES

### Screenshots
https://github.com/Codeinwp/neve-pro-addon/issues/1475#issuecomment-908197765

### Test instructions
- Install Woo and add some products on sale
- Make the sale tag round in the customizer


<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1475.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
