### PR TITLE
feat: HFG sidebar alignment & fixes

### DIFF
--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -13,7 +13,6 @@ type Props = {
 
 const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 	const { setting, params } = control;
-
 	const builder: string = params.builderType;
 	const hasColumns: boolean = params.columnsLayout;
 
@@ -22,6 +21,7 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 		maybeParseJson(setting.get())
 	);
 	const [isHidden, setHidden] = useState<boolean>(true);
+	const [isMounted, setMounted] = useState<boolean>(false);
 
 	const onChange = (nextValue: BuilderContentInterface) => {
 		const next = JSON.stringify(nextValue);
@@ -110,6 +110,26 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 		bindHideOnPaneCollapse();
 	}, []);
 
+	useEffect(() => {
+		window.wp.customize.bind('ready', () => {
+			window.wp.customize
+				.state('expandedPanel')
+				.bind((activePanel: Record<string, string>) => {
+					if (!activePanel) {
+						return;
+					}
+
+					if (!activePanel.id) {
+						return;
+					}
+
+					if (activePanel.id === `hfg_${builder}`) {
+						setMounted(true);
+					}
+				});
+		});
+	}, []);
+
 	return (
 		<HFGBuilder
 			hasColumns={hasColumns}
@@ -118,6 +138,7 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 			value={value}
 			onChange={onChange}
 			portalMount={portalMount}
+			mounted={isMounted}
 		/>
 	);
 };

--- a/assets/apps/customizer-controls/src/builder/components/BuilderHeaderNotification.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/BuilderHeaderNotification.tsx
@@ -29,10 +29,18 @@ const BuilderHeaderNotification: React.FC<Props> = ({
 	};
 
 	useEffect(() => {
-		document.addEventListener('nv-change-conditional-header', (e) => {
-			// @ts-ignore
+		// @ts-ignore
+		const updateName = (e) => {
 			setCurrentHeaderName(e.detail);
-		});
+		};
+
+		document.addEventListener('nv-change-conditional-header', updateName);
+
+		return () =>
+			document.removeEventListener(
+				'nv-change-conditional-header',
+				updateName
+			);
 	}, []);
 
 	const {

--- a/assets/apps/customizer-controls/src/builder/components/BuilderItem.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/BuilderItem.tsx
@@ -17,7 +17,7 @@ type Props = {
 
 const BuilderItem: React.FC<Props> = (props) => {
 	const { componentId, currentSection, slot, row, index } = props;
-	const { actions, builder } = useContext(BuilderContext);
+	const { actions, builder, sidebarItems } = useContext(BuilderContext);
 
 	const itemDetails =
 		window.NeveReactCustomize.HFG[builder].items[componentId];
@@ -27,7 +27,7 @@ const BuilderItem: React.FC<Props> = (props) => {
 	}
 
 	const { name, section } = itemDetails;
-	const { removeItem, updateSidebarItems } = actions;
+	const { removeItem, setSidebarItems } = actions;
 
 	const isBlockWidget = section && section.includes('neve_sidebar-widgets');
 
@@ -46,7 +46,11 @@ const BuilderItem: React.FC<Props> = (props) => {
 	const remove = () => {
 		removeItem(row, slot, index);
 		itemSection.expanded(false);
-		updateSidebarItems();
+		setSidebarItems(
+			[...sidebarItems, { id: componentId }].sort((a, b) => {
+				return a.id < b.id ? -1 : 1;
+			})
+		);
 	};
 
 	const iconSize = 18;

--- a/assets/apps/customizer-controls/src/builder/components/Row.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/Row.tsx
@@ -51,28 +51,28 @@ const Row: React.FC<Props> = ({ items, rowId }) => {
 	 * Check if the section is active when sections are expanded.
 	 */
 	useEffect(() => {
-		bindRowSettingsButton();
+		window.wp.customize.state('expandedSection').bind(rowSettingsHandler);
 
-		if (!hasColumns) {
-			return;
+		if (hasColumns) {
+			bindColumnsSync();
 		}
 
-		bindColumnsSync();
+		return () => {
+			window.wp.customize
+				.state('expandedSection')
+				.unbind(rowSettingsHandler);
+		};
 	}, []);
 
-	const bindRowSettingsButton = () => {
-		window.wp.customize
-			.state('expandedSection')
-			.bind((expandedSection: StringObjectKeys) => {
-				if (!expandedSection || expandedSection.id !== section) {
-					setCurrentRow(false);
-					return false;
-				}
+	const rowSettingsHandler = (expandedSection: StringObjectKeys) => {
+		if (!expandedSection || expandedSection.id !== section) {
+			setCurrentRow(false);
+			return false;
+		}
 
-				if (expandedSection.id === section) {
-					setCurrentRow(true);
-				}
-			});
+		if (expandedSection.id === section) {
+			setCurrentRow(true);
+		}
 	};
 
 	const bindColumnsSync = () => {
@@ -125,11 +125,6 @@ const Row: React.FC<Props> = ({ items, rowId }) => {
 				togglePreviewSidebar(status);
 			}
 		);
-
-		// Toggle theme sidebar if it was previously opened on customizer refresh.
-		window.wp.customize.previewer.bind('ready', () => {
-			togglePreviewSidebar(false);
-		});
 	}, []);
 
 	// Toggle sidebar in preview.
@@ -169,7 +164,7 @@ const Row: React.FC<Props> = ({ items, rowId }) => {
 				</div>
 
 				<div className="row-inner">
-					<Slot slotId={rowId} rowId={rowId} items={items} />
+					<Slot slotId={rowId} rowId={rowId} items={items || []} />
 				</div>
 			</div>
 		);

--- a/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { ReactSortable } from 'react-sortablejs';
+import { ItemInterface, ReactSortable } from 'react-sortablejs';
 import { Icon } from '@wordpress/components';
 import { dragHandle } from '@wordpress/icons';
 
@@ -7,10 +7,12 @@ import { __ } from '@wordpress/i18n';
 import { useContext } from '@wordpress/element';
 import BuilderContext from '../BuilderContext';
 
-const SidebarContent: React.FC = () => {
-	const { sidebarItems: items, builder, actions, dragging } = useContext(
-		BuilderContext
-	);
+type Props = {
+	items: ItemInterface[];
+};
+
+const SidebarContent: React.FC<Props> = ({ items }) => {
+	const { builder, actions, dragging } = useContext(BuilderContext);
 
 	const { onDragStart, onDragEnd, setSidebarItems } = actions;
 	const allItems = window.NeveReactCustomize.HFG[builder].items;
@@ -31,21 +33,20 @@ const SidebarContent: React.FC = () => {
 						onStart={onDragStart}
 						list={items}
 						setList={(next) => {
-							const nextItems = [...next]
-								.map((i) => {
-									return { id: i.id };
+							const nextState = next
+								.map((item) => {
+									return { id: item.id };
 								})
 								.sort((a, b) => {
 									return a.id < b.id ? -1 : 1;
 								});
-
-							setSidebarItems(nextItems);
+							setSidebarItems(nextState);
 						}}
 					>
 						{items.map((item, index) => {
 							const { name } = allItems[item.id];
 							return (
-								<div className="builder-item" key={index}>
+								<div className="builder-item" key={item.id}>
 									<Icon
 										className="handle"
 										icon={dragHandle}

--- a/assets/apps/customizer-controls/src/builder/components/Slot.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/Slot.tsx
@@ -25,7 +25,7 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 		sidebarItems,
 	} = useContext(BuilderContext);
 
-	const { updateLayout, onDragStart, updateSidebarItems } = actions;
+	const { updateLayout, onDragStart, setSidebarItems } = actions;
 	const [popupOpen, setPopupOpen] = useState<boolean>(false);
 	const [searchQuery, setSearchQuery] = useState<string>('');
 	const slotClasses = classnames('droppable-wrap', slotId, className, {
@@ -40,8 +40,8 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 		const nextItems = [...items];
 		nextItems.push({ id: itemId });
 		updateLayout(rowId, slotId, nextItems);
+		setSidebarItems(sidebarItems.filter((i) => i.id !== itemId));
 		setPopupOpen(false);
-		updateSidebarItems();
 	};
 
 	const runSearch = (e: ChangeEvent<HTMLInputElement>) => {
@@ -60,8 +60,7 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 				list={items}
 				setList={(newState) => {
 					const nextState = newState.map((item) => {
-						const { id } = item;
-						return { id };
+						return { id: item.id };
 					});
 					updateLayout(rowId, slotId, nextState);
 				}}

--- a/assets/js/src/customizer-preview/css-var-handler.js
+++ b/assets/js/src/customizer-preview/css-var-handler.js
@@ -18,6 +18,7 @@ export class CSSVariablesHandler {
 			responsive = false,
 			suffix = '',
 			fallback = 'inherit',
+			valueRemap,
 		} = params;
 
 		//Bail if no selectors or variables.
@@ -33,6 +34,7 @@ export class CSSVariablesHandler {
 		this.suffix = suffix;
 		this.responsive = responsive;
 		this.fallback = fallback;
+		this.valueRemap = valueRemap;
 
 		const css = this.getStyle();
 
@@ -179,11 +181,34 @@ export class CSSVariablesHandler {
 				? fallback
 				: this.parseDirectionalValue(singularValue, finalSuffix);
 
+			let innerStyle = '';
+
+			if (typeof variable === 'string') {
+				innerStyle = `${variable}:${singularValue};`;
+			}
+
+			// Some variables can be remapped when the values are string but responsive.
+			if (Array.isArray(variable)) {
+				variable.forEach((v) => {
+					let finalValue = singularValue;
+
+					if (
+						this.valueRemap &&
+						this.valueRemap[v] &&
+						this.valueRemap[v][singularValue]
+					) {
+						finalValue = this.valueRemap[v][singularValue];
+					}
+
+					innerStyle += `${v}:${finalValue};`;
+				});
+			}
+
 			if (mediaQueries[device]) {
 				style += `@media(${mediaQueries[device]}) {`;
 			}
 			style += `${selector}{`;
-			style += `${variable}:${singularValue};`;
+			style += innerStyle;
 			style += '}';
 			if (mediaQueries[device]) {
 				style += '}';

--- a/assets/scss/components/elements/_hfg-alignments.scss
+++ b/assets/scss/components/elements/_hfg-alignments.scss
@@ -2,103 +2,15 @@
 	display: flex;
 	align-items: center;
 }
-$component-alignments: (
-	"right" : flex-end,
-	"left" : flex-start,
-	"center": center,
-);
 
-//<editor-fold desc="Mobile Horizontal Alignments">
-@each $alignment, $flex-setting in $component-alignments {
-	.hfg-is-group.mobile-#{$alignment} {
-		justify-content: $flex-setting;
-	}
-	.mobile-#{$alignment} {
-		text-align: #{$alignment};
-
-		.nav-ul,
-		.nv-nav-wrap,
-		.component-wrap,
-		.site-logo,
-		.nv-search-icon-component,
-		.builder-item--footer-menu {
-			justify-content: $flex-setting;
-		}
-	}
+.nav-ul a,
+.builder-item--footer-menu,
+.component-wrap,
+.palette-icon-wrapper,
+.site-logo,
+.menu-item-nav-search,
+footer .nav-ul,
+.item--inner {
+	justify-content: var(--justify, flex-start);
+	text-align: var(--textAlign, left);
 }
-
-.mobile-justify .button {
-	flex-grow: 1;
-}
-//</editor-fold>
-
-//<editor-fold desc="Tablet Horizontal Alignments">
-@mixin hfg-alignments--tablet-sm() {
-
-	@each $alignment, $flex-setting in $component-alignments {
-		//mobile-right desktop-left tablet-left
-		.hfg-is-group.tablet-#{$alignment} {
-			justify-content: $flex-setting;
-		}
-		.tablet-#{$alignment} {
-			text-align: #{$alignment};
-
-			.nav-ul,
-			.nv-nav-wrap,
-			.component-wrap,
-			.site-logo,
-			.nv-search-icon-component,
-			.builder-item--footer-menu {
-				justify-content: $flex-setting;
-			}
-		}
-	}
-
-	.tablet-justify .button {
-		flex-grow: 1;
-	}
-}
-//</editor-fold>
-
-//<editor-fold desc="Laptop Horizontal Alignments">
-@mixin hfg-alignments--laptop() {
-
-	@each $alignment, $flex-setting in $component-alignments {
-		//mobile-right desktop-left tablet-left
-		.hfg-is-group.desktop-#{$alignment} {
-			justify-content: $flex-setting;
-		}
-		.desktop-#{$alignment} {
-			text-align: #{$alignment};
-			justify-content: $flex-setting;
-
-			.nav-ul,
-			.nv-nav-wrap,
-			.component-wrap,
-			.site-logo,
-			.nv-search-icon-component,
-			.builder-item--footer-menu {
-				justify-content: $flex-setting;
-			}
-		}
-	}
-
-	.desktop-justify .button {
-		flex-grow: 1;
-	}
-}
-//</editor-fold>
-
-//<editor-fold desc="Vertical Alignments">
-$component-v-alignments: (
-	"top" : flex-start,
-	"bottom": flex-end,
-	"middle": center,
-);
-
-@each $alignment, $align-self in $component-v-alignments {
-	.hfg-item-v-#{$alignment} {
-		align-self: $align-self;
-	}
-}
-//</editor-fold>

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -9,6 +9,11 @@
 	transition: 0.3s ease;
 }
 
+.dd-title {
+	flex-grow: var(--flexG);
+}
+
+
 // === Desktop menu === //
 .nav-ul {
 	display: flex;
@@ -33,7 +38,6 @@
 	}
 
 	li {
-		cursor: pointer;
 		display: block;
 		position: relative;
 
@@ -80,10 +84,6 @@
 			display: flex;
 		}
 
-		.menu-item-title-wrap {
-			flex-grow: 1;
-		}
-
 		.sub-menu {
 			left: 100%;
 			top: 0;
@@ -97,29 +97,24 @@
 	@extend %show-dropdown;
 }
 
-//We need to use display none on elements
-// that should not be tabbable in the viewport
-// otherise they will be considered when navigating with keyboard
-body:not(.is-menu-sidebar) .header-menu-sidebar-inner {
-	display: none;
-}
 // === Inside Sidebar === //
 .header-menu-sidebar {
 
-	.menu-item-title-wrap {
-		flex-grow: 1;
+	.nv-nav-wrap {
+		width: 100%;
 	}
 
 	.nav-ul {
-		margin: 0 -15px;
+		--spacing: 0;
 		flex-direction: column;
+		width: 100%;
 
 		li {
-			margin: 1px;
+			width: 100%;
 		}
 
 		a {
-			padding: $spacing-sm 20px;
+			padding: $spacing-sm 0;
 			white-space: unset;
 		}
 
@@ -129,8 +124,8 @@ body:not(.is-menu-sidebar) .header-menu-sidebar-inner {
 		}
 
 		.caret-wrap {
-			margin: -15px;
-			padding: 15px 30px 15px 20px;
+			margin: -15px 0;
+			padding: 15px 15px 15px 20px;
 
 			&.dropdown-open .caret {
 				transform: rotateX(180deg);
@@ -154,10 +149,6 @@ body:not(.is-menu-sidebar) .header-menu-sidebar-inner {
 
 			&.dropdown-open {
 				max-height: 1300px;
-			}
-
-			a {
-				padding-left: $spacing-xl;
 			}
 		}
 

--- a/assets/scss/components/hfg/frontend/layout/_footer.scss
+++ b/assets/scss/components/hfg/frontend/layout/_footer.scss
@@ -2,8 +2,12 @@
 	position: relative;
 	z-index: 10;
 
-	.item--inner.has_menu {
-		display: flex;
+	.item--inner {
+		width: 100%;
+
+		&.has_menu {
+			display: flex;
+		}
 	}
 
 	p {
@@ -23,6 +27,7 @@
 
 	.row {
 		display: grid;
+		align-items: var(--vAlign);
 	}
 
 	.builder-item {

--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -21,12 +21,6 @@
 			position: relative;
 		}
 	}
-
-	/* Item showing animation  */
-	.item--inner {
-		transition: transform 0.3s, opacity 0.3s;
-		opacity: 0;
-	}
 }
 
 .header-menu-sidebar-bg {
@@ -43,6 +37,28 @@
 	padding: 20px 0;
 	overflow-x: hidden;
 	height: 100%;
+	// We need to use display none on elements
+	// that should not be tabbable in the viewport
+	// otherwise they will be considered when navigating with keyboard.
+	display: none;
+
+	opacity: 0;
+	transition: opacity 0.3s ease;
+
+	.is-menu-sidebar & {
+		display: block;
+		opacity: 1;
+	}
+
+	.hiding-header-menu-sidebar & {
+		display: block;
+		transition: all 0.3s ease;
+		opacity: 0;
+	}
+
+	.item--inner {
+		width: 100%;
+	}
 }
 
 .menu_sidebar_slide_left {
@@ -119,56 +135,11 @@
 	}
 }
 
-/* Hiding Menu Sidebar animation. */
-.hiding-header-menu-sidebar {
-
-	.header-menu-sidebar {
-		visibility: visible;
-		transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
-	}
-
-	&.menu_sidebar_slide_left {
-
-		.header-menu-sidebar {
-			transform: translateX(-100%);
-		}
-	}
-
-	&.menu_sidebar_slide_right {
-
-		.header-menu-sidebar {
-			transform: translateX(100%);
-		}
-	}
-
-	&.menu_sidebar_dropdown {
-
-		.header-menu-sidebar-inner {
-			height: 0;
-			padding: 0;
-			overflow: hidden;
-		}
-	}
-
-	&.menu_sidebar_full_canvas {
-
-		.header-menu-sidebar {
-			opacity: 0;
-			pointer-events: none;
-		}
-	}
-}
-
 /* Showing Menu Sidebar animation. */
 .is-menu-sidebar {
 
 	.header-menu-sidebar {
 		visibility: visible;
-
-
-		.item--inner {
-			opacity: 1;
-		}
 	}
 
 	&.menu_sidebar_slide_left {

--- a/assets/scss/components/main/_media-queries.scss
+++ b/assets/scss/components/main/_media-queries.scss
@@ -1,8 +1,3 @@
-@media (min-width: #{$tablet-sm}) {
-
-	@include hfg-alignments--tablet-sm();
-}
-
 @media (min-width: #{$tablet}) {
 
 	@include comments--tablet();
@@ -14,9 +9,10 @@
 	@include nav-menu--laptop();
 	@include blog-layout-default-alt--laptop();
 	@include sidebar--laptop();
-	@include hfg-alignments--laptop();
 	@include gutenberg--laptop();
 }
 
+//@media (min-width: #{$tablet-sm}) {
+//}
 //@media (min-width: #{$desktop}) {
 //}

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1353,7 +1353,7 @@ abstract class Abstract_Builder implements Builder {
 						'classes'    => $classes,
 						'components' => [],
 					];
-					if ( $builder_id === 'footer' && ! empty( $vertical_align ) &&  ! $new_skin ) {
+					if ( $builder_id === 'footer' && ! empty( $vertical_align ) && ! $new_skin ) {
 						$render_buffer[ $slot ][ $render_index ]['vertical-align'] = 'hfg-item-v-' . $vertical_align;
 					}
 				}

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -40,6 +40,8 @@ abstract class Abstract_Builder implements Builder {
 	const TEXT_COLOR         = 'new_text_color';
 	const BACKGROUND_SETTING = 'background';
 	const WIDTH              = 'width';
+	const CONTENT_ALIGNMENT  = 'content_alignment';
+	const VERTICAL_ALIGN     = 'vertical_align';
 	/**
 	 * Layout config data.
 	 *
@@ -392,7 +394,7 @@ abstract class Abstract_Builder implements Builder {
 		}
 
 		if ( $this->columns_layout && neve_is_new_builder() ) {
-			$this->add_columns_layout_controls( $row_setting_id );
+			$this->add_columns_layout_controls( $row_setting_id, $row_id );
 		}
 
 		$default_colors = $this->get_default_row_colors( $row_id );
@@ -1351,7 +1353,7 @@ abstract class Abstract_Builder implements Builder {
 						'classes'    => $classes,
 						'components' => [],
 					];
-					if ( $builder_id === 'footer' && ! empty( $vertical_align ) ) {
+					if ( $builder_id === 'footer' && ! empty( $vertical_align ) &&  ! $new_skin ) {
 						$render_buffer[ $slot ][ $render_index ]['vertical-align'] = 'hfg-item-v-' . $vertical_align;
 					}
 				}
@@ -1406,11 +1408,9 @@ abstract class Abstract_Builder implements Builder {
 
 			$slot_classes = [ 'hfg-slot', $slot ];
 
-			if ( count( $slot_data ) === 1 ) {
-				$slot_classes[] = 'single';
-				if ( isset( $slot_data[0]['vertical-align'] ) ) {
-					$slot_classes[] = $slot_data[0]['vertical-align'];
-				}
+			// This doesn't apply to new skin as `vertical-align` is always empty.
+			if ( isset( $slot_data[0]['vertical-align'] ) ) {
+				$slot_classes[] = $slot_data[0]['vertical-align'];
 			}
 
 			if ( $row_index !== 'sidebar' ) {
@@ -1813,6 +1813,68 @@ abstract class Abstract_Builder implements Builder {
 	 * @param string $row_setting_id row id.
 	 */
 	private function add_sidebar_controls( $row_setting_id ) {
+		$align_choices = [
+			'left'   => [
+				'tooltip' => __( 'Left', 'neve' ),
+				'icon'    => 'editor-alignleft',
+			],
+			'center' => [
+				'tooltip' => __( 'Center', 'neve' ),
+				'icon'    => 'editor-aligncenter',
+			],
+			'right'  => [
+				'tooltip' => __( 'Right', 'neve' ),
+				'icon'    => 'editor-alignright',
+			],
+		];
+
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::CONTENT_ALIGNMENT,
+				'group'                 => $row_setting_id,
+				'tab'                   => SettingsManager::TAB_LAYOUT,
+				'transport'             => 'postMessage',
+				'label'                 => __( 'Alignment', 'neve' ),
+				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Radio_Buttons',
+				'section'               => $row_setting_id,
+				'options'               => [
+					'choices' => $align_choices,
+				],
+				'conditional_header'    => true,
+				'sanitize_callback'     => 'neve_sanitize_alignment',
+				'default'               => [
+					'desktop' => 'left',
+					'tablet'  => 'left',
+					'mobile'  => 'left',
+				],
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'vars'       => [
+							'--justify',
+							'--textAlign',
+							'--flexG',
+						],
+						'valueRemap' => [
+							'--justify' => [
+								'left'   => 'flex-start',
+								'center' => 'center',
+								'right'  => 'flex-end',
+							],
+							'--flexG'   => [
+								'left'   => '1',
+								'center' => '0',
+								'right'  => '1',
+							],
+						],
+						'responsive' => true,
+						'selector'   => '.header-menu-sidebar-bg',
+					],
+					'is_for' => 'horizontal',
+				],
+			]
+		);
+
 		SettingsManager::get_instance()->add(
 			[
 				'id'                 => self::LAYOUT_SETTING,
@@ -1831,7 +1893,7 @@ abstract class Abstract_Builder implements Builder {
 						'dropdown'    => __( 'Slide Down', 'neve' ),
 					],
 				],
-				'conditional_header' => $this->get_id() === 'header',
+				'conditional_header' => true,
 				'transport'          => 'refresh',
 				'sanitize_callback'  => 'wp_filter_nohtml_kses',
 				'default'            => 'slide_left',
@@ -1846,7 +1908,7 @@ abstract class Abstract_Builder implements Builder {
 				'label'                 => __( 'Sidebar Width', 'neve' ),
 				'transport'             => 'postMessage',
 				'section'               => $row_setting_id,
-				'conditional_header'    => $this->get_id() === 'header',
+				'conditional_header'    => true,
 				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
 				'default'               => '{ "mobile": "350", "tablet": "350", "desktop": "350" }',
 				'options'               => [
@@ -1889,9 +1951,10 @@ abstract class Abstract_Builder implements Builder {
 	/**
 	 * Adds Column Layout Controls.
 	 *
-	 * @param string $row_setting_id row id.
+	 * @param string $row_setting_id row setting id [e.g. hfg_footer_layout_bottom].
+	 * @param string $row_id row id.
 	 */
-	private function add_columns_layout_controls( $row_setting_id ) {
+	private function add_columns_layout_controls( $row_setting_id, $row_id ) {
 		$choices = [];
 
 		for ( $i = 1; $i <= 5; $i ++ ) {
@@ -1932,6 +1995,46 @@ abstract class Abstract_Builder implements Builder {
 				'transport'         => 'post' . $row_setting_id,
 				'sanitize_callback' => [ $this, 'sanitize_columns' ],
 				'default'           => 'equal',
+			]
+		);
+
+		$align_choices = [
+			'flex-start' => [
+				'tooltip' => __( 'Top', 'neve' ),
+				'icon'    => 'arrow-up',
+			],
+			'center'     => [
+				'tooltip' => __( 'Middle', 'neve' ),
+				'icon'    => 'sort',
+			],
+			'flex-end'   => [
+				'tooltip' => __( 'Bottom', 'neve' ),
+				'icon'    => 'arrow-down',
+			],
+		];
+
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::VERTICAL_ALIGN,
+				'group'                 => $row_setting_id,
+				'tab'                   => SettingsManager::TAB_LAYOUT,
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => 'wp_filter_nohtml_kses',
+				'default'               => 'flex-start',
+				'section'               => $row_setting_id,
+				'label'                 => __( 'Vertical Alignment', 'neve' ),
+				'type'                  => '\Neve\Customizer\Controls\React\Radio_Buttons',
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'vars'     => '--vAlign',
+						'selector' => '.' . $this->get_id() . '-' . $row_id . ' .row',
+					],
+					'is_for' => 'vertical',
+				],
+				'options'               => [
+					'choices' => $align_choices,
+				],
 			]
 		);
 	}
@@ -2019,6 +2122,54 @@ abstract class Abstract_Builder implements Builder {
 	 * @return array
 	 */
 	private function add_new_builder_styles( $css_array, $row ) {
+		$justify_map = [
+			'left'   => 'flex-start',
+			'center' => 'center',
+			'right'  => 'flex-end',
+		];
+
+		$align_default = [
+			'desktop' => 'left',
+			'tablet'  => 'left',
+			'mobile'  => 'left',
+		];
+
+		$align_id = $this->control_id . '_' . $row . '_' . self::CONTENT_ALIGNMENT;
+
+		if ( $row === 'sidebar' ) {
+			$css_array[] = [
+				Dynamic_Selector::KEY_SELECTOR => '.header-menu-sidebar-bg',
+				Dynamic_Selector::KEY_RULES    => [
+					'--justify'   => [
+						Dynamic_Selector::META_KEY     => $align_id,
+						Dynamic_Selector::META_IS_RESPONSIVE => true,
+						Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) use ( $justify_map ) {
+							return sprintf( '%s: %s;', $css_prop, $justify_map[ $value ] );
+						},
+						Dynamic_Selector::META_DEFAULT => $align_default,
+					],
+					'--textAlign' => [
+						Dynamic_Selector::META_KEY     => $align_id,
+						Dynamic_Selector::META_IS_RESPONSIVE => true,
+						Dynamic_Selector::META_DEFAULT => $align_default,
+					],
+					'--flexG'     => [
+						Dynamic_Selector::META_KEY     => $align_id,
+						Dynamic_Selector::META_IS_RESPONSIVE => true,
+						Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) {
+							if ( $value !== 'center' ) {
+								return sprintf( '%s: 1;', $css_prop );
+							}
+
+							return sprintf( '%s: 0;', $css_prop );
+						},
+						Dynamic_Selector::META_DEFAULT => $align_default,
+					],
+				],
+			];
+		}
+
+
 		if ( ! $this->columns_layout ) {
 			return $css_array;
 		}
@@ -2065,6 +2216,10 @@ abstract class Abstract_Builder implements Builder {
 					Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) use ( $layout ) {
 						return sprintf( '%s:%s;', $css_prop, $layout );
 					},
+				],
+				'--vAlign'                          => [
+					Dynamic_Selector::META_KEY     => $mods_prefix . self::VERTICAL_ALIGN,
+					Dynamic_Selector::META_DEFAULT => 'flex-start',
 				],
 			],
 		];

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -39,6 +39,7 @@ class CustomHtml extends Abstract_Component {
 		$this->set_property( 'icon', 'welcome-write-blog' );
 		$this->set_property( 'has_typeface_control', true );
 		$this->set_property( 'default_typography_selector', $this->default_typography_selector . '.builder-item--' . $this->get_id() . ' .nv-html-content' ); //phpcs:ignore WordPressVIPMinimum.Security.Vuejs.RawHTMLDirectiveFound
+		$this->set_property( 'has_horizontal_alignment', true );
 		add_filter( 'wp_kses_allowed_html', array( $this, 'allow_input_form_tags' ), 10, 2 );
 	}
 

--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -78,6 +78,7 @@ class Logo extends Abstract_Component {
 		$this->set_property( 'section', 'title_tagline' );
 		$this->set_property( 'preview_image', esc_url( get_template_directory_uri() . '/header-footer-grid/assets/images/customizer/component-site-logo.jpg' ) );
 		$this->set_property( 'default_selector', '.builder-item--' . $this->get_id() . ' .site-logo' );
+		$this->set_property( 'has_horizontal_alignment', true );
 	}
 
 	/**

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -65,7 +65,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		$expanded = strpos( $args->menu_id, 'sidebar' ) !== false ? 'tabindex="0"' : '';
 
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-			$title = '<span class="menu-item-title-wrap">' . $title . '</span>';
+			$title = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
 
 			$title .= '<div ' . $expanded . ' class="caret-wrap ' . $item->menu_order . '">';
 			$title .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "41 KB",
+			"limit": "38 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
- Adds alignment option to the mobile sidebar row setting;
- Adds vertical alignment option for each footer row;
- Removes alignment options for all header components, except HTML and Logo, which might have the need to adjust it on desktop too;
- Migrates inline style for builder alignments to CSS vars, reducing the size of the main CSS;
- Fixes issue with elements added inside the mobile sidebar from the popover (the available elements weren't updating);
- Fixes issue with builder JS app not loading async properly;
- Adds cleanup functions to some useEffect hooks; 
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

For #3134 
---
- You should be able to see the builder JavaScript files loading async in the Network tab of dev tools when entering either builder section in customizer;
- The builders should work as expected, without errors;


For #3131 
---
- Open the header builder panel and switch to the mobile view;
- Add a component to the mobile sidebar by clicking on the row (not adding it from the left side with drag-and-drop);
- It should disappear from the available components;
- If you drag the last component from the customize panel inside the builder anywhere, there should be no errors and everything should be working as expected;
- This should still work fine with the conditional headers from the pro version;

For Codeinwp/neve-pro-addon#1554
---
- There should be a new horizontal alignment option for the mobile sidebar row;
- It should work fine;
- The HTML and Logo components should have their own horizontal alignment setting that overrides this;
- No other header components should have the control;
- All footer components should have the horizontal alignment option;
- There should not be a vertical alignment option for the footer components anymore;
- All the footer rows should have their own vertical alignment control that controls all components alignment;

<!-- Issues that this pull request closes. -->
Closes #3134.
Closes #3131.
Closes Codeinwp/neve-pro-addon#1554.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
