### PR TITLE
chore: phpstan version hard-coded updated as 0.12.99 on gh action

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -111,4 +111,5 @@ jobs:
       - name: PHPStan Static Analysis
         uses: php-actions/phpstan@v2
         with:
+          version: 0.12.99
           memory_limit: 512M


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Phpstan version hard-coded updated as 0.12.99.

In the free time, we will add support for the phpstan v1.0 and update phpstan version again for the v1.0

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

<!-- Issues that this pull request closes. -->
Closes #3192 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
