### PR TITLE
fix: move autofocus to close button inside mobile nav menu

### DIFF
--- a/assets/js/src/frontend/hgf.js
+++ b/assets/js/src/frontend/hgf.js
@@ -7,6 +7,8 @@ import {
 	NV_FOCUS_TRAP_START,
 } from '../utils.js';
 
+const closeNavSelector = '.close-sidebar-panel .navbar-toggle';
+
 export const HFG = function () {
 	this.options = {
 		menuToggleDuration: 300,
@@ -21,9 +23,7 @@ export const HFG = function () {
  */
 HFG.prototype.init = function (skipSidebar = false) {
 	if (skipSidebar === false) {
-		const closeButtons = document.querySelectorAll(
-			'.close-sidebar-panel .navbar-toggle'
-		);
+		const closeButtons = document.querySelectorAll(closeNavSelector);
 		addEvent(closeButtons, 'click', () => {
 			this.toggleMenuSidebar(false);
 		});
@@ -91,8 +91,8 @@ HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
 						container: document.getElementById(
 							'header-menu-sidebar'
 						),
-						close: '.close-sidebar-panel button',
-						firstFocus: 'a,input',
+						close: closeNavSelector,
+						firstFocus: closeNavSelector,
 						backFocus: target,
 					},
 				})

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -80,7 +80,7 @@ function handleMobileDropdowns() {
 function openCarrets(e, caret) {
 	e.preventDefault();
 	e.stopPropagation();
-	if (e.keyCode && e.keyCode !== 9) {
+	if (e.keyCode && ![9, 13].includes(e.keyCode)) {
 		return;
 	}
 	const subMenu = caret.parentNode.parentNode.querySelector('.sub-menu');

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -80,6 +80,9 @@ function handleMobileDropdowns() {
 function openCarrets(e, caret) {
 	e.preventDefault();
 	e.stopPropagation();
+	if (e.keyCode && e.keyCode !== 9) {
+		return;
+	}
 	const subMenu = caret.parentNode.parentNode.querySelector('.sub-menu');
 	toggleClass(caret, strings[0]);
 	toggleClass(subMenu, strings[0]);

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -174,7 +174,7 @@
 	}
 
 	.amp.dropdown-open + .sub-menu {
-		max-height: 1300px !important;
+		display: block !important;
 	}
 }
 

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -127,7 +127,7 @@
 
 		.caret-wrap {
 			margin: -15px 0;
-			padding: 15px 15px 15px 20px;
+			padding: 15px 15px 15px 10px;
 
 			&.dropdown-open .caret {
 				transform: rotateX(180deg);
@@ -140,24 +140,24 @@
 			left: unset !important;
 			top: unset !important;
 			right: unset !important;
-			background: unset;
+			background: 0;
 			position: relative;
 			max-width: 100%;
 			box-shadow: none;
-			max-height: 0;
-			overflow: hidden;
+			display: none;
 
+			//Expanded by default vs desktop.
 			@extend %show-dropdown;
 
 			&.dropdown-open {
-				max-height: unset;
+				display: block;
 			}
 		}
 
 		&.dropdowns-expanded {
 
 			> li > .sub-menu {
-				max-height: 1200px;
+				display: block;
 			}
 
 			> li > a {

--- a/assets/scss/components/elements/navigation/_nav-toggle.scss
+++ b/assets/scss/components/elements/navigation/_nav-toggle.scss
@@ -18,6 +18,10 @@
 	box-shadow: none;
 	display: flex;
 	align-items: center;
+
+	&:focus {
+		outline: 1px solid;
+	}
 }
 
 .icon-bar {

--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -61,6 +61,14 @@
 	}
 }
 
+.hiding-header-menu-sidebar {
+
+	.close-sidebar-panel {
+		transition: 0.3s ease;
+		opacity: 0;
+	}
+}
+
 .menu_sidebar_slide_left {
 
 	.header-menu-sidebar {
@@ -97,7 +105,7 @@
 
 .menu_sidebar_dropdown {
 
-	.header-menu-sidebar-overlay {
+	.hfg-ov {
 		display: none;
 	}
 
@@ -107,10 +115,6 @@
 		top: unset;
 		width: 100%;
 		display: block;
-
-		.close-sidebar-panel {
-			display: none;
-		}
 	}
 
 	.header-menu-sidebar-inner {
@@ -198,7 +202,7 @@
 }
 
 //<editor-fold desc="Sidebar overlay">
-.header-menu-sidebar-overlay {
+.hfg-ov {
 	top: 0;
 	bottom: 0;
 	right: 0;

--- a/assets/scss/components/main/_a11y.scss
+++ b/assets/scss/components/main/_a11y.scss
@@ -2,11 +2,8 @@
 	position: absolute;
 	width: 1px;
 	height: 1px;
-	margin: 0;
-	overflow: hidden;
 	clip: rect(1px, 1px, 1px, 1px);
 	top: 32px;
-	left: 0;
 	background: var(--nv-site-bg);
 	padding: $spacing-xs $spacing-sm;
 

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -16,14 +16,23 @@ $row_index        = current_row();
 $interaction_type = row_setting( Abstract_Builder::LAYOUT_SETTING );
 $classes          = [ 'header-menu-sidebar', 'menu-sidebar-panel', $interaction_type ];
 $is_contained     = in_array( $interaction_type, [ 'full_canvas', 'dropdown' ], true );
+$close_contained  = $interaction_type === 'dropdown';
 $inner_classes    = 'header-menu-sidebar-inner ' . ( $is_contained ? ' container' : '' );
 $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
+$close_classes    = 'close-sidebar-panel navbar-toggle-wrapper' . ( $close_contained ? ' container' : '' )
+
 
 ?>
-<div id="header-menu-sidebar" class="<?php echo esc_attr( join( ' ', $classes ) ); ?>" data-row-id="<?php echo esc_attr( $row_index ); ?>">
+<div
+		id="header-menu-sidebar" class="<?php echo esc_attr( join( ' ', $classes ) ); ?>"
+		data-row-id="<?php echo esc_attr( $row_index ); ?>">
 	<div id="header-menu-sidebar-bg" class="header-menu-sidebar-bg">
-		<div class="close-sidebar-panel navbar-toggle-wrapper">
-			<button type="button" class="navbar-toggle active" <?php echo ( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+		<div class="<?php echo esc_attr( $close_classes ); ?>">
+			<button type="button"
+					class="navbar-toggle active"
+					<?php
+					echo( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+					?>
 					aria-label="
 					<?php
 					esc_html_e( 'Navigation Menu', 'neve' );
@@ -48,7 +57,7 @@ $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 			 *
 			 * @since 3.0.6
 			 */
-			do_action( 'neve_before_mobile_menu_content' ); 
+			do_action( 'neve_before_mobile_menu_content' );
 			?>
 			<?php render_components( HeaderBuilder::BUILDER_NAME ); ?>
 			<?php
@@ -57,9 +66,9 @@ $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 			 *
 			 * @since 3.0.6
 			 */
-			do_action( 'neve_after_mobile_menu_content' ); 
+			do_action( 'neve_after_mobile_menu_content' );
 			?>
 		</div>
 	</div>
 </div>
-<div class="header-menu-sidebar-overlay"></div>
+<div class="header-menu-sidebar-overlay hfg-ov"></div>


### PR DESCRIPTION
### Summary
Changes first focus inside the mobile menu to the close button instead of the first element. We must have an initial focus according to a11y guidelines, but I think it's fine if we have it on the close button instead of the menu item. 

This is what twentytwentyone does as well. 

Also changes some of the CSS to ensure we don't go over the limit.


cc: @cristian-ungureanu just keeping you in the loop 

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Open the site on a mobile device (or browserstack) and open the mobile sidebar;
- There should be no outline on menu items, but the close button should be now in focus;
- Focus should still work on the desktop version of the site;

<!-- Issues that this pull request closes. -->
Closes  #3154;
<!-- Should look like this: `Closes #1, #2, #3.` . -->
