### PR TITLE
Feat: header border [WIP]

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -83,7 +83,8 @@ $desktop: map-get($gl-devices-list, desktop);
 [data-row-id] {
 	color: var(--color);
 	background: var(--bgColor);
-	border-bottom-width: var(--borderWidth, 0);
+	border-bottom-width: var(--headerBorderWidth, 0);
+	border-bottom-color: var(--headerBorderColor, #000);
 	border-bottom-style: solid;
 
 	a {

--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -83,6 +83,8 @@ $desktop: map-get($gl-devices-list, desktop);
 [data-row-id] {
 	color: var(--color);
 	background: var(--bgColor);
+	border-bottom-width: var(--borderWidth, 0);
+	border-bottom-style: solid;
 
 	a {
 		color: var(--color);

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1083,7 +1083,14 @@ abstract class Abstract_Builder implements Builder {
 		$rules['--borderWidth'] = [
 			Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
-			Dynamic_Selector::META_DEFAULT       => '{ desktop: 0, tablet: 0, mobile: 0 }',
+			Dynamic_Selector::META_FILTER        => function ( $css_prop, $value, $meta, $device ) {
+				$value = (int) $value;
+				if ( $value > 0 ) {
+					return sprintf( '%s:%s;', $css_prop, $value . 'px' );
+				}
+
+				return '';
+			},
 		];
 
 		// If there is no default, use site background.

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -36,6 +36,7 @@ abstract class Abstract_Builder implements Builder {
 	const COLUMNS_NUMBER     = 'columns_number';
 	const COLUMNS_LAYOUT     = 'columns_layout';
 	const HEIGHT_SETTING     = 'height';
+	const BOTTOM_BORDER      = 'bottom_border';
 	const SKIN_SETTING       = 'skin';
 	const TEXT_COLOR         = 'new_text_color';
 	const BACKGROUND_SETTING = 'background';
@@ -390,6 +391,46 @@ abstract class Abstract_Builder implements Builder {
 				]
 			);
 		}
+
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::BOTTOM_BORDER,
+				'group'                 => $row_setting_id,
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'section'               => $row_setting_id,
+				'label'                 => __( 'Bottom border width', 'neve' ),
+				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
+				'live_refresh_selector' => '.header-main',
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'responsive' => true,
+						'vars'       => '--borderWidth',
+						'suffix'     => 'px',
+						'fallback'   => '0',
+						'selector'   => '.' . $this->get_id() . '-' . $row_id,
+					],
+					'prop'   => 'border-bottom-width',
+					'unit'   => 'px',
+				],
+				'options'               => [
+					'input_attrs' => [
+						'step'       => 1,
+						'min'        => 0,
+						'max'        => 50,
+						'defaultVal' => [
+							'mobile'  => 0,
+							'tablet'  => 0,
+							'desktop' => 0,
+						],
+						'units'      => [ 'px' ],
+					],
+				],
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => array( $this, 'sanitize_responsive_int_json' ),
+				'default'               => '{ "mobile": "0", "tablet": "0", "desktop": "0" }',
+				'conditional_header'    => $this->get_id() === 'header',
+			]
+		);
 
 		if ( $this->columns_layout && neve_is_new_builder() ) {
 			$this->add_columns_layout_controls( $row_setting_id );
@@ -1037,6 +1078,12 @@ abstract class Abstract_Builder implements Builder {
 		$rules['--color'] = [
 			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::TEXT_COLOR,
 			Dynamic_Selector::META_DEFAULT => $default_colors['text'],
+		];
+
+		$rules['--borderWidth'] = [
+			Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
+			Dynamic_Selector::META_IS_RESPONSIVE => true,
+			Dynamic_Selector::META_DEFAULT       => '{ desktop: 0, tablet: 0, mobile: 0 }',
 		];
 
 		// If there is no default, use site background.

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -36,7 +36,8 @@ abstract class Abstract_Builder implements Builder {
 	const COLUMNS_NUMBER     = 'columns_number';
 	const COLUMNS_LAYOUT     = 'columns_layout';
 	const HEIGHT_SETTING     = 'height';
-	const BOTTOM_BORDER      = 'bottom_border';
+	const BOTTOM_BORDER      = 'header_bottom_border';
+	const BORDER_COLOR       = 'header_border_color';
 	const SKIN_SETTING       = 'skin';
 	const TEXT_COLOR         = 'new_text_color';
 	const BACKGROUND_SETTING = 'background';
@@ -181,6 +182,7 @@ abstract class Abstract_Builder implements Builder {
 			'main'    => '#ffffff',
 			'bottom'  => '#ffffff',
 			'sidebar' => '#ffffff',
+			'border'  => '#e3e3e3',
 		),
 		'footer'      => array(
 			'top'    => '#ffffff',
@@ -392,46 +394,6 @@ abstract class Abstract_Builder implements Builder {
 			);
 		}
 
-		SettingsManager::get_instance()->add(
-			[
-				'id'                    => self::BOTTOM_BORDER,
-				'group'                 => $row_setting_id,
-				'tab'                   => SettingsManager::TAB_STYLE,
-				'section'               => $row_setting_id,
-				'label'                 => __( 'Bottom border width', 'neve' ),
-				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
-				'live_refresh_selector' => '.header-main',
-				'live_refresh_css_prop' => [
-					'cssVar' => [
-						'responsive' => true,
-						'vars'       => '--borderWidth',
-						'suffix'     => 'px',
-						'fallback'   => '0',
-						'selector'   => '.' . $this->get_id() . '-' . $row_id,
-					],
-					'prop'   => 'border-bottom-width',
-					'unit'   => 'px',
-				],
-				'options'               => [
-					'input_attrs' => [
-						'step'       => 1,
-						'min'        => 0,
-						'max'        => 50,
-						'defaultVal' => [
-							'mobile'  => 0,
-							'tablet'  => 0,
-							'desktop' => 0,
-						],
-						'units'      => [ 'px' ],
-					],
-				],
-				'transport'             => 'postMessage',
-				'sanitize_callback'     => array( $this, 'sanitize_responsive_int_json' ),
-				'default'               => '{ "mobile": "0", "tablet": "0", "desktop": "0" }',
-				'conditional_header'    => $this->get_id() === 'header',
-			]
-		);
-
 		if ( $this->columns_layout && neve_is_new_builder() ) {
 			$this->add_columns_layout_controls( $row_setting_id );
 		}
@@ -490,6 +452,69 @@ abstract class Abstract_Builder implements Builder {
 				'default'               => $default_colors['text'],
 			]
 		);
+
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::BOTTOM_BORDER,
+				'group'                 => $row_setting_id,
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'section'               => $row_setting_id,
+				'label'                 => __( 'Divider width', 'neve' ),
+				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
+				'live_refresh_selector' => $row_class,
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'responsive' => true,
+						'vars'       => '--headerBorderWidth',
+						'suffix'     => 'px',
+						'fallback'   => '0',
+						'selector'   => '.' . $this->get_id() . '-' . $row_id,
+					],
+					'prop'   => 'border-bottom-width',
+					'unit'   => 'px',
+				],
+				'options'               => [
+					'input_attrs' => [
+						'step'       => 1,
+						'min'        => 0,
+						'max'        => 50,
+						'defaultVal' => [
+							'mobile'  => 0,
+							'tablet'  => 0,
+							'desktop' => 0,
+						],
+						'units'      => [ 'px' ],
+					],
+				],
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => array( $this, 'sanitize_responsive_int_json' ),
+				'default'               => '{ "mobile": "0", "tablet": "0", "desktop": "0" }',
+				'conditional_header'    => $this->get_id() === 'header',
+			]
+		);
+
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::BORDER_COLOR,
+				'group'                 => $row_setting_id,
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'label'                 => __( 'Divider Color', 'neve' ),
+				'section'               => $row_setting_id,
+				'conditional_header'    => $this->get_id() === 'header',
+				'type'                  => 'neve_color_control',
+				'transport'             => 'postMessage',
+				'live_refresh_selector' => $row_class,
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'vars'     => '--headerBorderColor',
+						'selector' => '.' . $this->get_id() . '-' . $row_id,
+					],
+				],
+				'sanitize_callback'     => 'wp_filter_nohtml_kses',
+				'default'               => $this->default_colors['header']['border'],
+			]
+		);
+
 		do_action( 'hfg_row_settings', $this->get_id(), $row_id, $row_setting_id );
 	}
 
@@ -1075,12 +1100,7 @@ abstract class Abstract_Builder implements Builder {
 			];
 		}
 
-		$rules['--color'] = [
-			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::TEXT_COLOR,
-			Dynamic_Selector::META_DEFAULT => $default_colors['text'],
-		];
-
-		$rules['--borderWidth'] = [
+		$rules['--headerBorderWidth'] = [
 			Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
 			Dynamic_Selector::META_FILTER        => function ( $css_prop, $value, $meta, $device ) {
@@ -1091,6 +1111,16 @@ abstract class Abstract_Builder implements Builder {
 
 				return '';
 			},
+		];
+
+		$rules['--headerBorderColor'] = [
+			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::BORDER_COLOR,
+			Dynamic_Selector::META_DEFAULT => $this->default_colors['header']['border'],
+		];
+
+		$rules['--color'] = [
+			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::TEXT_COLOR,
+			Dynamic_Selector::META_DEFAULT => $default_colors['text'],
 		];
 
 		// If there is no default, use site background.


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a horizontal divider for the header with settings for width and color.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![Screenshot from 2021-09-23 13-12-10](https://user-images.githubusercontent.com/39873395/134490309-85e932e5-219f-4ed3-8b13-1468a0545b99.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Go to Customize -> Header -> Header Main (or any other header)
- The settings for divider width and color should be visible
- Apply changes to the divider and they should display in the front end

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1568.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
