### PR TITLE
Fix checkout compatibility issue

### DIFF
--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -36,6 +36,10 @@
 	form.checkout {
 		display: grid;
 		grid-template-columns: 1fr;
+
+		> *:not(#customer_details):not(.nv-order-review) {
+			grid-column: span 2;
+		}
 	}
 
 	.woocommerce-NoticeGroup {

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -197,7 +197,7 @@ class Woocommerce {
 			add_action(
 				'woocommerce_checkout_before_order_review_heading',
 				function () {
-					echo '<div>';
+					echo '<div class="nv-order-review">';
 				}
 			);
 			add_action( 'woocommerce_checkout_after_order_review', [ $this, 'close_div' ] );


### PR DESCRIPTION
### Summary
So, we have a grid with two columns. If a 3rd party adds an element there, it will push the last element on a new row. If the element that was added is of type grid, it will try to match the height of that other element on the same row (that's why the element is so big in the screenshot).

In this PR I target each element that is not part of the regular checkout form and make them show on both columns. This holds as long as the 3rd party adds something before or after the checkout columns and not between them.

### Will affect visual aspect of the product
NO


### Test instructions
1. Install and Activate the [Food Store](https://wordpress.org/plugins/food-store/) plugin
2. Open the Checkout page and check the fields
3. Test with and without [Neve Pro](https://github.com/Codeinwp/neve-pro-addon/pull/1595)

**If Neve Pro is active, you need to make sure that you have the [PR](https://github.com/Codeinwp/neve-pro-addon/pull/1595) made there regarding this issue. Please test other checkout layouts too**

<!-- Issues that this pull request closes. -->
Closes #3049.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
