### PR TITLE
Fix sidebar on 404 page

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -759,17 +759,17 @@ if (!newSkin) {
 			},
 			neve_other_pages_content_width: {
 				content:
-					'body:not(.single):not(.archive):not(.blog):not(.search) .neve-main > .container .col, body.post-type-archive-course .neve-main > .container .col, body.post-type-archive-llms_membership .neve-main > .container .col',
+					'body:not(.single):not(.archive):not(.blog):not(.search):not(.error404) .neve-main > .container .col, body.post-type-archive-course .neve-main > .container .col, body.post-type-archive-llms_membership .neve-main > .container .col',
 				sidebar:
-					'body:not(.single):not(.archive):not(.blog):not(.search) .nv-sidebar-wrap, body.post-type-archive-course .nv-sidebar-wrap, body.post-type-archive-llms_membership .nv-sidebar-wrap',
+					'body:not(.single):not(.archive):not(.blog):not(.search):not(.error404) .nv-sidebar-wrap, body.post-type-archive-course .nv-sidebar-wrap, body.post-type-archive-llms_membership .nv-sidebar-wrap',
 			},
 		},
 		contentWidthsPreview() {
+			const self = this;
 			$.each(this.contentWidths, function (id, args) {
 				wp.customize(id, function (value) {
 					value.bind(function (newval) {
-						const sidebar = $('.nv-sidebar-wrap');
-
+						const sidebar = $(self.contentWidths[id].sidebar);
 						if (newval >= 95) {
 							sidebar.addClass('hide');
 						} else {

--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -651,7 +651,7 @@ class Frontend extends Generator {
 			return;
 		}
 		// Others content width.
-		$this->_subscribers['body:not(.single):not(.archive):not(.blog):not(.search) .neve-main > .container .col, body.post-type-archive-course .neve-main > .container .col, body.post-type-archive-llms_membership .neve-main > .container .col'] = [
+		$this->_subscribers['body:not(.single):not(.archive):not(.blog):not(.search):not(.error404) .neve-main > .container .col, body.post-type-archive-course .neve-main > .container .col, body.post-type-archive-llms_membership .neve-main > .container .col'] = [
 			Config::CSS_PROP_MAX_WIDTH => [
 				Dynamic_Selector::META_KEY         => Config::MODS_OTHERS_CONTENT_WIDTH,
 				Dynamic_Selector::META_DEFAULT     => $this->sidebar_layout_width_default( Config::MODS_OTHERS_CONTENT_WIDTH ),
@@ -659,7 +659,7 @@ class Frontend extends Generator {
 				Dynamic_Selector::META_SUFFIX      => '%',
 			],
 		];
-		$this->_subscribers['body:not(.single):not(.archive):not(.blog):not(.search) .nv-sidebar-wrap, body.post-type-archive-course .nv-sidebar-wrap, body.post-type-archive-llms_membership .nv-sidebar-wrap']                                     = [
+		$this->_subscribers['body:not(.single):not(.archive):not(.blog):not(.search):not(.error404) .nv-sidebar-wrap, body.post-type-archive-course .nv-sidebar-wrap, body.post-type-archive-llms_membership .nv-sidebar-wrap']                                     = [
 			Config::CSS_PROP_MAX_WIDTH => [
 				Dynamic_Selector::META_KEY         => Config::MODS_OTHERS_CONTENT_WIDTH,
 				Dynamic_Selector::META_DEFAULT     => $this->sidebar_layout_width_default( Config::MODS_OTHERS_CONTENT_WIDTH ),

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,7 +51,7 @@ const ROLLUP_MODERN = {
 let all_coverage = {
 		'assets/js/build/all/metabox.js': 'assets/js/src/metabox.js',
 		'assets/js/build/all/gutenberg.js': 'assets/js/src/gutenberg.js',
-		'assets/js/build/all/customizer-preview.js': ['assets/js/src/customizer-preview/app.js', './inc/customizer/options/js/*.js'],
+		'assets/js/build/all/customizer-preview.js': ['assets/js/src/customizer-preview/app.js'],
 		'assets/js/build/all/customizer-controls.js': ['./assets/customizer/js/*.js']
 	},
 	__export = [],


### PR DESCRIPTION
### Summary
It seems like the sidebar on the 404 page was not working correctly.

To see the issue you should:
1. Disable "Enable Advanced Options"
2. Set a general value, let's say sidebar right and save customizer
( Not 100% sure 1 & 2 are required )
3. Enable "Enable Advanced Options"
4. You'll notice that the sidebar position is controlled from BLOG / ARCHIVE control and the sidebar width is controlled by OTHERS control

This PR fixes this behavior and makes the sidebar on the 404 page controlled by BLOG / ARCHIVE.

Also, I saw that[ those two files](https://github.com/Codeinwp/neve/tree/master/inc/customizer/options/js) were replaced and their function was included in [app.js](https://github.com/Codeinwp/neve/blob/master/assets/js/src/customizer-preview/app.js). When I tried to fix this issue, I saw that those two files are still used https://github.com/Codeinwp/neve/blob/master/rollup.config.js#L54. I removed them.

cc. @abaicus 

### Will affect visual aspect of the product
YES, on the 404 page, in some cases.


### Test instructions
- Go on a 404 page and enter customizer
- Try and change the controls and see if the issue previously described is still happening
- See other pages and check if anything else breaks

<!-- Issues that this pull request closes. -->
Closes #3204.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
