### PR TITLE
fix: edge case of footer columns not having a proper corresponding layout

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -2304,15 +2304,19 @@ abstract class Abstract_Builder implements Builder {
 			],
 		];
 
-		$layout      = $styles_map[ $columns ][ $layout ];
+		$proportions = 'equal';
+		if ( isset( $styles_map[ $columns ] ) && isset( $styles_map[ $columns ][ $layout ] ) ) {
+			$proportions = $styles_map[ $columns ][ $layout ];
+		}
+
 		$css_array[] = [
 			Dynamic_Selector::KEY_SELECTOR => '.' . $builder . '-' . $row . '-inner .row',
 			Dynamic_Selector::KEY_RULES    => [
 				Config::CSS_PROP_GRID_TEMPLATE_COLS => [
 					Dynamic_Selector::META_KEY     => $mods_prefix . self::COLUMNS_LAYOUT,
 					Dynamic_Selector::META_DEFAULT => 'auto',
-					Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) use ( $layout ) {
-						return sprintf( '%s:%s;', $css_prop, $layout );
+					Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) use ( $proportions ) {
+						return sprintf( '%s:%s;', $css_prop, $proportions );
 					},
 				],
 				'--vAlign'                          => [


### PR DESCRIPTION
### Summary
Fixes inconsistency where values for the layout were falling through even though they were non-existent
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
Reproduction steps here: https://github.com/Codeinwp/neve/issues/3195

<!-- Issues that this pull request closes. -->
Fixes #3195.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
