### PR TITLE
Food store compatibility fix

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -195,9 +195,17 @@ class Woocommerce {
 
 		if ( neve_is_new_skin() ) {
 			add_action(
+				'woocommerce_checkout_before_customer_details', 
+				function () {
+					echo '<div class="nv-customer-details">';
+				},
+				0 
+			);
+			add_action( 'woocommerce_checkout_after_customer_details', [ $this, 'close_div' ] );
+			add_action(
 				'woocommerce_checkout_before_order_review_heading',
 				function () {
-					echo '<div>';
+					echo '<div class="nv-order-review">';
 				}
 			);
 			add_action( 'woocommerce_checkout_after_order_review', [ $this, 'close_div' ] );


### PR DESCRIPTION
### Summary
Wrap the customer details in a div and make sure the open div has the lowest priority so it would execute before all other plugins.

### Will affect visual aspect of the product
NO


### Test instructions
1. Install and Activate the [Food Store](https://wordpress.org/plugins/food-store/) plugin
2. Open the Checkout page and check the fields
3. Test with and without Neve Pro. When testing with Neve Pro make sure you check with other layouts too

<!-- Issues that this pull request closes. -->
Closes #3049.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
