### PR TITLE
fix: handle invalid number of columns in storybook

### DIFF
--- a/stories/hfg/BuilderColumns.stories.js
+++ b/stories/hfg/BuilderColumns.stories.js
@@ -14,9 +14,13 @@ export default {
 const Template = (args) => {
 	const [value, setValue] = useState('equal');
 	const [columns, setColumns] = useState(1);
+	const [safeColumns, setSafeColumns] = useState(1);
 
 	const updateColNumber = (e) => {
 		setColumns(e.target.value);
+		if (choices[columns]) {
+			setSafeColumns(columns);
+		}
 	};
 
 	const choices = {
@@ -85,8 +89,14 @@ const Template = (args) => {
 	};
 
 	useEffect(() => {
-		if (!choices[columns][value]) {
-			setValue(Object.keys(choices[columns])[0]);
+		if (choices[columns]) {
+			setSafeColumns(columns);
+		}
+	}, [columns]);
+
+	useEffect(() => {
+		if (!choices[safeColumns][value]) {
+			setValue(Object.keys(choices[safeColumns])[0]);
 		}
 	}, [columns]);
 
@@ -105,7 +115,7 @@ const Template = (args) => {
 			<BuilderColumns
 				value={value}
 				onChange={setValue}
-				columns={columns}
+				columns={safeColumns}
 				choices={choices}
 				{...args}
 			/>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Stoped storybook page from returning a TypeError when the number of columns is not in range in the Builder Columns Control.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to storybook > HFG > Builder Columns Control
- Clear the columns number field (or set a number that is not in the range 1-5)
- The page should not return an error and the current number of columns should be equal to the last valid input.

<!-- Issues that this pull request closes. -->
Closes #3048.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
