### PR TITLE
fix: remove aria-role on carret for menu, breaking AMP validator

### DIFF
--- a/inc/compatibility/amp.php
+++ b/inc/compatibility/amp.php
@@ -87,7 +87,7 @@ class Amp {
 			return $item_output;
 		}
 
-		$caret  = '<div aria-role="button" class="caret-wrap ' . $item->menu_order . '">';
+		$caret  = '<div  class="caret-wrap ' . $item->menu_order . '">';
 		$caret .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
 		$caret .= '</div>';
 


### PR DESCRIPTION

### Summary
Due to aria-role attribute used in the carret submenu div, the AMP validator was reporting error with the menu.

### Will affect visual aspect of the product
No


### Test instructions

- Activate AMP in developer mode
- Install Neve and configure one menu for Primary menu with 2 levels menu items
- Check that no issues are reported by AMP validator, previously we had warnings reported on carret icon. 
- Make sure that each item from the menu is reachable by keyword navigation both on amp/non amp and on mobile/desktop

<!-- Issues that this pull request closes. -->
Closes #3110
<!-- Should look like this: `Closes #1, #2, #3.` . -->
