### PR TITLE
add upsell message and button to starter sites card

### DIFF
--- a/assets/apps/dashboard/src/Components/Card.js
+++ b/assets/apps/dashboard/src/Components/Card.js
@@ -29,10 +29,7 @@ const Card = (props) => {
 			</div>
 			<div className="card-content">
 				{description && (
-					<p
-						className="card-description"
-						dangerouslySetInnerHTML={{ __html: description }}
-					></p>
+					<p className="card-description">{description}</p>
 				)}
 				{children}
 			</div>

--- a/assets/apps/dashboard/src/Components/Card.js
+++ b/assets/apps/dashboard/src/Components/Card.js
@@ -29,7 +29,7 @@ const Card = (props) => {
 			</div>
 			<div className="card-content">
 				{description && (
-					<p className="card-description">{description}</p>
+					<p className="card-description" dangerouslySetInnerHTML={{__html: description}}></p>
 				)}
 				{children}
 			</div>

--- a/assets/apps/dashboard/src/Components/Card.js
+++ b/assets/apps/dashboard/src/Components/Card.js
@@ -29,7 +29,10 @@ const Card = (props) => {
 			</div>
 			<div className="card-content">
 				{description && (
-					<p className="card-description" dangerouslySetInnerHTML={{__html: description}}></p>
+					<p
+						className="card-description"
+						dangerouslySetInnerHTML={{ __html: description }}
+					></p>
 				)}
 				{children}
 			</div>

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -75,7 +75,7 @@ const Start = (props) => {
 							</Button>
 						)}
 						{!neveDash.isValidLicense && (
-							<Button href={neveDash.getNeveURL} isSecondary>
+							<Button href={neveDash.startSitesgetNeveProURL} isSecondary>
 								{__('Get Neve Pro', 'neve')}
 							</Button>
 						)}

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -56,6 +56,9 @@ const Start = (props) => {
 					title={__('Starter Sites', 'neve')}
 					description={neveDash.strings.starterSitesCardDescription}
 				>
+					{!neveDash.isValidLicense && (
+						<p>{neveDash.strings.starterSitesCardUpsellMessage}</p>
+					)}
 					<div className="button-group">
 						{tabs['starter-sites'] ? (
 							<Button

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -75,7 +75,10 @@ const Start = (props) => {
 							</Button>
 						)}
 						{!neveDash.isValidLicense && (
-							<Button href={neveDash.startSitesgetNeveProURL} isSecondary>
+							<Button
+								href={neveDash.startSitesgetNeveProURL}
+								isSecondary
+							>
 								{__('Get Neve Pro', 'neve')}
 							</Button>
 						)}

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -56,23 +56,29 @@ const Start = (props) => {
 					title={__('Starter Sites', 'neve')}
 					description={neveDash.strings.starterSitesCardDescription}
 				>
-					{tabs['starter-sites'] ? (
-						<Button
-							isPrimary
-							onClick={() => {
-								setTab('starter-sites');
-							}}
-						>
-							{__('Go to Starter Sites', 'neve')}
-						</Button>
-					) : (
-						<Button href={tpcAdminURL} isPrimary>
-							{__('Go to Starter Sites', 'neve')}
-						</Button>
-					)}
+					<div class="button-group">
+						{tabs['starter-sites'] ? (
+							<Button
+								isPrimary
+								onClick={() => {
+									setTab('starter-sites');
+								}}
+							>
+								{__('Go to Starter Sites', 'neve')}
+							</Button>
+						) : (
+							<Button href={tpcAdminURL} isPrimary>
+								{__('Go to Starter Sites', 'neve')}
+							</Button>
+						)}
+						{!neveDash.isValidLicense &&
+							<Button href={neveDash.getNeveURL} isSecondary>
+								{__('Get Neve Pro', 'neve')}
+							</Button>
+						}
+					</div>
 				</Card>
 			)}
-
 			<Card
 				classNames="customizer-quick-links"
 				icon={neveDash.assets + 'compass.svg'}

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -56,7 +56,7 @@ const Start = (props) => {
 					title={__('Starter Sites', 'neve')}
 					description={neveDash.strings.starterSitesCardDescription}
 				>
-					<div class="button-group">
+					<div className="button-group">
 						{tabs['starter-sites'] ? (
 							<Button
 								isPrimary
@@ -71,11 +71,11 @@ const Start = (props) => {
 								{__('Go to Starter Sites', 'neve')}
 							</Button>
 						)}
-						{!neveDash.isValidLicense &&
+						{!neveDash.isValidLicense && (
 							<Button href={neveDash.getNeveURL} isSecondary>
 								{__('Get Neve Pro', 'neve')}
 							</Button>
-						}
+						)}
 					</div>
 				</Card>
 			)}

--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -35,6 +35,11 @@
 		a, button {
 			align-self: flex-start;
 			margin-top: auto;
+      margin-right: 10px;
+      &.is-secondary{
+        outline: 1.5px solid;
+        font-weight: 800;
+      }
 		}
 	}
 

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -188,11 +188,13 @@ class Main {
 			'assets'              => get_template_directory_uri() . '/assets/img/dashboard/',
 			'hasOldPro'           => (bool) ( defined( 'NEVE_PRO_VERSION' ) && version_compare( NEVE_PRO_VERSION, '1.1.11', '<' ) ),
 			'isRTL'               => is_rtl(),
+			'isValidLicense'      => $this->is_valid_license(),
 			'notifications'       => $this->get_notifications(),
 			'customizerShortcuts' => $this->get_customizer_shortcuts(),
 			'plugins'             => $this->get_useful_plugins(),
 			'featureData'         => $this->get_free_pro_features(),
 			'showFeedbackNotice'  => $this->should_show_feedback_notice(),
+			'getNeveURL'          => esc_url( 'https://themeisle.com/themes/neve/upgrade/?utm_source=welcome+starter+sites+card&utm_medium=dashboard&utm_campaign=neve' ),
 			'upgradeURL'          => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
 			'supportURL'          => esc_url( 'https://wordpress.org/support/theme/neve/' ),
 			'docsURL'             => esc_url( 'https://docs.themeisle.com/article/946-neve-doc' ),
@@ -202,7 +204,7 @@ class Main {
 				/* translators: %s - Theme name */
 				'header'                        => sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: %s - Theme name */
-				'starterSitesCardDescription'   => sprintf( __( '%s now comes with a sites library with various designs to pick from. Visit our collection of demos that are constantly being added.', 'neve' ), wp_kses_post( $theme_name ) ),
+				'starterSitesCardDescription'   => sprintf( __( '%s comes with a sites library allowing you to import a ready-made website in no time. New sites are constantly being added.', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: %s - Theme name */
 				'starterSitesTabDescription'    => sprintf( __( 'With %s, you can choose from multiple unique demos, specially designed for you, that can be installed with a single click. You just need to choose your favorite, and we will take care of everything else.', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: 1 - Theme name, 2 - Cloud Templates & Patterns Collection */
@@ -231,6 +233,13 @@ class Main {
 			'tpcPath'             => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
 			'tpcAdminURL'         => admin_url( 'themes.php?page=tiob-starter-sites' ),
 		];
+
+		if ( ! $this->is_valid_license() ) {
+			$starter_sites_desc                             = $data['strings']['starterSitesCardDescription'];
+			$neve_pro_upsell                                = esc_html__( 'Upgrade to the Pro version and get instant access to all Premium Starter Sites; including Expert Sites, and much more.', 'neve' );
+			$starter_sites_desc_upsell                      = $starter_sites_desc . '<br/><br/>' . $neve_pro_upsell;
+			$data['strings']['starterSitesCardDescription'] = $starter_sites_desc_upsell;
+		}
 
 		if ( defined( 'NEVE_PRO_PATH' ) ) {
 			$data['changelogPro'] = $this->cl_handler->get_changelog( NEVE_PRO_PATH . '/CHANGELOG.md' );
@@ -508,4 +517,22 @@ class Main {
 		}
 		return false;
 	}
+
+	/**
+	 * Check if the Neve Pro license is valid.
+	 *
+	 * @return bool 
+	 */
+	private function is_valid_license() {
+
+		$nv_pro_data = get_option( 'neve_pro_addon_license_data' ); 
+		
+		if ( $nv_pro_data->license === 'valid' ) {
+			return false;
+		}
+
+		return false;
+
+	}
+
 }

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -204,7 +204,7 @@ class Main {
 				/* translators: %s - Theme name */
 				'header'                        => sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: %s - Theme name */
-				'starterSitesCardDescription'   => sprintf( __( '%s comes with a sites library allowing you to import a ready-made website in no time. New sites are constantly being added.', 'neve' ), wp_kses_post( $theme_name ) ),
+				'starterSitesCardDescription'   => sprintf( __( '%s now comes with a sites library with various designs to pick from. Visit our collection of demos that are constantly being added.', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: %s - Theme name */
 				'starterSitesTabDescription'    => sprintf( __( 'With %s, you can choose from multiple unique demos, specially designed for you, that can be installed with a single click. You just need to choose your favorite, and we will take care of everything else.', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: 1 - Theme name, 2 - Cloud Templates & Patterns Collection */

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -527,8 +527,8 @@ class Main {
 
 		$nv_pro_data = get_option( 'neve_pro_addon_license_data' ); 
 		
-		if ( $nv_pro_data->license === 'valid' ) {
-			return false;
+		if ( is_object( $nv_pro_data ) && $nv_pro_data->license === 'valid' ) {
+			return true;
 		}
 
 		return false;

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -183,23 +183,23 @@ class Main {
 		$plugin_name       = apply_filters( 'ti_wl_plugin_name', 'Neve Pro' );
 		$plugin_name_addon = apply_filters( 'ti_wl_plugin_name', 'Neve Pro Addon' );
 		$data              = [
-			'nonce'               => wp_create_nonce( 'wp_rest' ),
-			'version'             => 'v' . NEVE_VERSION,
-			'assets'              => get_template_directory_uri() . '/assets/img/dashboard/',
-			'hasOldPro'           => (bool) ( defined( 'NEVE_PRO_VERSION' ) && version_compare( NEVE_PRO_VERSION, '1.1.11', '<' ) ),
-			'isRTL'               => is_rtl(),
-			'isValidLicense'      => $this->is_valid_license(),
-			'notifications'       => $this->get_notifications(),
-			'customizerShortcuts' => $this->get_customizer_shortcuts(),
-			'plugins'             => $this->get_useful_plugins(),
-			'featureData'         => $this->get_free_pro_features(),
-			'showFeedbackNotice'  => $this->should_show_feedback_notice(),
-			'getNeveURL'          => esc_url( 'https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=welcomestartersitescard&utm_campaign=neve&utm_content=gotostartersites' ),
-			'upgradeURL'          => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
-			'supportURL'          => esc_url( 'https://wordpress.org/support/theme/neve/' ),
-			'docsURL'             => esc_url( 'https://docs.themeisle.com/article/946-neve-doc' ),
-			'codexURL'            => esc_url( 'https://codex.nevewp.com/' ),
-			'strings'             => [
+			'nonce'                   => wp_create_nonce( 'wp_rest' ),
+			'version'                 => 'v' . NEVE_VERSION,
+			'assets'                  => get_template_directory_uri() . '/assets/img/dashboard/',
+			'hasOldPro'               => (bool) ( defined( 'NEVE_PRO_VERSION' ) && version_compare( NEVE_PRO_VERSION, '1.1.11', '<' ) ),
+			'isRTL'                   => is_rtl(),
+			'isValidLicense'          => $this->is_valid_license(),
+			'notifications'           => $this->get_notifications(),
+			'customizerShortcuts'     => $this->get_customizer_shortcuts(),
+			'plugins'                 => $this->get_useful_plugins(),
+			'featureData'             => $this->get_free_pro_features(),
+			'showFeedbackNotice'      => $this->should_show_feedback_notice(),
+			'startSitesgetNeveProURL' => $this->build_neve_pro_upsell_url( 'starter_sites' ),
+			'upgradeURL'              => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
+			'supportURL'              => esc_url( 'https://wordpress.org/support/theme/neve/' ),
+			'docsURL'                 => esc_url( 'https://docs.themeisle.com/article/946-neve-doc' ),
+			'codexURL'                => esc_url( 'https://codex.nevewp.com/' ),
+			'strings'                 => [
 				'proTabTitle'                   => wp_kses_post( $plugin_name ),
 				/* translators: %s - Theme name */
 				'header'                        => sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme_name ) ),
@@ -227,12 +227,12 @@ class Main {
 					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
 				),
 			],
-			'changelog'           => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),
-			'onboarding'          => [],
-			'hasFileSystem'       => WP_Filesystem(),
-			'hidePluginsTab'      => apply_filters( 'neve_hide_useful_plugins', ! array_key_exists( 'useful_plugins', $old_about_config ) ),
-			'tpcPath'             => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
-			'tpcAdminURL'         => admin_url( 'themes.php?page=tiob-starter-sites' ),
+			'changelog'               => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),
+			'onboarding'              => [],
+			'hasFileSystem'           => WP_Filesystem(),
+			'hidePluginsTab'          => apply_filters( 'neve_hide_useful_plugins', ! array_key_exists( 'useful_plugins', $old_about_config ) ),
+			'tpcPath'                 => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
+			'tpcAdminURL'             => admin_url( 'themes.php?page=tiob-starter-sites' ),
 		];
 
 		if ( defined( 'NEVE_PRO_PATH' ) ) {
@@ -527,6 +527,38 @@ class Main {
 
 		return false;
 
+	}
+
+	/**
+	 * Build neve pro upsell URL.
+	 * 
+	 * @param string $upsell 
+	 * @return string 
+	 */
+	private function build_neve_pro_upsell_url( $upsell ) {
+
+		$utm_medium   = 'nevedashboard';
+		$utm_campaign = 'neve';
+
+		switch ( $upsell ) {
+			case 'starter_sites':
+				$utm_source  = 'welcomestartersitescard';
+				$utm_content = 'gotostartersites';
+				break;
+			
+			default:
+				$utm_source  = 'neveupsell';
+				$utm_content = '';
+				break;
+		}
+
+		$link = "https://themeisle.com/themes/neve/upgrade/?utm_medium=$utm_medium&utm_source=$utm_source&utm_campaign=$utm_campaign";
+		
+		if ( ! empty( $utm_content ) ) {
+			$link = $link . "&utm_content=$utm_content";
+		}
+
+		return esc_url( $link );
 	}
 
 }

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -194,7 +194,7 @@ class Main {
 			'plugins'             => $this->get_useful_plugins(),
 			'featureData'         => $this->get_free_pro_features(),
 			'showFeedbackNotice'  => $this->should_show_feedback_notice(),
-			'getNeveURL'          => esc_url( 'https://themeisle.com/themes/neve/upgrade/?utm_source=welcome+starter+sites+card&utm_medium=dashboard&utm_campaign=neve' ),
+			'getNeveURL'          => esc_url( 'https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=welcomestartersitescard&utm_campaign=neve&utm_content=gotostartersites' ),
 			'upgradeURL'          => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
 			'supportURL'          => esc_url( 'https://wordpress.org/support/theme/neve/' ),
 			'docsURL'             => esc_url( 'https://docs.themeisle.com/article/946-neve-doc' ),
@@ -205,6 +205,7 @@ class Main {
 				'header'                        => sprintf( __( '%s Options', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: %s - Theme name */
 				'starterSitesCardDescription'   => sprintf( __( '%s now comes with a sites library with various designs to pick from. Visit our collection of demos that are constantly being added.', 'neve' ), wp_kses_post( $theme_name ) ),
+				'starterSitesCardUpsellMessage' => esc_html__( 'Upgrade to the Pro version and get instant access to all Premium Starter Sites — including Expert Sites — and much more.', 'neve' ),
 				/* translators: %s - Theme name */
 				'starterSitesTabDescription'    => sprintf( __( 'With %s, you can choose from multiple unique demos, specially designed for you, that can be installed with a single click. You just need to choose your favorite, and we will take care of everything else.', 'neve' ), wp_kses_post( $theme_name ) ),
 				/* translators: 1 - Theme name, 2 - Cloud Templates & Patterns Collection */
@@ -233,13 +234,6 @@ class Main {
 			'tpcPath'             => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
 			'tpcAdminURL'         => admin_url( 'themes.php?page=tiob-starter-sites' ),
 		];
-
-		if ( ! $this->is_valid_license() ) {
-			$starter_sites_desc                             = $data['strings']['starterSitesCardDescription'];
-			$neve_pro_upsell                                = esc_html__( 'Upgrade to the Pro version and get instant access to all Premium Starter Sites; including Expert Sites, and much more.', 'neve' );
-			$starter_sites_desc_upsell                      = $starter_sites_desc . '<br/><br/>' . $neve_pro_upsell;
-			$data['strings']['starterSitesCardDescription'] = $starter_sites_desc_upsell;
-		}
 
 		if ( defined( 'NEVE_PRO_PATH' ) ) {
 			$data['changelogPro'] = $this->cl_handler->get_changelog( NEVE_PRO_PATH . '/CHANGELOG.md' );

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -194,7 +194,7 @@ class Main {
 			'plugins'                 => $this->get_useful_plugins(),
 			'featureData'             => $this->get_free_pro_features(),
 			'showFeedbackNotice'      => $this->should_show_feedback_notice(),
-			'startSitesgetNeveProURL' => $this->build_neve_pro_upsell_url( 'starter_sites' ),
+			'startSitesgetNeveProURL' => esc_url( 'https://themeisle.com/themes/neve/upgrade/?utm_medium=nevedashboard&utm_source=welcomestartersitescard&utm_campaign=neve&utm_content=gotostartersites' ),
 			'upgradeURL'              => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
 			'supportURL'              => esc_url( 'https://wordpress.org/support/theme/neve/' ),
 			'docsURL'                 => esc_url( 'https://docs.themeisle.com/article/946-neve-doc' ),
@@ -527,38 +527,6 @@ class Main {
 
 		return false;
 
-	}
-
-	/**
-	 * Build neve pro upsell URL.
-	 * 
-	 * @param string $upsell 
-	 * @return string 
-	 */
-	private function build_neve_pro_upsell_url( $upsell ) {
-
-		$utm_medium   = 'nevedashboard';
-		$utm_campaign = 'neve';
-
-		switch ( $upsell ) {
-			case 'starter_sites':
-				$utm_source  = 'welcomestartersitescard';
-				$utm_content = 'gotostartersites';
-				break;
-			
-			default:
-				$utm_source  = 'neveupsell';
-				$utm_content = '';
-				break;
-		}
-
-		$link = "https://themeisle.com/themes/neve/upgrade/?utm_medium=$utm_medium&utm_source=$utm_source&utm_campaign=$utm_campaign";
-		
-		if ( ! empty( $utm_content ) ) {
-			$link = $link . "&utm_content=$utm_content";
-		}
-
-		return esc_url( $link );
 	}
 
 }


### PR DESCRIPTION
### Summary
Adds upsell messages and button inside starter sites card

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions

- Upsell message and button should appear whenever license is not active, not valid or Pro plugin not installed
- Upsell message and button should not appear when valid license is set.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1739
<!-- Should look like this: `Closes #1, #2, #3.` . -->
