### PR TITLE
chore: change archive post title tag back to h2 [closes #3107]

### DIFF
--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -162,15 +162,12 @@ class Template_Parts extends Base_View {
 	 * @return string
 	 */
 	private function get_title() {
-		$tag = neve_is_new_skin() ? 'h3' : 'h2';
+		$markup = '<h2 class="blog-entry-title entry-title">';
 
-		$markup = '';
-
-		$markup .= '<' . $tag . ' class="blog-entry-title entry-title">';
 		$markup .= '<a href="' . esc_url( get_the_permalink() ) . '" rel="bookmark">';
 		$markup .= get_the_title();
 		$markup .= '</a>';
-		$markup .= '</' . $tag . '>';
+		$markup .= '</h2>';
 
 		return $markup;
 	}


### PR DESCRIPTION
### Summary
Changes post title tag to h2 on archive
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The post title tag should be h2 instead of h3 
- There should be no visual difference 
- The options that should be affecting the post title should work as expected

<!-- Issues that this pull request closes. -->
Closes #3107
<!-- Should look like this: `Closes #1, #2, #3.` . -->
