### PR TITLE
Feat/issue 2971

### DIFF
--- a/assets/apps/customizer-controls/src/common/ColorControl.js
+++ b/assets/apps/customizer-controls/src/common/ColorControl.js
@@ -1,11 +1,14 @@
 import PropTypes from 'prop-types';
 import GlobalColorsPicker from '../common/GlobalColorsPicker';
-// we can add back ColorPicker here when issue https://github.com/WordPress/gutenberg/issues/30798 is resolved
-import { Button, Dropdown } from '@wordpress/components';
+import { Button, Dropdown, Spinner, ColorPicker } from '@wordpress/components';
+import { lazy, Suspense } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
-import ColorPickerFix from './ColorPickerFix';
+// lazy load this so that is used to replace the default ColorPicker only if required
+// The fix is for this issue https://github.com/WordPress/gutenberg/issues/30798
+// applies to versions of WordPress < 5.8
+const ColorPickerFix = lazy(() => import('./ColorPickerFix'));
 
 const ColorControl = ({
 	label,
@@ -15,6 +18,19 @@ const ColorControl = ({
 	disableGlobal,
 }) => {
 	let toggle = null;
+	const { shouldUseColorPickerFix } = window.NeveReactCustomize;
+
+	/**
+	 * Check if Default Color Picker can be used or the patched version.
+	 *
+	 * @return {boolean} Can use default.
+	 */
+	const canUseDefaultColorPicker = () => {
+		if (shouldUseColorPickerFix === undefined) {
+			return false;
+		}
+		return parseInt(shouldUseColorPickerFix) !== 1;
+	};
 
 	const handleChange = (value) => {
 		const { r, g, b, a } = value.rgb;
@@ -70,10 +86,25 @@ const ColorControl = ({
 					<>
 						{/* eslint-disable-next-line  jsx-a11y/anchor-has-content */}
 						<a href="#color-picker" />
-						<ColorPickerFix
-							color={selectedColor}
-							onChangeComplete={handleChange}
-						/>
+						<Suspense fallback={<Spinner />}>
+							{!canUseDefaultColorPicker() && (
+								<>
+									<ColorPickerFix
+										color={selectedColor}
+										onChangeComplete={handleChange}
+									/>
+								</>
+							)}
+							{canUseDefaultColorPicker() && (
+								<>
+									<ColorPicker
+										color={selectedColor}
+										onChangeComplete={handleChange}
+									/>
+								</>
+							)}
+						</Suspense>
+
 						{selectedColor && (
 							<Button
 								className="clear"

--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -503,6 +503,19 @@ function neve_is_new_widget_editor() {
 }
 
 /**
+ * Check that the active WordPress version is greater than the passed value.
+ *
+ * @param string $version The default check is for `5.8` other values are accepted.
+ *
+ * @return bool
+ * @since 3.0.5
+ */
+function is_using_wp_version( $version = '5.8' ) {
+	global $wp_version;
+	return version_compare( $wp_version, $version, '>=' );
+}
+
+/**
  * Wrapper for wp_remote_get on VIP environments.
  *
  * @param string $url Url to check.

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -117,6 +117,7 @@ class Loader {
 				array(
 					'nonce'                         => wp_create_nonce( 'wp_rest' ),
 					'headerControls'                => [],
+					'shouldUseColorPickerFix'       => (int) ( ! is_using_wp_version( '5.8' ) ),
 					'instructionalVid'              => esc_url( get_template_directory_uri() . '/header-footer-grid/assets/images/customizer/hfg.mp4' ),
 					'dynamicTags'                   => array(
 						'controls' => array(),


### PR DESCRIPTION
### Summary
Added a check for WordPress version and conditioned the load of the patched version of the ColorPicker based on that.

### Will affect visual aspect of the product
NO

### Test instructions
1. Test the color pickers from Customizer with version higher or equal to 5.8
2. Test the color pickers from Customizer with version lower than 5.8

The patched version was made for this issue: https://github.com/Codeinwp/neve/issues/2628
You can use the details provided there to test that no regression is introduced.

Closes #2971.
