### PR TITLE
Fix ordering control

### DIFF
--- a/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
+++ b/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
@@ -108,8 +108,7 @@ const OrderingComponent = ({ control }) => {
 
 							break;
 					}
-
-					updateValue(newVal);
+					updateValue(normalizeValue(newVal));
 				});
 			}
 		);


### PR DESCRIPTION
### Summary
Fixed the ordering control when header layout is changed on the single post

### Will affect visual aspect of the product
NO

### Test instructions
- Enable blog booster module
- Go to Layouts -> Single Post and change switch the layouts ( cover / normal )
- Make sure the control doesn't break like in the following image
![image](https://user-images.githubusercontent.com/9929553/138879047-7d501f62-8400-4eda-9afc-335d6e098240.png)


<!-- Issues that this pull request closes. -->
Closes #3174.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
