### PR TITLE
fix: clear button not clickable on woocommerce widget filter dropdowns

### DIFF
--- a/assets/scss/components/compat/woocommerce/_widgets.scss
+++ b/assets/scss/components/compat/woocommerce/_widgets.scss
@@ -27,3 +27,11 @@
 		}
 	}
 }
+
+.woocommerce-widget-layered-nav .select2-selection--single {
+	padding-right: 30px !important;
+}
+
+body .select2-dropdown {
+	z-index: 100001;
+}


### PR DESCRIPTION
### Summary
Fixes the issue with the clear button inside WooCommerce widgets filter dropdowns.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

-  On a WordPress instance with Woocommerce
-  Go to Appearance->Widgets and we add "Filter products by Attribute", this must be set to dropdown (https://vertis.d.pr/MOIp17)
- After selecting something in the dropdown, the clear button should be clickable

<!-- Issues that this pull request closes. -->
Closes #2943.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
