### PR TITLE
fix: event binding on mobile sidebar when core header is not used, fi…

### DIFF
--- a/assets/js/src/frontend/hgf.js
+++ b/assets/js/src/frontend/hgf.js
@@ -40,13 +40,15 @@ HFG.prototype.init = function (skipSidebar = false) {
 	 * When click to outside of menu sidebar.
 	 */
 	const overlay = document.querySelector('.header-menu-sidebar-overlay');
-	addEvent(
-		overlay,
-		'click',
-		function () {
-			this.toggleMenuSidebar(false);
-		}.bind(this)
-	);
+	if (overlay) {
+		addEvent(
+			overlay,
+			'click',
+			function () {
+				this.toggleMenuSidebar(false);
+			}.bind(this)
+		);
+	}
 };
 
 /**


### PR DESCRIPTION

### Summary
Fix event binding error on mobile sidebar when core header is not used

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions

1. Make sure the latest version of Neve is running
2. Install & activate Elementor and Elementor Pro
3. Navigate to Elementor -> Templates -> Theme Builder
4. Create a header template, set it to appear on all pages, and publish it
5. Visit the front page of the website and open the browser console(eventually scroll the page down a bit with the console open)
6. The error is no longer showing up.

<!-- Issues that this pull request closes. -->
Closes #3123
