### PR TITLE
Fix compatibility with cartflows plugin

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -203,7 +203,7 @@ class Woocommerce {
 				},
 				0
 			);
-			add_action( 'woocommerce_checkout_after_customer_details', [ $this, 'close_div' ] );
+			add_action( 'woocommerce_checkout_after_customer_details', [ $this, 'close_div' ], PHP_INT_MAX );
 			add_action(
 				'woocommerce_checkout_before_order_review_heading',
 				function () {


### PR DESCRIPTION
### Summary
Seems that the container we've added to fix compatibility with foodstore plugin was closing too early so the button wasn't in that container.
I just changed the priority of when we close the 'nv-customer-details' div.

### Will affect visual aspect of the product
NO


### Test instructions
- Test that nothing breaks on the checkout page with all the checkout settings.
- Check the comment that Stefan added in the issue, update the instance he already created and see if the problem is solved

- 

<!-- Issues that this pull request closes. -->
Closes #3201.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
