### PR TITLE
fix: list indent overrides some blocks that contain ul/ol

### DIFF
--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -58,6 +58,7 @@ pre {
 .nv-content-wrap,
 .excerpt-wrap {
 	--listPad: 20px;
+	--listStyle: disc;
 
 	&::after {
 		content: "";
@@ -65,15 +66,10 @@ pre {
 		display: table;
 	}
 
-	ul {
-		list-style-type: initial;
-	}
-
 	> ul,
 	> ol {
 		margin: $spacing-lg 0;
 	}
-
 
 	li {
 		margin-top: $spacing-xs;

--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -57,6 +57,7 @@ pre {
 
 .nv-content-wrap,
 .excerpt-wrap {
+	--listPad: 20px;
 
 	&::after {
 		content: "";
@@ -73,10 +74,6 @@ pre {
 		margin: $spacing-lg 0;
 	}
 
-	ul,
-	ol {
-		padding-left: $spacing-lg;
-	}
 
 	li {
 		margin-top: $spacing-xs;

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -100,3 +100,7 @@ ul,
 ol {
 	padding-left: var(--listPad, 0);
 }
+
+ul {
+	list-style: var(--listStyle, none);
+}

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -95,3 +95,8 @@ h6 {
 	letter-spacing: var(--h6LetterSpacing);
 	text-transform: var(--h6TextTransform);
 }
+
+ul,
+ol {
+	padding-left: var(--listPad, 0);
+}


### PR DESCRIPTION
### Summary
Fixes issue with list indents interfering with some block styles that contained ul/ol tags.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add some lists that have multiple indent levels;
- The lists should have spacing to the left;
- Add blocks that contain ul/ol tags (you can try the ones mentioned in the issue [here](https://github.com/Codeinwp/neve/issues/3028));
- These blocks should look fine, having no space on the left side;
- No other lists inside the theme should be affected (Navigation Menus, or any other component using `<ul>` & `<ol>` tags;
- Blocks mentioned inside the issue should not have the list-style (the dots/numbers before li elements), but lists in content should have them;

<!-- Issues that this pull request closes. -->
Closes #3028.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
