### PR TITLE
fix: neve_before_pagination hook on the first paginated page

### DIFF
--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -155,7 +155,17 @@ class Pagination extends Base_View {
 			return;
 		}
 
-		if ( ! $this->has_infinite_scroll() && is_paged() ) {
+		$paginate_args = array( 'type' => 'list' );
+		if ( $this->has_jump_to() ) {
+			$paginate_args['format'] = '?paged=%#%';
+		}
+		$links = paginate_links( $paginate_args );
+
+		if ( empty( $links ) ) {
+			return;
+		}
+
+		if ( ! $this->has_infinite_scroll() ) {
 			/**
 			 * Executes actions before pagination.
 			 *
@@ -164,11 +174,6 @@ class Pagination extends Base_View {
 			do_action( 'neve_before_pagination' );
 		}
 
-		$paginate_args = array( 'type' => 'list' );
-		if ( $this->has_jump_to() ) {
-			$paginate_args['format'] = '?paged=%#%';
-		}
-		$links = paginate_links( $paginate_args );
 		$links = str_replace(
 			array( '<a class="prev', '<a class="next' ),
 			array(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before the PR, the hook **neve_before_pagination** wasn't working on the first page of the pagination.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure you've enough posts to see pagination on blog archive page and enable pagination for the blog/archive.
- Add a snippet for the **neve_before_pagination** hook, it should work on the all pages that contains pagination.
- Make sure there is no regression on the pagination feature.

<!-- Issues that this pull request closes. -->
Closes #3253,codeinwp/neve-pro-addon#1601
<!-- Should look like this: `Closes #1, #2, #3.` . -->
