### PR TITLE
fix: HFG Components Labels Font Styles

### DIFF
--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -38,3 +38,8 @@
 	padding: var(--padding, 0);
 	margin: var(--margin, 0);
 }
+
+.inherit-ff {
+	font-family: var(--inheritedFF);
+	font-weight: var(--inheritedFW);
+}

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2,7 +2,6 @@
 @import "components/main/variables";
 @import "components/main/extends";
 @import "components/main/reset";
-
 @import "components/main/grid";
 @import "components/main/typography";
 @import "components/main/a11y";
@@ -20,5 +19,4 @@
 @import "components/elements/hfg-alignments";
 @import "components/main/media-queries";
 @import "components/compat/elementor";
-
-@import "./components/hfg/style";
+@import "components/hfg/style";

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1425,6 +1425,14 @@ abstract class Abstract_Builder implements Builder {
 				}
 				if ( count( $component_group['components'] ) > 1 ) {
 					$component_group['classes'][] = 'hfg-is-group';
+
+					// If there is a primary or secondary menu component inside the group, add a class to it.
+					foreach ( $component_group['components'] as $component_slug ) {
+						if ( strpos( $component_slug, 'primary-menu' ) === false && strpos( $component_slug, 'secondary-menu' ) === false ) {
+							continue;
+						}
+						$component_group['classes'][] = 'has-' . $component_slug;
+					}
 				}
 				echo sprintf( '<div class="%s">', esc_attr( join( ' ', $component_group['classes'] ) ) );
 				foreach ( $component_group['components'] as $component ) {

--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -768,20 +768,21 @@ abstract class Abstract_Component implements Component {
 				]
 			);
 
-			/*
-			Attempt to match the font family for cart icon.
-			if ( strpos( $this->get_id(), Nav::COMPONENT_ID ) > - 1 ) {
+			if ( strpos( $this->get_id(), Nav::COMPONENT_ID ) !== false || strpos( $this->get_id(), SecondNav::COMPONENT_ID ) !== false ) {
 				$css_array[] = [
-					Dynamic_Selector::KEY_SELECTOR => '.builder-item--' . $this->get_id() . ' ~ .builder-item--header_cart_icon',
+					Dynamic_Selector::KEY_SELECTOR => '.hfg-is-group.has-' . $this->get_id() . ' .inherit-ff',
 					Dynamic_Selector::KEY_RULES    => [
-						'--fontFamily'    => [
+						'--inheritedFF' => [
 							Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FONT_FAMILY_ID,
 							Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FONT_FAMILY_ID ),
+						],
+						'--inheritedFW' => [
+							Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.fontWeight',
+							Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'fontWeight' ),
 						],
 					],
 				];
 			}
-			*/
 		}
 
 		$css_array[] = [
@@ -999,12 +1000,12 @@ abstract class Abstract_Component implements Component {
 	 * Add horizontal alignment to component.
 	 */
 	private function add_horizontal_alignment_control() {
-		if ( strpos( $this->get_id(), Search::COMPONENT_ID ) > - 1 ) {
+		if ( strpos( $this->get_id(), Search::COMPONENT_ID ) !== false ) {
 			return;
 		}
 
 		// New skin drops alignment for navigation
-		if ( neve_is_new_skin() && strpos( $this->get_id(), Nav::COMPONENT_ID ) > - 1 ) {
+		if ( neve_is_new_skin() && strpos( $this->get_id(), Nav::COMPONENT_ID ) !== false ) {
 			return;
 		}
 
@@ -1022,7 +1023,7 @@ abstract class Abstract_Component implements Component {
 				'icon'    => 'editor-alignright',
 			],
 		];
-		if ( strpos( $this->get_id(), Button::COMPONENT_ID ) > - 1 ) {
+		if ( strpos( $this->get_id(), Button::COMPONENT_ID ) !== false ) {
 			$align_choices['justify'] = [
 				'tooltip' => __( 'Justify', 'neve' ),
 				'icon'    => 'editor-justify',

--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -291,7 +291,7 @@ class CartIcon extends Abstract_Component {
 			'--labelSize'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::LABEL_SIZE_ID,
 				Dynamic_Selector::META_SUFFIX  => 'px',
-				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::LABEL_SIZE_ID ),
+				Dynamic_Selector::META_DEFAULT => 15,
 			],
 			'--color'      => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::COLOR_ID,

--- a/header-footer-grid/templates/components/component-cart-icon.php
+++ b/header-footer-grid/templates/components/component-cart-icon.php
@@ -40,7 +40,7 @@ if ( (bool) $expand_enabled === false ) {
 		<a href="<?php echo esc_url( wc_get_cart_url() ); ?>" class="cart-icon-wrapper">
 			<?php
 			if ( ! empty( $cart_label ) ) {
-				echo '<span class="cart-icon-label">';
+				echo '<span class="cart-icon-label inherit-ff">';
 				echo wp_kses_post( $cart_label );
 				echo '</span>';
 			}

--- a/header-footer-grid/templates/components/component-palette-switch.php
+++ b/header-footer-grid/templates/components/component-palette-switch.php
@@ -24,7 +24,7 @@ if ( neve_is_amp() ) {
 	<a class="toggle palette-icon-wrapper" href="#" <?php echo $amp_state; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<span class="icon"><?php echo $svg_icon; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></span>
 		<?php if ( $label !== '' ) { ?>
-			<span class="label builder-item--primary-menu"><?php echo esc_html( $label ); ?></span>
+			<span class="label inherit-ff"><?php echo esc_html( $label ); ?></span>
 		<?php } ?>
 	</a>
 </div>

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -783,7 +783,7 @@ class Woocommerce {
 		$cart_label = get_theme_mod( 'header_cart_icon_' . CartIcon::CART_LABEL );
 		if ( ! empty( $cart_label ) ) {
 			$cart_label                    = Magic_Tags::get_instance()->do_magic_tags( $cart_label );
-			$fragments['.cart-icon-label'] = '<span class="cart-icon-label">' . $cart_label . '</span>';
+			$fragments['.cart-icon-label'] = '<span class="cart-icon-label inherit-ff">' . $cart_label . '</span>';
 		}
 
 		return $fragments;


### PR DESCRIPTION
### Summary
Makes the Palette `Switcher`, `Cart` and `My Account` **(Pro Component)** header components labels inherit the font styles (family and weight) of the `Primary Menu` and `Secondary Menu` if these are next to each other (in the same slot, in the same group);
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES (might change things for people who had these components next to each other)

### Screenshots <!-- if applicable -->
**Before:**
![image](https://user-images.githubusercontent.com/15010186/134111873-2dafc8de-5326-409d-9449-3cfdadeec7c0.png)
**With this PR:**
![image](https://user-images.githubusercontent.com/15010186/134113655-ffa3b38a-c8ac-441c-8964-3a0a32bad498.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Set up a header that has a primary/secondary navigation component with a different font family;
- Any of the components mentioned in the summary, when placed in the same slot (i.e. form a group) with either one of the ones mentioned above should inherit Font Family and Font Weight from the menu;

<!-- Issues that this pull request closes. -->
Closes #2491.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
