### PR TITLE
fix: repeater control adding unused values to the db

### DIFF
--- a/assets/apps/customizer-controls/src/repeater/Repeater.js
+++ b/assets/apps/customizer-controls/src/repeater/Repeater.js
@@ -54,12 +54,26 @@ const Repeater = ({ fields, value, onUpdate }) => {
 		onUpdate(newValue);
 	};
 
+	const setList = (l) => {
+		const final = l.map((i) => {
+			Object.keys(i).forEach((k) => {
+				if (![...Object.keys(fields), 'visibility'].includes(k)) {
+					delete i[k];
+				}
+			});
+			return i;
+		});
+
+		onUpdate(final);
+		return final;
+	};
+
 	return (
 		<div className="nv-repeater">
 			<ReactSortable
 				className="nv-repeater-items-container"
 				list={value}
-				setList={onUpdate}
+				setList={setList}
 				animation={300}
 				forceFallback={true}
 				handle=".nv-repeater-handle"


### PR DESCRIPTION
### Summary
The repeater control shouldn't enable publishing inside the customizer on load.

This will still happen if the values were previously saved wrong in the DB.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add a header/footer component that uses a repeater 
- Upon customizer load, the publish button shouldn't be enabled on a clean instance

<!-- Issues that this pull request closes. -->
closes #3194.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
