### PR TITLE
Feat add more hooks for custom layouts

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -44,6 +44,8 @@ function neve_hooks() {
 			'neve_before_header_wrapper_hook',
 			'neve_after_header_hook',
 			'neve_after_header_wrapper_hook',
+			'neve_before_mobile_menu_content',
+			'neve_after_mobile_menu_content',
 		),
 		'footer'     => array(
 			'neve_before_footer_hook',
@@ -117,6 +119,7 @@ function neve_hooks() {
 			'woocommerce_cart_totals_before_order_total',
 			'woocommerce_proceed_to_checkout',
 			'woocommerce_after_cart_totals',
+			'woocommerce_cart_is_empty',
 		);
 		$hooks['checkout'] = array(
 			'woocommerce_before_checkout_billing_form',
@@ -130,6 +133,23 @@ function neve_hooks() {
 			'woocommerce_review_order_before_submit',
 			'woocommerce_review_order_after_submit',
 			'woocommerce_review_order_after_payment',
+		);
+		$hooks['login']    = array(
+			'woocommerce_login_form_start',
+			'woocommerce_login_form_end',
+		);
+		$hooks['register'] = array(
+			'woocommerce_register_form_end',
+			'woocommerce_register_form_start',
+		);
+		$hooks['account']  = array(
+			'woocommerce_before_my_account',
+			'woocommerce_before_account_navigation',
+			'woocommerce_account_navigation',
+			'woocommerce_after_account_navigation',
+			'woocommerce_account_content',
+			'woocommerce_account_dashboard',
+			'woocommerce_after_my_account',
 		);
 	}
 

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -42,9 +42,24 @@ $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 			</button>
 		</div>
 		<div id="header-menu-sidebar-inner" class="<?php echo esc_attr( $inner_classes ); ?>">
+			<?php
+			/**
+			 * Executes actions before the content of the menu sidebar that appears on mobile devices.
+			 *
+			 * @since 3.0.6
+			 */
+			do_action( 'neve_before_mobile_menu_content' ); 
+			?>
 			<?php render_components( HeaderBuilder::BUILDER_NAME ); ?>
+			<?php
+			/**
+			 * Executes actions after the content of the menu sidebar that appears on mobile devices.
+			 *
+			 * @since 3.0.6
+			 */
+			do_action( 'neve_after_mobile_menu_content' ); 
+			?>
 		</div>
 	</div>
 </div>
 <div class="header-menu-sidebar-overlay"></div>
-


### PR DESCRIPTION
### Summary
Added two new locations in menu sidebar on mobile neve_before_mobile_menu_content and neve_after_mobile_menu_content
Made the hooks from woocommerce available in custom layouts. The list can be found in the issue's text.

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->
https://vertis.d.pr/w0oZmX

### Test instructions
- To achieve the goal of the issue, this PR should be tested with https://github.com/Codeinwp/neve-pro-addon/pull/1620
- If https://github.com/Codeinwp/neve-pro-addon/pull/1620 the newly added hooks should be present in the "Hooks" select input but the "Custom hook" feature will not be present
- It should be tested and see if the custom layout you add appears in the newly added locations. 
- The locations are mentioned in the issue's text

<!-- Issues that this pull request closes. -->
Closes Codeinwp\neve-pro-addon#1576.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
