### PR TITLE
Fix customizer load error with elementor-pro

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -354,7 +354,7 @@ class Elementor extends Page_Builder_Base {
 
 		$transient_key        = 'neve_elementor_has_template_' . $elementor_template_type;
 		$transient_expiry_sec = HOUR_IN_SECONDS;
-		$cached_value         = get_transient( $transient_key );
+		$cached_value         = get_transient( $transient_key ) == true; // cast transient (string) to bool
 
 		if ( $force_refresh !== true && $cached_value !== false ) {
 			return $cached_value;


### PR DESCRIPTION

### Summary
Currently customizer fails to load when elementor-pro is installed but no "product" or "product-archive" template is present. This happens because on `inc/compatibility/woocommerce.php` L114, `NeveReactCustomize.elementor` is set to `{ hasElementorProductTemplate: "0", hasElementorShopTemplate: "0" }` as `Elementor::has_template` returns string value instead of bool or int. In JavaScript land, "0" is a truthy value, unlike php thus resulting in an error being thrown.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add neve (master) & elementor-pro to a wordpress site 
- Open customizer. You'll see customizer sections fail to load
- Merge PR
- Open customizer again. It should load properly now
