### PR TITLE
Fix: text decoration on links

### DIFF
--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -33,9 +33,11 @@ p {
 }
 
 a {
+	--linkDeco: none;
+
 	color: var(--nv-primary-accent);
 	cursor: pointer;
-	text-decoration: none;
+	text-decoration: var(--linkDeco);
 
 	&:hover,
 	&:focus {
@@ -49,8 +51,8 @@ a {
 .nv-template .neve-main,
 .nv-comment-content {
 
-	a:not([class*="button"]) {
-		text-decoration: underline;
+	a:not([class]) {
+		--linkDeco: underline;
 	}
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Removes the underline from the anchors that are not simple links.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![Screenshot from 2021-11-23 15-50-16](https://user-images.githubusercontent.com/39873395/143036367-0ce0f73f-f9f1-494d-9f8f-15d729ff081a.png)
![Screenshot from 2021-11-23 15-52-30](https://user-images.githubusercontent.com/39873395/143036609-7f751b29-2fe9-4477-a83d-c2a79d1021cc.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The links that are not associated with any class (eg. the links to the products from the cart) should be underlined.
- The buttons, notices, and all the other anchors that have a class shouldn't have any text decorations.

<!-- Issues that this pull request closes. -->
Closes #3167.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
