### PR TITLE
chore: remove byline in header components inserter upsell

### DIFF
--- a/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
@@ -156,12 +156,6 @@ const ComponentsPopover: React.FC<Props> = ({
 							<span className="count">
 								15+ {__('Components', 'neve')}
 							</span>
-							<p>
-								{__(
-									'Upgrade to Neve Pro and unlock all components, including Wish List, Breadcrumbs, Custom Layouts and many more.',
-									'neve'
-								)}
-							</p>
 							<Button
 								isPrimary
 								className="upsell-btn"

--- a/assets/apps/customizer-controls/src/builder/scss/_items-popover.scss
+++ b/assets/apps/customizer-controls/src/builder/scss/_items-popover.scss
@@ -112,6 +112,7 @@
 		}
 
 		.upsell-btn {
+			margin-top: 10px;
 			line-height: 1;
 			font-size: 13px;
 			border-radius: 4px;

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -389,9 +389,10 @@ class Front_End {
 	 */
 	public function get_strings() {
 		return [
-			'add_item'     => __( 'Add item', 'neve' ),
-			'add_items'    => __( 'Add items by clicking the ones below.', 'neve' ),
-			'all_selected' => __( 'All items are already selected.', 'neve' ),
+			'add_item'          => __( 'Add item', 'neve' ),
+			'add_items'         => __( 'Add items by clicking the ones below.', 'neve' ),
+			'all_selected'      => __( 'All items are already selected.', 'neve' ),
+			'upsell_components' => __( 'Upgrade to Neve Pro and unlock all components, including Wish List, Breadcrumbs, Custom Layouts and many more.', 'neve' ),
 		];
 	}
 }


### PR DESCRIPTION
chore: remove byline in header components inserter upsell

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Into Customizer > Header 
- Click the add button on any row
- The description inside the upsell (text before button) should not be there anymore

<!-- Issues that this pull request closes. -->
Closes  Codeinwp/neve-pro-addon#1724.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
