### PR TITLE
Fix: Font family saving issue on the Header Nav widget

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -846,6 +846,7 @@ abstract class Abstract_Component implements Component {
 					'transport'             => 'postMessage',
 					'priority'              => $priority + 1,
 					'type'                  => '\Neve\Customizer\Controls\React\Font_Family',
+					'sanitize_callback'     => 'sanitize_text_field',
 					'live_refresh_selector' => $this->default_typography_selector,
 					'live_refresh_css_prop' => array(
 						'cssVar' => [


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Font family was corrupting when saving on HFG builder. It's fixed with this PR.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Go Customizer -> Header -> Click 'set' icon of the Primary Menu -> Go 'Style' tab then, change font-family.
- Make sure the font that you chosen works well on customizer preview and fontend.

<!-- Issues that this pull request closes. -->
Closes #3055 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
