### PR TITLE
fix: solve new lines for existing content and safari support #3178

### DIFF
--- a/assets/apps/customizer-controls/src/rich-text/RichText.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichText.js
@@ -178,6 +178,15 @@ const RichText = ({
 		initEditor();
 	}, []);
 
+	// Re-init text editor content on conditional changes.
+	useEffect(() => {
+		document.addEventListener('neve-changed-customizer-value', (e) => {
+			if (!e.detail) return false;
+			if (e.detail.id !== id) return false;
+			setEditorContent(e.detail.value);
+		});
+	}, []);
+
 	return (
 		<div
 			className="neve-white-background-control neve-rich-text"

--- a/assets/apps/customizer-controls/src/rich-text/RichText.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichText.js
@@ -7,8 +7,9 @@ const RichText = ({ onChange, currentValue, label, id, editorId }) => {
 			<textarea
 				id={editorId}
 				data-customize-setting-link={id}
-				className="neve-custom-html-control-tinymce-editor"
+				className="neve-custom-html-control-tinymce-editor mce-tinymce"
 				value={currentValue}
+				style={{ width: '100%' }}
 				onChange={({ target: { value } }) => onChange(value)}
 			/>
 		</div>

--- a/assets/apps/customizer-controls/src/rich-text/RichText.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichText.js
@@ -1,15 +1,206 @@
+/* global NeveReactCustomize, Event */
 import PropTypes from 'prop-types';
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+import DynamicFieldInserter from '../dynamic-fields/dynamic-field-inserter';
 
-const RichText = ({ onChange, currentValue, label, id, editorId }) => {
+const RichText = ({
+	onChange,
+	currentValue,
+	label,
+	id,
+	toolbars,
+	allowedDynamicFields,
+}) => {
+	const textArea = useRef(null);
+	const useDynamicFields = Boolean(
+		Array.isArray(allowedDynamicFields) && allowedDynamicFields.length
+	);
+	const toolbarOneDefaults =
+		'formatselect,bold,italic,bullist,numlist,link,wp_adv';
+	const toolbarTwoDefaults =
+		'strikethrough,hr,forecolor,pastetext,removeformat';
+	const {
+		toolbar1 = toolbarOneDefaults,
+		toolbar2 = toolbarTwoDefaults,
+	} = toolbars;
+	const editorId = `${id}-editor`;
+	NeveReactCustomize.fieldSelection = {};
+
+	/**
+	 * Get the editor to be used based on the available version that WP loads.
+	 */
+	const correctEditor = wp.oldEditor || wp.editor;
+
+	/**
+	 * A listener to trigger the update state on change.
+	 */
+	const listener = useCallback(
+		() => onChange(correctEditor.getContent(editorId)),
+		[editorId]
+	);
+
+	/**
+	 * Method to add a change listener for the current editor.
+	 */
+	const addEditorChangeListener = () => {
+		if (window.tinymce.editors[editorId]) {
+			window.tinymce.editors[editorId].on('change', listener);
+		}
+	};
+
+	/**
+	 * Method to remove a change listener for the current editor.
+	 */
+	const removeEditorChangeListener = () => {
+		if (window.tinymce.editors[editorId]) {
+			window.tinymce.editors[editorId].off('change', listener);
+		}
+	};
+
+	/**
+	 * Initialise the editor.
+	 */
+	const initEditor = () => {
+		correctEditor.initialize(editorId, {
+			quicktags: true,
+			mediaButtons: true,
+
+			tinymce: {
+				toolbar1,
+				toolbar2,
+				style_formats_merge: true,
+				style_formats: [],
+			},
+		});
+
+		setTimeout(addEditorChangeListener, 0);
+
+		if (wp.oldEditor) {
+			setTimeout(() => {
+				removeEditorChangeListener();
+
+				correctEditor.remove(editorId);
+
+				correctEditor.initialize(editorId, {
+					quicktags: true,
+					mediaButtons: true,
+
+					tinymce: {
+						toolbar1,
+						toolbar2,
+						style_formats_merge: true,
+						style_formats: [],
+					},
+				});
+
+				setTimeout(addEditorChangeListener, 0);
+			}, 300);
+		}
+	};
+
+	/**
+	 * Method to update the editor content and state.
+	 *
+	 * @param {string} content The new content.
+	 */
+	const setEditorContent = (content) => {
+		onChange(content);
+		window.tinymce.editors[editorId].setContent(content);
+	};
+
+	/**
+	 * Add dynamic tag to input field.
+	 *
+	 * @param {string} magicTag
+	 * @param {string} optionType
+	 */
+	const addToField = function (magicTag, optionType) {
+		let tag;
+		const codeEditor = textArea.current;
+		const isVisualEditor = !window.tinymce.editors[editorId].hidden;
+
+		if (optionType === 'url') {
+			tag = `<a href="{${magicTag}}">Link</a>`;
+		} else {
+			tag = `{${magicTag}}`;
+		}
+
+		if (isVisualEditor) {
+			window.tinymce.editors[editorId].editorCommands.execCommand(
+				'mceInsertContent',
+				false,
+				tag
+			);
+			window.tinymce.editors[editorId].focus();
+		} else {
+			if (NeveReactCustomize.fieldSelection[id]) {
+				const { start, end } = NeveReactCustomize.fieldSelection[id];
+				const length = codeEditor.value.length;
+				codeEditor.value =
+					codeEditor.value.substring(0, start) +
+					tag +
+					codeEditor.value.substring(end, length);
+			} else {
+				codeEditor.value += tag;
+			}
+			codeEditor.focus();
+		}
+		codeEditor.dispatchEvent(new Event('change'));
+	};
+
+	const controlWrapperStyle = {
+		position: 'relative',
+	};
+	const dynamicFieldStyle = {
+		position: 'absolute',
+		top: 0,
+		right: '8px',
+	};
+
+	const textAreaStyle = {
+		width: '100%',
+	};
+
+	useEffect(() => {
+		// We also hook here to listen for changes of the dynamic settings change to also trigger the editor content update.
+		if (textArea && textArea.current) {
+			textArea.current.addEventListener('change', () => {
+				setEditorContent(textArea.current.value);
+			});
+
+			textArea.current.addEventListener('focusout', function (e) {
+				NeveReactCustomize.fieldSelection[id] = {
+					start: e.target.selectionStart,
+					end: e.target.selectionEnd,
+				};
+			});
+		}
+		initEditor();
+	}, []);
+
 	return (
-		<div className="neve-white-background-control neve-rich-text">
+		<div
+			className="neve-white-background-control neve-rich-text"
+			style={controlWrapperStyle}
+		>
 			<span className="customize-control-title">{label}</span>
+			{useDynamicFields && (
+				<span style={dynamicFieldStyle}>
+					<DynamicFieldInserter
+						options={NeveReactCustomize?.dynamicTags?.options || []}
+						allowedOptionsTypes={allowedDynamicFields}
+						onSelect={(magicTag, group) =>
+							addToField(magicTag, group)
+						}
+					/>
+				</span>
+			)}
 			<textarea
+				ref={textArea}
 				id={editorId}
-				data-customize-setting-link={id}
 				className="neve-custom-html-control-tinymce-editor mce-tinymce"
 				value={currentValue}
-				style={{ width: '100%' }}
+				style={textAreaStyle}
 				onChange={({ target: { value } }) => onChange(value)}
 			/>
 		</div>
@@ -18,7 +209,8 @@ const RichText = ({ onChange, currentValue, label, id, editorId }) => {
 
 RichText.propTypes = {
 	id: PropTypes.string.isRequired,
-	editorId: PropTypes.string.isRequired,
+	toolbars: PropTypes.object,
+	allowedDynamicFields: PropTypes.array,
 	label: PropTypes.string.isRequired,
 	onChange: PropTypes.func.isRequired,
 	currentValue: PropTypes.string.isRequired,

--- a/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
@@ -54,13 +54,12 @@ const RichTextComponent = ({ control }) => {
 	 * Initialise the editor.
 	 */
 	const initEditor = () => {
-		// We also hook here to listen for changes of the dynamic settings change to also trigger the editor content update.
-		const input = document.querySelector(
-			`[data-customize-setting-link="${controlId}"]`
-		);
-		input.addEventListener('change', () => {
-			setEditorContent(input.value);
+		// this replaces the default line breaks for old textarea content
+		let content = document.getElementById(editorId).value;
+		content = content.replace(/[a-zA-Z0-9\}(?:\s)]\n/g, function (a) {
+			return a + '<br/>';
 		});
+		document.getElementById(editorId).value = content;
 
 		correctEditor().initialize(editorId, {
 			quicktags: true,
@@ -123,6 +122,14 @@ const RichTextComponent = ({ control }) => {
 	 * We check here that the section is visible so that we trigger the editor load and initialisation
 	 */
 	useEffect(() => {
+		// We also hook here to listen for changes of the dynamic settings change to also trigger the editor content update.
+		const input = document.querySelector(
+			`[data-customize-setting-link="${controlId}"]`
+		);
+		input.addEventListener('change', () => {
+			setEditorContent(input.value);
+		});
+
 		// Update value from events passed by the conditional header
 		document.addEventListener('neve-changed-customizer-value', (e) => {
 			if (!e.detail) return false;

--- a/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
@@ -48,6 +48,15 @@ const RichTextComponent = ({ control }) => {
 		});
 	}, []);
 
+	useEffect(() => {
+		document.addEventListener('neve-changed-customizer-value', (e) => {
+			if (isVisible) return;
+			if (!e.detail) return false;
+			if (e.detail.id !== controlId) return false;
+			updateValues(e.detail.value);
+		});
+	}, []);
+
 	return (
 		<Suspense fallback={<Spinner />}>
 			{isVisible && (

--- a/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
@@ -29,6 +29,12 @@ const RichTextComponent = ({ control }) => {
 	 * We check here that the section is visible so that we trigger the load of the component
 	 */
 	useEffect(() => {
+		document.addEventListener('neve-changed-customizer-value', (e) => {
+			if (!e.detail) return false;
+			if (e.detail.id !== controlId) return false;
+			updateValues(e.detail.value);
+		});
+
 		window.wp.customize.bind('ready', () => {
 			window.wp.customize
 				.state('expandedSection')

--- a/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
@@ -1,112 +1,19 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
+import { useEffect, useState, lazy, Suspense } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
 import PropTypes from 'prop-types';
 
-import RichText from './RichText';
+const RichText = lazy(() => import('./RichText'));
 
 const RichTextComponent = ({ control }) => {
-	const [value, setValue] = useState(control.setting.get());
-	let isInit = false;
+	const [isVisible, setVisible] = useState(false);
+	let controlValue = control.setting.get();
+	// this replaces the default line breaks for old textarea content
+	controlValue = controlValue.replace(/[a-zA-Z0-9\}(?:\s)]\n/g, function (a) {
+		return a + '<br/>';
+	});
+	const [value, setValue] = useState(controlValue);
 	const { id: controlId, params } = control;
-	const { label, section, toolbars } = params;
-	const toolbarOneDefaults =
-		'formatselect,bold,italic,bullist,numlist,link,wp_adv';
-	const toolbarTwoDefaults =
-		'strikethrough,hr,forecolor,pastetext,removeformat';
-	const {
-		toolbar1 = toolbarOneDefaults,
-		toolbar2 = toolbarTwoDefaults,
-	} = toolbars;
-	const editorId = `${controlId}-editor`;
-	/**
-	 * Get the editor to be used based on the available version that WP loads.
-	 *
-	 * @return {*} The editor that is currently available.
-	 */
-	const correctEditor = () => wp.oldEditor || wp.editor;
-
-	/**
-	 * A listener to trigger the update state on change.
-	 */
-	const listener = useCallback(
-		() => updateValues(correctEditor().getContent(editorId)),
-		[editorId]
-	);
-
-	/**
-	 * Method to add a change listener for the current editor.
-	 */
-	const addEditorChangeListener = () => {
-		if (window.tinymce.editors[editorId]) {
-			window.tinymce.editors[editorId].on('change', listener);
-		}
-	};
-
-	/**
-	 * Method to remove a change listener for the current editor.
-	 */
-	const removeEditorChangeListener = () => {
-		if (window.tinymce.editors[editorId]) {
-			window.tinymce.editors[editorId].off('change', listener);
-		}
-	};
-
-	/**
-	 * Initialise the editor.
-	 */
-	const initEditor = () => {
-		// this replaces the default line breaks for old textarea content
-		let content = document.getElementById(editorId).value;
-		content = content.replace(/[a-zA-Z0-9\}(?:\s)]\n/g, function (a) {
-			return a + '<br/>';
-		});
-		document.getElementById(editorId).value = content;
-
-		correctEditor().initialize(editorId, {
-			quicktags: true,
-			mediaButtons: true,
-
-			tinymce: {
-				toolbar1,
-				toolbar2,
-				style_formats_merge: true,
-				style_formats: [],
-			},
-		});
-
-		setTimeout(addEditorChangeListener, 0);
-
-		if (wp.oldEditor) {
-			setTimeout(() => {
-				removeEditorChangeListener();
-
-				correctEditor().remove(editorId);
-
-				correctEditor().initialize(editorId, {
-					quicktags: true,
-					mediaButtons: true,
-
-					tinymce: {
-						toolbar1,
-						toolbar2,
-						style_formats_merge: true,
-						style_formats: [],
-					},
-				});
-
-				setTimeout(addEditorChangeListener, 0);
-			}, 300);
-		}
-	};
-
-	/**
-	 * Method to update the editor content and state.
-	 *
-	 * @param {string} content The new content.
-	 */
-	const setEditorContent = (content) => {
-		updateValues(content);
-		window.tinymce.editors[editorId].setContent(content);
-	};
+	const { label, section, toolbars, allowedDynamicFields } = params;
 
 	/**
 	 * Method to update state and trigger control setting change.
@@ -119,24 +26,9 @@ const RichTextComponent = ({ control }) => {
 	};
 
 	/**
-	 * We check here that the section is visible so that we trigger the editor load and initialisation
+	 * We check here that the section is visible so that we trigger the load of the component
 	 */
 	useEffect(() => {
-		// We also hook here to listen for changes of the dynamic settings change to also trigger the editor content update.
-		const input = document.querySelector(
-			`[data-customize-setting-link="${controlId}"]`
-		);
-		input.addEventListener('change', () => {
-			setEditorContent(input.value);
-		});
-
-		// Update value from events passed by the conditional header
-		document.addEventListener('neve-changed-customizer-value', (e) => {
-			if (!e.detail) return false;
-			if (e.detail.id !== controlId) return false;
-			updateValues(e.detail.value);
-		});
-
 		window.wp.customize.bind('ready', () => {
 			window.wp.customize
 				.state('expandedSection')
@@ -149,22 +41,26 @@ const RichTextComponent = ({ control }) => {
 						return;
 					}
 
-					if (expandedSection.id === section && isInit === false) {
-						initEditor();
-						isInit = true;
+					if (expandedSection.id === section && isVisible === false) {
+						setVisible(true);
 					}
 				});
 		});
 	}, []);
 
 	return (
-		<RichText
-			id={controlId}
-			label={label}
-			onChange={updateValues}
-			editorId={editorId}
-			currentValue={value}
-		/>
+		<Suspense fallback={<Spinner />}>
+			{isVisible && (
+				<RichText
+					id={controlId}
+					label={label}
+					onChange={updateValues}
+					toolbars={toolbars}
+					allowedDynamicFields={allowedDynamicFields}
+					currentValue={value}
+				/>
+			)}
+		</Suspense>
 	);
 };
 

--- a/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichTextComponent.js
@@ -29,12 +29,6 @@ const RichTextComponent = ({ control }) => {
 	 * We check here that the section is visible so that we trigger the load of the component
 	 */
 	useEffect(() => {
-		document.addEventListener('neve-changed-customizer-value', (e) => {
-			if (!e.detail) return false;
-			if (e.detail.id !== controlId) return false;
-			updateValues(e.detail.value);
-		});
-
 		window.wp.customize.bind('ready', () => {
 			window.wp.customize
 				.state('expandedSection')

--- a/e2e-tests/cypress/integration/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/layout/blog-archive-settings.spec.ts
@@ -179,7 +179,7 @@ describe('Blog/Archive 3 / Covers Layout', function () {
 
 	it('Masonry', function () {
 		cy.request('wp-json/wpthememods/v1/settings').then((response) => {
-			expect(response.body).to.contains(`"neve_enable_masonry":true`);
+			expect(response.body).to.have.property('neve_enable_masonry', true);
 		});
 		cy.visit('/');
 		cy.get('article.post').each((el) => {

--- a/e2e-tests/cypress/integration/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/layout/blog-archive-settings.spec.ts
@@ -179,7 +179,7 @@ describe('Blog/Archive 3 / Covers Layout', function () {
 
 	it('Masonry', function () {
 		cy.request('wp-json/wpthememods/v1/settings').then((response) => {
-			expect(response.body).to.have.property('neve_enable_masonry', true);
+			expect(response.body).to.contains(`"neve_enable_masonry":true`);
 		});
 		cy.visit('/');
 		cy.get('article.post').each((el) => {

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -150,13 +150,14 @@ class CustomHtml extends Abstract_Component {
 				'section'            => $this->section,
 				'options'            => array(
 					'input_attrs' => array(
-						'toolbars' => array(
+						'toolbars'             => array(
 							'toolbar1' => 'formatselect,styleselect,bold,italic,bullist,numlist,link,alignleft,aligncenter,alignright,wp_adv',
 							'toolbar2' => 'strikethrough,hr,forecolor,pastetext,removeformat,charmap,outdent,indent',
 						),
+						'allowedDynamicFields' => array( 'string', 'url' ),
 					),
 				),
-				'use_dynamic_fields' => array( 'string', 'url' ),
+				// 'use_dynamic_fields' => array( 'string', 'url' ),
 				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);

--- a/header-footer-grid/Core/Components/CustomHtml.php
+++ b/header-footer-grid/Core/Components/CustomHtml.php
@@ -157,7 +157,6 @@ class CustomHtml extends Abstract_Component {
 						'allowedDynamicFields' => array( 'string', 'url' ),
 					),
 				),
-				// 'use_dynamic_fields' => array( 'string', 'url' ),
 				'conditional_header' => $this->get_builder_id() === 'header',
 			]
 		);

--- a/inc/customizer/controls/react/rich_text.php
+++ b/inc/customizer/controls/react/rich_text.php
@@ -24,9 +24,13 @@ class Rich_Text extends \WP_Customize_Control {
 	 */
 	public function to_json() {
 		parent::to_json();
-		$this->json['toolbars'] = [];
+		$this->json['toolbars']             = [];
+		$this->json['allowedDynamicFields'] = [];
 		if ( isset( $this->input_attrs['toolbars'] ) && ! empty( $this->input_attrs['toolbars'] ) ) {
 			$this->json['toolbars'] = $this->input_attrs['toolbars'];
+		}
+		if ( isset( $this->input_attrs['allowedDynamicFields'] ) && ! empty( $this->input_attrs['allowedDynamicFields'] ) ) {
+			$this->json['allowedDynamicFields'] = $this->input_attrs['allowedDynamicFields'];
 		}
 	}
 }


### PR DESCRIPTION
### Summary
Solve regression #3178 and improve Safari support

### Will affect visual aspect of the product
NO

### Test instructions
1. Use a HTML component inside the Header that already has data set before using the new component
2. Check that when switching to the new control the content lines are preserved
3. Check that on Safari it does not break the Customizer
4. Check that the code editor is being displayed correctly

Closes #3178.
