### PR TITLE
Fix: reset button on range control resets all devices

### DIFF
--- a/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
+++ b/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
@@ -86,6 +86,13 @@ const ResponsiveRangeComponent = ({ control }) => {
 	};
 
 	const updateValues = (newValue) => {
+		// This happens when the reset button is pressed
+		if (newValue === undefined) {
+			setValue(defaultVal);
+			control.setting.set(JSON.stringify(defaultVal));
+			return;
+		}
+
 		const nextValue = { ...value };
 		nextValue[currentDevice] = newValue;
 		setValue(nextValue);
@@ -110,7 +117,6 @@ const ResponsiveRangeComponent = ({ control }) => {
 			</div>
 			<div className="range-wrap">
 				<RangeControl
-					resetFallbackValue={defaultVal[currentDevice]}
 					value={displayValue}
 					min={min || 0}
 					max={max || 100}

--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -159,11 +159,7 @@ const Typeface = (props) => {
 					onChange({ fontSize: nextVal });
 				}}
 				onReset={() => {
-					const nextFS = { ...fontSize };
-					nextFS[currentDevice] = defaultFS[currentDevice];
-					nextFS.suffix[currentDevice] =
-						defaultFS.suffix[currentDevice];
-					onChange({ fontSize: nextFS });
+					onChange({ fontSize: defaultFS });
 					if (refreshAfterReset) {
 						wp.customize.previewer.refresh();
 					}
@@ -196,11 +192,7 @@ const Typeface = (props) => {
 					onChange({ lineHeight: nextVal });
 				}}
 				onReset={() => {
-					const nextLH = { ...lineHeight };
-					nextLH[currentDevice] = defaultLH[currentDevice];
-					nextLH.suffix[currentDevice] =
-						defaultLH.suffix[currentDevice];
-					onChange({ lineHeight: nextLH });
+					onChange({ lineHeight: defaultLH });
 					if (refreshAfterReset) {
 						wp.customize.previewer.refresh();
 					}
@@ -241,9 +233,7 @@ const Typeface = (props) => {
 					onChange({ letterSpacing: nextVal });
 				}}
 				onReset={() => {
-					const nextLS = { ...letterSpacing };
-					nextLS[currentDevice] = defaultLS[currentDevice];
-					onChange({ letterSpacing: nextLS });
+					onChange({ letterSpacing: defaultLS });
 					if (refreshAfterReset) {
 						wp.customize.previewer.refresh();
 					}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR makes all responsive controls reset the values for all devices when clicking the reset button (the problem was with the range and number controls).

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- In the customizer go to a responsive range control (for example Header -> Primary Menu -> Items Spacing) and to a number control ( Typography -> General -> Font Size )
- Change the values for all devices and then click the reset button
- The values should be reset for all devices

<!-- Issues that this pull request closes. -->
Closes #3197.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
