### PR TITLE
fix: letterbox effect on video embeds

### DIFF
--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -15,7 +15,6 @@ dl {
 .nv-iframe-embed {
 	position: relative;
 	padding-bottom: 56.25%; /* 16:9 */
-	padding-top: 25px;
 	height: 0;
 
 	iframe {

--- a/assets/scss/elements/_content.scss
+++ b/assets/scss/elements/_content.scss
@@ -3,7 +3,6 @@
 .nv-iframe-embed {
   position: relative;
   padding-bottom: 56.25%; /* 16:9 */
-  padding-top: 25px;
   height: 0;
 
   iframe {

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -234,7 +234,6 @@ class Front_End {
 			'youtu.be',
 			'cloudup.com',
 			'dailymotion.com',
-			'collegehumor.com',
 			'ted.com',
 			'vimeo.com',
 		];


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Removes the letterbox effect from video embeds for the following sources:
- youtube.com
- youtu.be
- cloudup.com
- dailymotion.com
- ted.com
- vimeo.com

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots
![image](https://user-images.githubusercontent.com/15010186/131689687-f0d1e682-96f9-4237-a5d1-02786486bef6.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add embeds from the sites mentioned above;
- They should not have the letterbox effect mentioned in the issue;
- This should be fixed on the old skin as well;

<!-- Issues that this pull request closes. -->
Closes #1220.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
