### PR TITLE
chore: drop form fields & labels spacing controls & fix password-protected posts

### DIFF
--- a/assets/scss/components/compat/woocommerce/_account.scss
+++ b/assets/scss/components/compat/woocommerce/_account.scss
@@ -13,20 +13,11 @@ body.woocommerce-account {
 		margin-bottom: 0;
 	}
 
-	.form-row {
-		margin: 0;
-		padding: 0;
-	}
-
 	.woocommerce-form-login .form-row:nth-child(3) {
 		flex-direction: row-reverse;
 		align-items: center;
 		display: flex;
 		justify-content: flex-end;
-	}
-
-	.woocommerce-form__label-for-checkbox {
-		--formLabelSpacing: 0;
 	}
 
 	nav > ul {

--- a/assets/scss/components/compat/woocommerce/_blocks.scss
+++ b/assets/scss/components/compat/woocommerce/_blocks.scss
@@ -15,7 +15,3 @@
 		@extend %nv-button-primary-hover;
 	}
 }
-
-input.wc-block-product-search__field {
-	--formFieldSpacing: 0;
-}

--- a/assets/scss/components/compat/woocommerce/_cart.scss
+++ b/assets/scss/components/compat/woocommerce/_cart.scss
@@ -9,11 +9,6 @@
 
 //</editor-fold>
 
-#coupon_code {
-
-	@extend %nv-reset-field-spacing;
-}
-
 //<editor-fold desc="Coupon code">
 .woocommerce table.cart td.actions .input-text#coupon_code {
 	width: 200px;

--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -162,7 +162,6 @@
 .woocommerce-page {
 
 	.select2-container {
-		margin-bottom: var(--formFieldSpacing);
 
 		&.select2-container--open {
 			outline: 0;
@@ -178,8 +177,6 @@
 
 	.select2-container--default .select2-selection--single {
 		height: auto;
-
-		@extend %nv-reset-field-spacing;
 	}
 
 	.select2-container--default .select2-selection--single,

--- a/assets/scss/components/compat/woocommerce/_generic.scss
+++ b/assets/scss/components/compat/woocommerce/_generic.scss
@@ -88,3 +88,7 @@ main .nv-shop {
 		margin-bottom: $spacing-aired;
 	}
 }
+
+.woocommerce form .form-row {
+	margin-bottom: $spacing-md;
+}

--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -8,11 +8,6 @@
 	position: relative;
 }
 
-.qty {
-
-	@extend %nv-reset-field-spacing;
-}
-
 .woocommerce.single .nv-woo-filters {
 	display: none;
 }

--- a/assets/scss/components/compat/woocommerce/_shop-loop.scss
+++ b/assets/scss/components/compat/woocommerce/_shop-loop.scss
@@ -1,10 +1,5 @@
 @import "../../main/variables";
 
-.woocommerce .woocommerce-ordering select {
-
-	@extend %nv-reset-field-spacing;
-}
-
 .nv-woo-filters {
 	display: flex;
 	align-items: center;

--- a/assets/scss/components/compat/woocommerce/single/_reviews.scss
+++ b/assets/scss/components/compat/woocommerce/single/_reviews.scss
@@ -14,14 +14,6 @@
 	#reviews {
 		display: grid;
 		grid-row-gap: $spacing-xl;
-		--formFieldSpacing: 10px;
-
-		form {
-
-			p {
-				margin-bottom: 0 !important;
-			}
-		}
 
 		.comment-form-cookies-consent {
 			margin-bottom: $spacing-md !important;

--- a/assets/scss/components/elements/_form-elements.scss
+++ b/assets/scss/components/elements/_form-elements.scss
@@ -11,8 +11,6 @@
 	display: flex;
 	max-width: 100%;
 	line-height: 1;
-	--formFieldSpacing: 0;
-	--formLabelSpacing: 0;
 	--primaryBtnBg: var(--formFieldBgColor);
 	--primaryBtnHoverBg: var(--formFieldBgColor);
 	--primaryBtnColor: var(--formFieldBorderColor);

--- a/assets/scss/components/elements/_sidebar.scss
+++ b/assets/scss/components/elements/_sidebar.scss
@@ -41,8 +41,6 @@
 	li {
 		margin-top: $spacing-xs;
 	}
-
-	@extend %nv-reset-field-spacing;
 }
 
 .wp-block-search .wp-block-search__button {

--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -65,6 +65,10 @@
 	}
 }
 
+.post-password-form input[type="submit"] {
+	margin-top: $spacing-md;
+}
+
 .nv-tags-list,
 .tagcloud {
 

--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -65,30 +65,6 @@
 	}
 }
 
-.post-password-form {
-	margin-bottom: $spacing-md;
-	text-align: center;
-
-	input[type="submit"] {
-		height: 39px;
-		margin-left: $spacing-xs;
-	}
-
-	label {
-		margin-bottom: 0;
-	}
-
-	p {
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
-
-	label > input {
-		margin-left: $spacing-xs;
-	}
-}
-
 .nv-tags-list,
 .tagcloud {
 

--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -105,7 +105,6 @@
 
 // Form Fields
 %nv-form-fields {
-	margin-bottom: var(--formFieldSpacing);
 	border-style: solid;
 	border-color: var(--formFieldBorderColor);
 	border-width: var(--formFieldBorderWidth);
@@ -123,16 +122,11 @@
 }
 
 %nv-form-labels {
-	margin-bottom: var(--formLabelSpacing);
 	font-weight: var(--formLabelFontWeight, var(--bodyFontWeight));
 	text-transform: var(--formLabelTextTransform);
 	letter-spacing: var(--formLabelLetterSpacing);
 	line-height: var(--formLabelLineHeight);
 	font-size: var(--formLabelFontSize, var(--bodyFontSize));
-}
-
-%nv-reset-field-spacing {
-	--formFieldSpacing: 0;
 }
 
 %nv-has-typography {

--- a/assets/scss/woocommerce/_cart.scss
+++ b/assets/scss/woocommerce/_cart.scss
@@ -129,10 +129,6 @@
     border-top: $muted-border;
   }
 
-  .form-row {
-    padding: 5px 0;
-  }
-
   ul#shipping_method {
     text-align: left;
 

--- a/assets/scss/woocommerce/_checkout.scss
+++ b/assets/scss/woocommerce/_checkout.scss
@@ -74,10 +74,6 @@
 		align-items: center;
 	  }
 
-	  .form-row {
-		padding: 0;
-	  }
-
 	  .lost_password {
 		float: right;
 	  }
@@ -139,11 +135,6 @@
 
 	label {
 	  font-size: .85em;
-	}
-
-	.form-row {
-	  padding: 0;
-	  margin-bottom: 0;
 	}
 
 	textarea {
@@ -315,7 +306,6 @@
 	  flex-direction: row;
 
 	  p.form-row {
-		margin-bottom: 0;
 		width: auto;
 	  }
 

--- a/assets/scss/woocommerce/_generic.scss
+++ b/assets/scss/woocommerce/_generic.scss
@@ -140,6 +140,10 @@ $notices: (
 
 //</editor-fold>
 
+.woocommerce form .form-row {
+	margin-bottom: 20px;
+}
+
 
 @mixin generic--tablet-sm() {
 	.woocommerce-notices-wrapper > div {

--- a/e2e-tests/cypress/integration/customizer/form-fields/form-fields.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/form-fields/form-fields.spec.ts
@@ -40,8 +40,7 @@ describe('Form fields', function () {
 			.and('have.css', 'line-height', '24px')
 			.and('have.css', 'letter-spacing', '1.5px')
 			.and('have.css', 'font-weight', '100')
-			.and('have.css', 'text-transform', 'capitalize')
-			.and('have.css', 'margin-bottom', '20px');
+			.and('have.css', 'text-transform', 'capitalize');
 	});
 	it('Checks up the button', function () {
 		cy.visit('/hello-world');

--- a/inc/core/settings/mods.php
+++ b/inc/core/settings/mods.php
@@ -377,8 +377,6 @@ class Mods {
 					'tablet-unit'  => 'px',
 					'mobile-unit'  => 'px',
 				];
-			case Config::MODS_FORM_FIELDS_SPACING:
-				return $new ? 40 : 10;
 			case Config::MODS_FORM_FIELDS_PADDING:
 				return [
 					'top'    => $new ? 10 : 7,

--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -812,11 +812,6 @@ class Frontend extends Generator {
 		$this->_subscribers[] = [
 			Dynamic_Selector::KEY_SELECTOR => ':root',
 			Dynamic_Selector::KEY_RULES    => [
-				'--formFieldSpacing'       => [
-					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_SPACING,
-					Dynamic_Selector::META_DEFAULT => Mods::get_alternative_mod_default( Config::MODS_FORM_FIELDS_SPACING ),
-					Dynamic_Selector::META_SUFFIX  => 'px',
-				],
 				'--formFieldBorderWidth'   => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_BORDER_WIDTH,
 					Dynamic_Selector::META_SUFFIX  => 'px',
@@ -871,11 +866,6 @@ class Frontend extends Generator {
 					Dynamic_Selector::META_KEY => Config::MODS_FORM_FIELDS_TYPEFACE . '.fontWeight',
 				],
 				// Form Labels
-				'--formLabelSpacing'       => [
-					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_LABELS_SPACING,
-					Dynamic_Selector::META_DEFAULT => 10,
-					Dynamic_Selector::META_SUFFIX  => 'px',
-				],
 				'--formLabelFontSize'      => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.fontSize',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
@@ -1043,13 +1033,6 @@ class Frontend extends Generator {
 	 * Setup legacy form field styles.
 	 */
 	private function setup_legacy_form_fields_style() {
-		$this->_subscribers[ Config::CSS_SELECTOR_FORM_INPUTS_WITH_SPACING ] = [
-			Config::CSS_PROP_MARGIN_BOTTOM => [
-				Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_SPACING,
-				Dynamic_Selector::META_DEFAULT => 10,
-			],
-		];
-
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_INPUTS ] = [
 			Config::CSS_PROP_BACKGROUND_COLOR => Config::MODS_FORM_FIELDS_BACKGROUND_COLOR,
 			Config::CSS_PROP_BORDER_WIDTH     => Config::MODS_FORM_FIELDS_BORDER_WIDTH,
@@ -1089,11 +1072,6 @@ class Frontend extends Generator {
 		];
 
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_INPUTS_LABELS ] = [
-			Config::CSS_PROP_MARGIN_BOTTOM  => [
-				Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_LABELS_SPACING,
-				Dynamic_Selector::META_SUFFIX  => 'px',
-				Dynamic_Selector::META_DEFAULT => 10,
-			],
 			Config::CSS_PROP_FONT_SIZE      => [
 				Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.fontSize',
 				Dynamic_Selector::META_IS_RESPONSIVE => true,

--- a/inc/customizer/options/form_fields.php
+++ b/inc/customizer/options/form_fields.php
@@ -75,7 +75,7 @@ class Form_Fields extends Base_Customizer {
 					'priority'         => 10,
 					'class'            => 'form-fields-accordion',
 					'accordion'        => true,
-					'controls_to_wrap' => 6,
+					'controls_to_wrap' => 5,
 				],
 				'Neve\Customizer\Controls\Heading'
 			)
@@ -131,46 +131,6 @@ class Form_Fields extends Base_Customizer {
 					],
 				],
 				'\Neve\Customizer\Controls\React\Nr_Spacing'
-			)
-		);
-
-		// Spacing
-		$default_spacing = Mods::get_alternative_mod_default( Config::MODS_FORM_FIELDS_SPACING );
-		$this->add_control(
-			new Control(
-				Config::MODS_FORM_FIELDS_SPACING,
-				[
-					'sanitize_callback' => 'absint',
-					'transport'         => $this->selective_refresh,
-					'default'           => $default_spacing,
-				],
-				[
-					'label'                 => esc_html__( 'Field Spacing', 'neve' ),
-					'section'               => $this->section_id,
-					'type'                  => 'neve_range_control',
-					'input_attrs'           => [
-						'min'        => 50,
-						'max'        => 100,
-						'defaultVal' => $default_spacing,
-					],
-					'priority'              => 16,
-					'live_refresh_selector' => true,
-					'live_refresh_css_prop' => [
-						'cssVar'   => [
-							'selector' => 'body',
-							'vars'     => '--formFieldSpacing',
-							'suffix'   => 'px',
-						],
-						'template' => '
-						 form:not([role="search"]):not(.woocommerce-cart-form):not(.woocommerce-ordering):not(.cart) input:read-write:not(#coupon_code),
-						 form textarea,
-						 form select,
-						 .woocommerce-page .select2 {
-						    margin-bottom: {{value}}px;
-					     }',
-					],
-				],
-				'Neve\Customizer\Controls\React\Range'
 			)
 		);
 
@@ -522,43 +482,9 @@ class Form_Fields extends Base_Customizer {
 					'class'            => 'form-labels-accordion',
 					'accordion'        => true,
 					'expanded'         => false,
-					'controls_to_wrap' => 2,
+					'controls_to_wrap' => 1,
 				],
 				'Neve\Customizer\Controls\Heading'
-			)
-		);
-
-		// Label spacing
-		$this->add_control(
-			new Control(
-				Config::MODS_FORM_FIELDS_LABELS_SPACING,
-				[
-					'sanitize_callback' => 'absint',
-					'transport'         => $this->selective_refresh,
-					'default'           => 10,
-				],
-				[
-					'label'                 => esc_html__( 'Label Spacing', 'neve' ),
-					'section'               => $this->section_id,
-					'type'                  => 'neve_range_control',
-					'input_attrs'           => [
-						'min'        => 50,
-						'max'        => 100,
-						'defaultVal' => 10,
-					],
-					'priority'              => 51,
-					'live_refresh_selector' => true,
-					'live_refresh_css_prop' => [
-						'cssVar'     => [
-							'selector' => 'body',
-							'suffix'   => 'px',
-							'vars'     => '--formLabelSpacing',
-						],
-						'responsive' => false,
-						'template'   => 'body form label, body .wpforms-container .wpforms-field-label, .woocommerce form .form-row label {margin-bottom: {{value}}px;}',
-					],
-				],
-				'Neve\Customizer\Controls\React\Range'
 			)
 		);
 


### PR DESCRIPTION
### Summary

Goes together with [this PR](https://github.com/Codeinwp/neve-pro-addon/pull/1543), but should still work fine with the old version of Pro. It's just some minor CSS rules removed over there.

Removes the form fields spacing and from label spacing controls inside the customizer;
Adds 20px distance for WooCommerce forms (Checkout, My Account, etc);
Removes any other margin we used to have on generic form fields;
Fixes Password Protected posts style. They will be left-aligned from now on;

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
Yes

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Nothing should be broken with forms - in terms of how it looks;
- Everything should still work inside the customizer as expected;
- Create a password-protected post;
- The password form should look ok and be left-aligned;

<!-- Issues that this pull request closes. -->
Closes #2996
Closes #3042 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
