### PR TITLE
Fix underline links

### DIFF
--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -170,10 +170,6 @@ pre {
 
 
 // === Links === //
-a {
-	text-decoration: none;
-}
-
 a:not(.wp-block-button__link) {
 	color: var(--nv-primary-accent);
 

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -44,10 +44,14 @@ a {
 	}
 }
 
-.entry-content, .widget_text, .page .neve-main, .nv-comment-content {
-  a {
-	text-decoration: underline;
-  }
+.entry-content,
+.widget_text,
+.page .neve-main,
+.nv-comment-content {
+
+	a {
+		text-decoration: underline;
+	}
 }
 
 ins {

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -44,6 +44,12 @@ a {
 	}
 }
 
+.entry-content, .widget_text, .page .neve-main, .nv-comment-content {
+  a {
+	text-decoration: underline;
+  }
+}
+
 ins {
 	text-decoration: none;
 }

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -46,7 +46,7 @@ a {
 
 .entry-content,
 .widget_text,
-.page .neve-main,
+.page-template .neve-main,
 .nv-comment-content {
 
 	a {

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -46,7 +46,7 @@ a {
 
 .entry-content,
 .widget_text,
-.page-template .neve-main,
+.nv-template .neve-main,
 .nv-comment-content {
 
 	a {

--- a/page-templates/template-pagebuilder-full-width.php
+++ b/page-templates/template-pagebuilder-full-width.php
@@ -8,6 +8,13 @@
  *
  * @package Neve
  */
+add_action(
+	'body_class',
+	function ( $class ) {
+		$class[] = 'nv-template';
+		return $class;
+	}
+);
 
 get_header();
 if ( have_posts() ) {


### PR DESCRIPTION
### Summary
Added a class for the neve full-width template on the body as it didn't have anywhere to place it.
I targeted only our template because a general rule for templates cannot be written.

### Will affect visual aspect of the product
YES

<!-- Issues that this pull request closes. -->
Closes #3087.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
