### PR TITLE
Fix pll search on other language

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -5,18 +5,23 @@
  * @package Neve.
  */
 
-$placeholder     = apply_filters( 'nv_search_placeholder', __( 'Search for...', 'neve' ) );
-$aria_label      = __( 'Search', 'neve' );
-$current_lang    = function_exists( 'pll_current_language' ) ? pll_current_language() : '';
-$default_lang    = function_exists( 'pll_default_language' ) ? pll_default_language() : '';
-$language_subdir = $current_lang !== $default_lang ? $current_lang . '/' : '';
+$placeholder = apply_filters( 'nv_search_placeholder', __( 'Search for...', 'neve' ) );
+$aria_label  = __( 'Search', 'neve' );
+$home_url    = home_url( '/' );
+
+if ( function_exists( 'PLL' ) ) {
+	$pll_data = PLL();
+	if ( property_exists( $pll_data, 'links' ) && method_exists( $pll_data->links, 'get_home_url' ) ) {
+		$home_url = $pll_data->links->get_home_url( null, true );
+	}
+}
 
 ?>
 
 <form role="search"
 	method="get"
 	class="search-form"
-	action="<?php echo esc_url( home_url( '/' . $language_subdir ) ); ?>">
+	action="<?php echo esc_url( $home_url ); ?>">
 	<label>
 		<span class="screen-reader-text"><?php echo esc_html__( 'Search for...', 'neve' ); ?></span>
 	</label>

--- a/searchform.php
+++ b/searchform.php
@@ -8,7 +8,6 @@
 $placeholder = apply_filters( 'nv_search_placeholder', __( 'Search for...', 'neve' ) );
 $aria_label  = __( 'Search', 'neve' );
 $home_url    = home_url( '/' );
-
 if ( function_exists( 'PLL' ) ) {
 	$pll_data = PLL();
 	if ( property_exists( $pll_data, 'links' ) && method_exists( $pll_data->links, 'get_home_url' ) ) {

--- a/searchform.php
+++ b/searchform.php
@@ -5,14 +5,18 @@
  * @package Neve.
  */
 
-$placeholder = apply_filters( 'nv_search_placeholder', __( 'Search for...', 'neve' ) );
-$aria_label  = __( 'Search', 'neve' );
+$placeholder     = apply_filters( 'nv_search_placeholder', __( 'Search for...', 'neve' ) );
+$aria_label      = __( 'Search', 'neve' );
+$current_lang    = function_exists( 'pll_current_language' ) ? pll_current_language() : '';
+$default_lang    = function_exists( 'pll_default_language' ) ? pll_default_language() : '';
+$language_subdir = $current_lang !== $default_lang ? $current_lang . '/' : '';
+
 ?>
 
 <form role="search"
 	method="get"
 	class="search-form"
-	action="<?php echo esc_url( home_url( '/' ) ); ?>">
+	action="<?php echo esc_url( home_url( '/' . $language_subdir ) ); ?>">
 	<label>
 		<span class="screen-reader-text"><?php echo esc_html__( 'Search for...', 'neve' ); ?></span>
 	</label>


### PR DESCRIPTION
### Summary
Due to Polylang implementation, we must specify in what language should the search happen.

### Will affect visual aspect of the product
NO


### Test instructions
- Install Polylang, add more languages then translate the posts for each language
- Switch to a specific language and use the search form


<!-- Issues that this pull request closes. -->
Closes #2999.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
