### PR TITLE
fix: styles breaking due to old font-family values containing quotes and slashes 

### DIFF
--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -360,6 +360,10 @@ class Css_Prop {
 	 * @param string $value the font family value.
 	 */
 	public static function format_font_family_value( $value ) {
+		// At some point we were setting the DB values with quotes and removed that.
+		// Make sure we drop the slashes and quotes.
+		$value = str_replace( [ '"', '\\' ], '', $value );
+
 		if ( strpos( $value, ',' ) !== false ) {
 			$value = explode( ',', $value );
 


### PR DESCRIPTION
### Summary
Fixes issue with inline styles breaking when using a quoted value for any font family control inside the customizer. 

At some point we started quoting font-family inside the db and then removed it.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Import this file with customizer-import-export (make sure you rename it to have a `.dat` extension);
[neve-export (3).txt](https://github.com/Codeinwp/neve/files/7467931/neve-export.3.txt)
- On the old version, inline styles should be broken;
- Using the version on this branch, the issue should be fixed;

<!-- Issues that this pull request closes. -->
Closes #3189.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
