### PR TITLE
fix: header mobile sidebar components had some wrong styles

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -143,6 +143,7 @@ body:not(.is-menu-sidebar) .header-menu-sidebar-inner {
 			left: unset !important;
 			top: unset !important;
 			right: unset !important;
+			background: unset;
 			position: relative;
 			max-width: 100%;
 			box-shadow: none;

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -12,6 +12,7 @@ namespace HFG;
 use HFG\Core\Builder\Abstract_Builder;
 use HFG\Core\Builder\Header as HeaderBuilder;
 
+$row_index        = current_row();
 $interaction_type = row_setting( Abstract_Builder::LAYOUT_SETTING );
 $classes          = [ 'header-menu-sidebar', 'menu-sidebar-panel', $interaction_type ];
 $is_contained     = in_array( $interaction_type, [ 'full_canvas', 'dropdown' ], true );
@@ -19,7 +20,7 @@ $inner_classes    = 'header-menu-sidebar-inner ' . ( $is_contained ? ' container
 $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 
 ?>
-<div id="header-menu-sidebar" class="<?php echo esc_attr( join( ' ', $classes ) ); ?>">
+<div id="header-menu-sidebar" class="<?php echo esc_attr( join( ' ', $classes ) ); ?>" data-row-id="<?php echo esc_attr( $row_index ); ?>">
 	<div id="header-menu-sidebar-bg" class="header-menu-sidebar-bg">
 		<div class="close-sidebar-panel navbar-toggle-wrapper">
 			<button type="button" class="navbar-toggle active" <?php echo ( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>


### PR DESCRIPTION
### Summary
- adds `data-row-id` data attribute to the header mobile sidebar;
- fixes issue with styling done on the `[data-row-id]` selector not applying;
- fixes issue with dropdowns inside the mobile sidebar inheriting overlay color instead of being transparent;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions

For #3116:
---
<!-- Describe how this pull request can be tested. -->
- follow the #3116 issue reproduction steps; 
- the colors should be applying properly on the components inside the mobile sidebar;
- all other styles should be working fine 

For #3127:
---
- add a primary menu with dropdowns inside the mobile sidebar;
- add a background image and make sure it has an overlay;
- dropdowns inside the mobile sidebar should not have a background color like described in #3127;

<!-- Issues that this pull request closes. -->
Closes #3116
Closes #3127
<!-- Should look like this: `Closes #1, #2, #3.` . -->
