### PR TITLE
chore: old skin custom layouts not acting properly

### DIFF
--- a/assets/scss/main/_gutenberg.scss
+++ b/assets/scss/main/_gutenberg.scss
@@ -19,6 +19,7 @@ body {
 	  .alignfull, .alignwide {
 		max-width: 100%;
 		margin-left: auto;
+		margin-right: auto;
 	  }
   }
 }


### PR DESCRIPTION
### Summary
On old skin, custom layouts that were wide-aligned were placed to the right instead of the center. Now they should work fine
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a custom layout, add a cover block, columns block, or any other block that can be aligned wide. It's easier to see the difference using a block with a background.;
- Replace the header / footer / 404 page with the custom layout;
- The custom layout should display center-aligned, not to the right

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1474.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
