### PR TITLE
Fix outdated template error on WooCommerce Status

### DIFF
--- a/woocommerce/product-searchform.php
+++ b/woocommerce/product-searchform.php
@@ -2,7 +2,17 @@
 /**
  * The template for displaying product search form
  *
- * @package Neve.
+ * This template can be overridden by copying it to neve/woocommerce/product-searchform.php.
+ *
+ * HOWEVER, on occasion WooCommerce will need to update template files and you
+ * (the theme developer) will need to copy the new files to your theme to
+ * maintain compatibility. We try to do this as little as possible, but it does
+ * happen. When this occurs the version of the template file will be bumped and
+ * the readme will list any important changes.
+ *
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce\Templates
+ * @version 3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
WooCommerce was giving and error about the outdated template on status page, it's fixed with the PR.

I've just updated the PHPdoc, it's enough to fix the alert. 

Btw: The main structure of the product-searchform.php is different from WC one because of we've refactored the product-searchform.php to fix errors reported by https://themes.trac.wordpress.org/ticket/105195#comment:3 . We're using get_search_form() instead of hard-coded form on there.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
Before the PR: https://vertis.d.pr/q8uXt5
After the PR: https://vertis.d.pr/9UpUwS

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure there is no outdated template error on WooCommerce status page.

<!-- Issues that this pull request closes. -->
Closes #3136 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
