### PR TITLE
Add cypress test for sidebar menu subitems alignment

### DIFF
--- a/e2e-tests/cypress/fixtures/customizer/hfg/menu-item-alignment-setup.json
+++ b/e2e-tests/cypress/fixtures/customizer/hfg/menu-item-alignment-setup.json
@@ -1,0 +1,10 @@
+{
+    "neve_migrated_hfg_colors": true,
+    "nav_menu_locations": {
+        "primary": 176
+    },
+    "ti_prev_theme": "twentytwentyone",
+    "neve_ran_migrations": true,
+    "custom_css_post_id": -1,
+    "hfg_header_layout_v2": "{\"desktop\":{\"top\":{\"left\":[],\"c-left\":[],\"center\":[{\"id\":\"nav-icon\"}],\"c-right\":[],\"right\":[]},\"main\":{\"left\":[{\"id\":\"logo\"}],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[{\"id\":\"primary-menu\"}]},\"bottom\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]}},\"mobile\":{\"top\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"main\":{\"left\":[{\"id\":\"logo\"}],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[{\"id\":\"nav-icon\"}]},\"bottom\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"sidebar\":[{\"id\":\"primary-menu\"}]}}"
+}

--- a/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
@@ -1,0 +1,20 @@
+describe('Menu item alignment', function () {
+	before('Setup customizer', function () {
+		cy.fixture('customizer/hfg/menu-item-alignment-setup').then((setup) => {
+			cy.setCustomizeSettings(setup);
+		});
+	});
+	it('Checks up item alignment', function () {
+		cy.visit('/');
+		cy.findByRole('button', {
+			name: /navigation menu/i,
+		}).click();
+		cy.get('.menu-item-title-wrap')
+			.contains('About The Tests')
+			.should('have.css', 'text-align', 'left');
+		cy.get(
+			'#nv-primary-navigation-sidebar > .menu-item-1643 > [href="http://localhost:8080/level-1/"] > .caret-wrap',
+		).click();
+		cy.get('.menu-item-title-wrap').contains('Level 2').should('have.css', 'text-align', 'left');
+	});
+});


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Adds a cypress test for checking the menu subitems alignment, as it was a regression issue. 
This was part of the cypress dojo.
### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- All specs should pass the pipeline

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve/issues/3061 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
