### PR TITLE
Removed unused get_assets_suffix() method

### DIFF
--- a/header-footer-grid/Core/Customizer.php
+++ b/header-footer-grid/Core/Customizer.php
@@ -122,17 +122,17 @@ class Customizer {
 	 * @access  public
 	 */
 	public function scripts() {
-		$suffix = $this->get_assets_suffix();
+
 		wp_enqueue_style(
 			'hfg-customizer-control',
-			esc_url( Config::get_url() ) . '/assets/css/admin/customizer/customizer' . $suffix . '.css',
+			esc_url( Config::get_url() ) . '/assets/css/admin/customizer/customizer.css',
 			array(),
 			Main::VERSION
 		);
 
 		wp_register_script(
 			'hfg-layout-builder',
-			esc_url( Config::get_url() ) . '/assets/js/customizer/builder' . $suffix . '.js',
+			esc_url( Config::get_url() ) . '/assets/js/customizer/builder.js',
 			array(
 				'customize-controls',
 				'jquery-ui-resizable',
@@ -211,10 +211,10 @@ class Customizer {
 		if ( ! is_customize_preview() ) {
 			return;
 		}
-		$suffix = $this->get_assets_suffix();
+
 		wp_enqueue_script(
 			'hfg-customizer',
-			esc_url( Config::get_url() ) . '/assets/js/customizer/customizer' . $suffix . '.js',
+			esc_url( Config::get_url() ) . '/assets/js/customizer/customizer.js',
 			array(
 				'customize-preview',
 				'customize-selective-refresh',

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -19,23 +19,6 @@ namespace HFG\Traits;
 trait Core {
 
 	/**
-	 * Return if assets should use `.min` suffix or not.
-	 *
-	 * @since   1.0.0
-	 * @access  public
-	 * @return string
-	 */
-	public function get_assets_suffix() {
-		// $suffix = '.min';
-		// if ( defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ) {
-		// $suffix = '';
-		// }
-
-		return '';
-	}
-
-
-	/**
 	 * Utility method to convert associative array to css rules.
 	 *
 	 * @since   1.0.0


### PR DESCRIPTION
### Summary
Removed unused method introduced by this commit 8 months ago: https://github.com/Codeinwp/neve/commit/a84353d56ec3af7c14ad6c23d0e8b73f4c30f891 things seem to be working fine without it so went ahead and removed the code all together

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this patch
- Test that Header Footer Grid operation is fine

<!-- Issues that this pull request closes. -->
Closes #2992
<!-- Should look like this: `Closes #1, #2, #3.` . -->
