### PR TITLE
chore: remove useless clearfix [closes #3064]

### DIFF
--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -59,12 +59,6 @@ pre {
 	--listPad: 20px;
 	--listStyle: disc;
 
-	&::after {
-		content: "";
-		clear: both;
-		display: table;
-	}
-
 	> ul,
 	> ol {
 		margin: $spacing-lg 0;


### PR DESCRIPTION
### Summary
Removes clearfix on `.nv-content-wrap` and `.excerpt-wrap`. It seems that it wasn't doing anything. 
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The posts archive should still work as expected with all the settings inside the **Layout  > Blog / Archive** section;
- Nothing should go out of line;
- The layout shouldn't break;

<!-- Issues that this pull request closes. -->
Closes #3064.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
