### PR TITLE
Fix underline links

### DIFF
--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -170,10 +170,6 @@ pre {
 
 
 // === Links === //
-a {
-	text-decoration: none;
-}
-
 a:not(.wp-block-button__link) {
 	color: var(--nv-primary-accent);
 

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -44,10 +44,14 @@ a {
 	}
 }
 
-.entry-content, .widget_text, .page .neve-main, .nv-comment-content {
-  a {
-	text-decoration: underline;
-  }
+.entry-content,
+.widget_text,
+.page .neve-main,
+.nv-comment-content {
+
+	a {
+		text-decoration: underline;
+	}
 }
 
 ins {

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -44,6 +44,12 @@ a {
 	}
 }
 
+.entry-content, .widget_text, .page .neve-main, .nv-comment-content {
+  a {
+	text-decoration: underline;
+  }
+}
+
 ins {
 	text-decoration: none;
 }

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -46,7 +46,7 @@ a {
 
 .entry-content,
 .widget_text,
-.page .neve-main,
+.page-template .neve-main,
 .nv-comment-content {
 
 	a {


### PR DESCRIPTION
### Summary
Underline links on page/post content and in text widgets

### Will affect visual aspect of the product
YES


### Test instructions
We need to be compliant with this rule:

> When links appear within a larger body of block-level content, they must be clearly distinguishable from surrounding content (Post content, comment content, text widgets, custom options with large blocks of texts). https://make.wordpress.org/themes/handbook/review/accessibility/required/#content-links

I identified in our theme 4 areas: post content / page content / comment content / text widgets and I added a rule that links in those areas to have an underline.
You should:
- Check those areas and see if underline applies
- Let me know if you think we should add the underline for other links

<!-- Issues that this pull request closes. -->
Closes #3087.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
