### PR TITLE
Fix: removed redundant border settings from sidebar

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1125,25 +1125,25 @@ abstract class Abstract_Builder implements Builder {
 				},
 				Dynamic_Selector::META_DEFAULT       => '{ desktop: 0, tablet: 0, mobile: 0 }',
 			];
+
+			$rules['--rowBWidth'] = [
+				Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
+				Dynamic_Selector::META_IS_RESPONSIVE => true,
+				Dynamic_Selector::META_FILTER        => function ( $css_prop, $value, $meta, $device ) {
+					$value = (int) $value;
+					if ( $value >= 0 ) {
+						return sprintf( '%s:%s;', $css_prop, $value . 'px' );
+					}
+
+					return '';
+				},
+			];
+
+			$rules['--rowBColor'] = [
+				Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::BORDER_COLOR,
+				Dynamic_Selector::META_DEFAULT => 'var(--nv-light-bg)',
+			];
 		}
-
-		$rules['--rowBWidth'] = [
-			Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
-			Dynamic_Selector::META_IS_RESPONSIVE => true,
-			Dynamic_Selector::META_FILTER        => function ( $css_prop, $value, $meta, $device ) {
-				$value = (int) $value;
-				if ( $value > 0 ) {
-					return sprintf( '%s:%s;', $css_prop, $value . 'px' );
-				}
-
-				return '';
-			},
-		];
-
-		$rules['--rowBColor'] = [
-			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::BORDER_COLOR,
-			Dynamic_Selector::META_DEFAULT => 'var(--nv-light-bg)',
-		];
 
 		$rules['--color'] = [
 			Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::TEXT_COLOR,

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -394,6 +394,67 @@ abstract class Abstract_Builder implements Builder {
 					'conditional_header'    => $this->get_id() === 'header',
 				]
 			);
+
+			SettingsManager::get_instance()->add(
+				[
+					'id'                    => self::BOTTOM_BORDER,
+					'group'                 => $row_setting_id,
+					'tab'                   => SettingsManager::TAB_STYLE,
+					'section'               => $row_setting_id,
+					'label'                 => __( 'Border Width', 'neve' ),
+					'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
+					'live_refresh_selector' => true,
+					'live_refresh_css_prop' => [
+						'cssVar' => [
+							'responsive'           => true,
+							'vars'                 => '--rowBWidth',
+							'suffix'               => 'px',
+							'fallback'             => '0',
+							'selector'             => '.' . $this->get_id() . '-' . $row_id,
+							'dispatchWindowResize' => true,
+						],
+					],
+					'options'               => [
+						'input_attrs' => [
+							'step'       => 1,
+							'min'        => 0,
+							'max'        => 50,
+							'defaultVal' => [
+								'mobile'  => 0,
+								'tablet'  => 0,
+								'desktop' => 0,
+							],
+							'units'      => [ 'px' ],
+						],
+					],
+					'transport'             => 'postMessage',
+					'sanitize_callback'     => array( $this, 'sanitize_responsive_int_json' ),
+					'default'               => '{ "mobile": "0", "tablet": "0", "desktop": "0" }',
+					'conditional_header'    => $this->get_id() === 'header',
+				]
+			);
+
+			SettingsManager::get_instance()->add(
+				[
+					'id'                    => self::BORDER_COLOR,
+					'group'                 => $row_setting_id,
+					'tab'                   => SettingsManager::TAB_STYLE,
+					'label'                 => __( 'Border Color', 'neve' ),
+					'section'               => $row_setting_id,
+					'conditional_header'    => $this->get_id() === 'header',
+					'type'                  => 'neve_color_control',
+					'transport'             => 'postMessage',
+					'live_refresh_selector' => true,
+					'live_refresh_css_prop' => [
+						'cssVar' => [
+							'vars'     => '--rowBColor',
+							'selector' => '.' . $this->get_id() . '-' . $row_id,
+						],
+					],
+					'sanitize_callback'     => 'neve_sanitize_colors',
+					'default'               => 'var(--nv-light-bg)',
+				]
+			);
 		}
 
 		if ( $this->columns_layout && neve_is_new_builder() ) {
@@ -452,67 +513,6 @@ abstract class Abstract_Builder implements Builder {
 				],
 				'sanitize_callback'     => 'wp_filter_nohtml_kses',
 				'default'               => $default_colors['text'],
-			]
-		);
-
-		SettingsManager::get_instance()->add(
-			[
-				'id'                    => self::BOTTOM_BORDER,
-				'group'                 => $row_setting_id,
-				'tab'                   => SettingsManager::TAB_STYLE,
-				'section'               => $row_setting_id,
-				'label'                 => __( 'Border Width', 'neve' ),
-				'type'                  => '\Neve\Customizer\Controls\React\Responsive_Range',
-				'live_refresh_selector' => true,
-				'live_refresh_css_prop' => [
-					'cssVar' => [
-						'responsive'           => true,
-						'vars'                 => '--rowBWidth',
-						'suffix'               => 'px',
-						'fallback'             => '0',
-						'selector'             => '.' . $this->get_id() . '-' . $row_id,
-						'dispatchWindowResize' => true,
-					],
-				],
-				'options'               => [
-					'input_attrs' => [
-						'step'       => 1,
-						'min'        => 0,
-						'max'        => 50,
-						'defaultVal' => [
-							'mobile'  => 0,
-							'tablet'  => 0,
-							'desktop' => 0,
-						],
-						'units'      => [ 'px' ],
-					],
-				],
-				'transport'             => 'postMessage',
-				'sanitize_callback'     => array( $this, 'sanitize_responsive_int_json' ),
-				'default'               => '{ "mobile": "0", "tablet": "0", "desktop": "0" }',
-				'conditional_header'    => $this->get_id() === 'header',
-			]
-		);
-
-		SettingsManager::get_instance()->add(
-			[
-				'id'                    => self::BORDER_COLOR,
-				'group'                 => $row_setting_id,
-				'tab'                   => SettingsManager::TAB_STYLE,
-				'label'                 => __( 'Border Color', 'neve' ),
-				'section'               => $row_setting_id,
-				'conditional_header'    => $this->get_id() === 'header',
-				'type'                  => 'neve_color_control',
-				'transport'             => 'postMessage',
-				'live_refresh_selector' => true,
-				'live_refresh_css_prop' => [
-					'cssVar' => [
-						'vars'     => '--rowBColor',
-						'selector' => '.' . $this->get_id() . '-' . $row_id,
-					],
-				],
-				'sanitize_callback'     => 'neve_sanitize_colors',
-				'default'               => 'var(--nv-light-bg)',
 			]
 		);
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The sidebar had some border controls that didn't do anything because they shouldn't be there.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to Customizing -> Header -> Mobile Sidebar
- There shouldn't be any controls for the border

<!-- Issues that this pull request closes. -->
Closes #3206.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
