### PR TITLE
fix: issue with infinit scroll in some context

### DIFF
--- a/assets/js/src/frontend/blog.js
+++ b/assets/js/src/frontend/blog.js
@@ -105,6 +105,7 @@ const requestMorePosts = () => {
  * @return {*} Sanitized URL.
  */
 const maybeParseUrlForCustomizer = (url) => {
+	if (typeof wp === 'undefined') return url;
 	//Add change-set uuid.
 	if (typeof wp.customize === 'undefined') return url;
 	url +=


### PR DESCRIPTION
### Summary
In some contexts the `parent.wp` object might not be defined this is accentuaded when embed scripts removal is enabled since the embeded scripts might be the only one that initialize the object.
This is only used for the customizer and it works in customizer context but on the frontend it blocked script execution if the object was not present although it was not being used.
 Codeinwp/neve-pro-addon#1645

### Will affect visual aspect of the product
NO

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1645.
