### PR TITLE
Fixed the unclosed div element on the shop page

### DIFF
--- a/inc/views/product_layout.php
+++ b/inc/views/product_layout.php
@@ -32,10 +32,7 @@ class Product_Layout extends Base_View {
 
 		// We are using this twice since product_image_wrap is opening two divs which needs to be closed.
 		add_action( 'woocommerce_before_shop_loop_item_title', array( $this, 'wrapper_close_div' ), 11 );
-		if ( neve_pro_has_support( 'malformed_div_on_shop' ) ) {
-			add_action( 'woocommerce_before_shop_loop_item_title', array( $this, 'wrapper_close_div' ), 14 );
-		}
-
+		add_action( 'woocommerce_before_shop_loop_item_title', array( $this, 'wrapper_close_div' ), 14 );
 
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
There was unclosed div tags on shop page on Neve if Neve Pro is disabled. It's fixed with the PR.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure there are no unclosed tags in the shop page. It should work the following cases:
-- Only Install Neve
-- Install Neve + Neve Pro

- Make sure there are no unnecessary a element on the shop page. (#3076)

<!-- Issues that this pull request closes. -->
Closes #3076,#3008.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
