### PR TITLE
Fix missing default value for vertical align on cover layout

### DIFF
--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -1157,6 +1157,11 @@ class Frontend extends Generator {
 			'--vAlign'  => [
 				Dynamic_Selector::META_KEY           => Config::MODS_POST_COVER_TITLE_POSITION,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
+				Dynamic_Selector::META_DEFAULT       => [
+					'mobile'  => 'center',
+					'tablet'  => 'center',
+					'desktop' => 'center',
+				],
 			],
 		];
 


### PR DESCRIPTION
### Summary
The control had a default value in the customizer but when applied on the frontend, the value was missing.

### Will affect visual aspect of the product
NO


### Test instructions
- Create a new instance in tastewp
- Go in the customizer and enable the cover layout on a single blog, save and go to the single post
- Check the title position, it should be centered instead of aligned bottom as it was before

<!-- Issues that this pull request closes. -->
Closes #3143.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
