### PR TITLE
Fix sidebar visibility on customizer preview

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -761,9 +761,11 @@ if (!newSkin) {
 			$.each(this.contentWidths, function (id, args) {
 				wp.customize(id, function (value) {
 					value.bind(function (newval) {
+						const hideSidebar = newval >= 95 ? `display:none` : ``;
+
 						const style = ` @media (min-width: 961px) {
 							${args.content} { max-width: ${newval}% !important; }
-							${args.sidebar} { max-width: ${100 - newval}% !important; }
+							${args.sidebar} { max-width: ${100 - newval}% !important; ${hideSidebar} }
 						}`;
 						addCSS(id + '-css', style);
 					});

--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -761,12 +761,19 @@ if (!newSkin) {
 			$.each(this.contentWidths, function (id, args) {
 				wp.customize(id, function (value) {
 					value.bind(function (newval) {
-						const hideSidebar = newval >= 95 ? `display:none` : ``;
+						const sidebar = $('.nv-sidebar-wrap');
+
+						if (newval >= 95) {
+							sidebar.addClass('hide');
+						} else {
+							sidebar.removeClass('hide');
+						}
 
 						const style = ` @media (min-width: 961px) {
 							${args.content} { max-width: ${newval}% !important; }
-							${args.sidebar} { max-width: ${100 - newval}% !important; ${hideSidebar} }
+							${args.sidebar} { max-width: ${100 - newval}% !important; }
 						}`;
+
 						addCSS(id + '-css', style);
 					});
 				});

--- a/assets/scss/components/elements/_sidebar.scss
+++ b/assets/scss/components/elements/_sidebar.scss
@@ -11,7 +11,7 @@
 	flex-grow: 1;
 
 	&.hide {
-		display:none;
+		display: none;
 	}
 }
 

--- a/assets/scss/components/elements/_sidebar.scss
+++ b/assets/scss/components/elements/_sidebar.scss
@@ -9,6 +9,10 @@
 	padding: $spacing-aired 15px;
 	margin-bottom: $spacing-md;
 	flex-grow: 1;
+
+	&.hide {
+		display:none;
+	}
 }
 
 .widget {

--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -48,7 +48,7 @@ class Layout_Sidebar extends Base_View {
 			$content_width = $meta_width;
 		}
 
-		if ( $content_width >= 95 ) {
+		if ( $content_width >= 95 && ! is_customize_preview() ) {
 			return;
 		}
 

--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -48,8 +48,16 @@ class Layout_Sidebar extends Base_View {
 			$content_width = $meta_width;
 		}
 
-		if ( $content_width >= 95 && ! is_customize_preview() ) {
-			return;
+		$class_hide_sidebar_conditionally = '';
+
+		if ( $content_width >= 95 ) {
+			if ( is_customize_preview() ) {
+				// render the sidebar and hide it with CSS
+				$class_hide_sidebar_conditionally = 'hide';
+			} else {
+				// do not load sidebar as SSR
+				return;
+			}
 		}
 
 		if ( $theme_mod !== $position ) {
@@ -61,7 +69,7 @@ class Layout_Sidebar extends Base_View {
 		}
 
 		$args = array(
-			'wrap_classes' => 'nv-' . $position . ' ' . $sidebar_setup['sidebar_slug'],
+			'wrap_classes' => 'nv-' . $position . ' ' . $sidebar_setup['sidebar_slug'] . ' ' . $class_hide_sidebar_conditionally,
 			'data_attrs'   => apply_filters( 'neve_sidebar_data_attrs', '', $sidebar_setup['sidebar_slug'] ),
 			'close_button' => $this->get_sidebar_close( $sidebar_setup['sidebar_slug'] ),
 			'slug'         => $sidebar_setup['sidebar_slug'],


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
With the PR, if the content width of the layout that has "Others" type exceed the 95%, hide sidebar on the customizer preview.

Before the PR, page reload was required.

Note: I have tested the other post types such as blog/archive, the sidebar always seems even the content width is 100%. So, I'm not sure if we use the fix these.

My some findings before the PR:
- blog/archive - it's not working, the sidebar shows all time even if the content %100.
- single post - it's not working, the sidebar shows all time even if the content %100.
- shop/archive - it's not working, the sidebar shows all time even if the content %100.
- single product - when content width is exceed the 95%, the sidebar is hidden on frontend but it's showed on customizer
- other - when content width is exceed the 95%, the sidebar is hidden on frontend but it's showed on customizer

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Open customizer -> Layout -> Content/Sidebar -> Others
- Change content width, if content width exceed 95%, it should be hidden on customizer preview and frontend.
- Change content width, if content width under the 95%, it should be showed on customizer preview and frontend.

<!-- Issues that this pull request closes. -->
Closes #3019 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
