### PR TITLE
Fix: storybook icons appearance [ref #3046]

### DIFF
--- a/.storybook/theme.js
+++ b/.storybook/theme.js
@@ -4,5 +4,5 @@ export default create({
 	base: 'light',
 	brandTitle: 'Neve by ThemeIsle',
 	brandUrl: 'https://themeisle.com',
-	brandImage: 'https://raw.githubusercontent.com/Codeinwp/neve/master/dashboard/assets/logo.svg',
+	brandImage: 'https://raw.githubusercontent.com/Codeinwp/neve/master/assets/img/dashboard/logo.svg',
 });

--- a/assets/apps/customizer-controls/src/common/Accordion.js
+++ b/assets/apps/customizer-controls/src/common/Accordion.js
@@ -17,7 +17,12 @@ const Accordion = ({ children, label, initiallyExpanded = true }) => {
 			<button className={classes} onClick={toggle}>
 				<h4>
 					{label}
-					<Icon size={30} icon={expanded ? chevronUp : chevronDown} />
+					<Icon
+						width={30}
+						height={30}
+						size={30}
+						icon={expanded ? chevronUp : chevronDown}
+					/>
 				</h4>
 			</button>
 			{expanded && children}

--- a/assets/apps/customizer-controls/src/scss/_button-appearance.scss
+++ b/assets/apps/customizer-controls/src/scss/_button-appearance.scss
@@ -22,6 +22,11 @@
     margin: 0 -16px -1px;
   }
 
+  .components-panel__arrow {
+	width: 24px;
+	height: 24px;
+  }
+
   .components-panel__row {
     margin-top: 10px;
     display: block;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Provided a temporary fix for the huge icons in storybook.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Open storybook
- Go to Accordion or Button Appearance components
- The arrow icons should have a normal size

<!-- Issues that this pull request closes. -->
Closes #3046.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
