### PR TITLE
[i18n] Fix hardcoded concatenation for "Neve Options" menu item and page title

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -124,8 +124,8 @@ class Main {
 			return;
 		}
 
-		$page_title = $theme['name'] . ' ' . __( 'Options', 'neve' ) . ' ';
-		$menu_name  = $theme['name'] . ' ' . __( 'Options', 'neve' ) . ' ';
+		$page_title = sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme['name'] ) );
+		$menu_name  = sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme['name'] ) );
 
 		$theme_page = ! empty( $theme['template'] ) ? $theme['template'] . '-welcome' : $theme['slug'] . '-welcome';
 		add_theme_page( $page_title, $menu_name, 'activate_plugins', $theme_page, [ $this, 'render' ] );


### PR DESCRIPTION
### Summary
Fix i18n of Menu item and Page title "Neve Options".
The current menu item and page title are Neve + '  ' + 'Options', which is a problem for i18n of languages where this concatenation should be reversed, eg.: Portuguese translation: "Opções do Neve".
Currently it's impossible to correctly translate this, as the menu renders "Neve Opções", which wrong.

### Will affect visual aspect of the product
YES


<!-- Issues that this pull request closes. -->
Closes #3111.
