### PR TITLE
fix: footer components not updating after columns change [closes #3101]

### DIFF
--- a/assets/apps/customizer-controls/src/builder/components/Row.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/Row.tsx
@@ -29,7 +29,7 @@ const Row: React.FC<Props> = ({ items, rowId }) => {
 		hasColumns,
 		previewSidebar,
 	} = useContext(BuilderContext);
-	const { updateLayout, togglePreviewSidebar } = actions;
+	const { updateLayout, togglePreviewSidebar, updateSidebarItems } = actions;
 	const slots: SlotTypes[] = ['left', 'c-left', 'center', 'c-right', 'right'];
 
 	const section = `hfg_${builder}_layout_${rowId}`;
@@ -92,6 +92,7 @@ const Row: React.FC<Props> = ({ items, rowId }) => {
 				}
 			});
 			setColumns(parsedColNumber);
+			updateSidebarItems();
 		};
 
 		window.wp.customize.control(


### PR DESCRIPTION
### Summary
Fixes issue where footer components were not sent back to the components sidebar and the add component popover.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Fill a footer row with components (it should have more than 1 column);
- Switch the columns number to something lower than initial;
- The components that disappeared from the footer row should be reinstated inside the customizer sidebar and the popover for adding components.

<!-- Issues that this pull request closes. -->
Closes #3101.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
