### PR TITLE
fix: dropdowns display in mobile sidebar mega-menu

### DIFF
--- a/.github/workflows/build-dev-artifacts.yml
+++ b/.github/workflows/build-dev-artifacts.yml
@@ -147,6 +147,10 @@ jobs:
           - machines: 1
             specs: "useful-plugins"
             envs: "useful-plugins"
+          ## Mega menu specs needs just one machine
+          - machines: 1
+            specs: "mega-menu"
+            envs: "mega-menu"
           ## 2 machines for classic editor tests
           - machines: 1
             specs: "editor/classic"

--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -54,14 +54,7 @@
 .header-menu-sidebar-inner {
 
 	.neve-mega-menu .neve-mm-col > .sub-menu {
-
-		.sub-menu {
-			max-height: 0;
-
-			&.dropdown-open {
-				max-height: 3000px;
-			}
-		}
+		display: block;
 	}
 }
 

--- a/bin/envs/mega-menu/start.sh
+++ b/bin/envs/mega-menu/start.sh
@@ -1,0 +1,9 @@
+wp --allow-root plugin is-installed wordpress-importer && wp --allow-root plugin update wordpress-importer ||  wp --allow-root plugin install wordpress-importer
+##Setup core content.
+wp --allow-root plugin activate wordpress-importer
+curl -O https://gist.githubusercontent.com/abaicus/371542fbe92a27a88b176b0ed196094c/raw/f888b08fe6fc19cf78b0b73acc19a77a12a5c2a8/mega-menu.xml
+wp --allow-root import ./mega-menu.xml --authors=skip  --skip=image_resize
+
+#Generic setup
+wp --allow-root rewrite structure /%postname%/
+wp --allow-root menu location assign mega-menu primary

--- a/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
+++ b/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
@@ -1,0 +1,52 @@
+describe('Mega Menu Check', () => {
+	it('Desktop Mega Menu', () => {
+		cy.visit('/');
+
+		cy.get('.header--row .neve-mega-menu').as('mm').should('exist');
+
+		cy.get('@mm').realHover();
+
+		cy.get('@mm').find('> .sub-menu').should('be.visible');
+		cy.get('@mm').find('.neve-mm-col').should('be.visible').and('have.length', 4);
+		cy.get('@mm').find('.neve-mm-divider').should('be.visible').and('have.length', 4);
+		cy.get('@mm').find('.neve-mm-heading > span').should('be.visible').and('have.length', 4);
+
+		cy.get('@mm').find('.neve-mm-col > .sub-menu > .menu-item-has-children').as('dd');
+
+		cy.get('@dd').should('be.visible').and('have.length', 1);
+		cy.get('@dd').realHover();
+
+		cy.get('@dd').find('.sub-menu').should('be.visible');
+		cy.get('@dd')
+			.find('.sub-menu a')
+			.should('contain', 'Submenu Link')
+			.and('be.visible')
+			.and('have.length', 2);
+	});
+
+	it('Mobile Mega Menu', () => {
+		cy.visit('/');
+		cy.viewport('iphone-x');
+
+		cy.get('.header--row .navbar-toggle').click();
+
+		cy.get('.header-menu-sidebar .neve-mega-menu').as('mm');
+
+		cy.get('@mm').find(' > a > .caret-wrap').click();
+
+		cy.get('@mm').find('> .sub-menu').should('be.visible');
+		cy.get('@mm').find('.neve-mm-col').should('be.visible').and('have.length', 4);
+		cy.get('@mm').find('.neve-mm-divider').should('be.visible').and('have.length', 4);
+		cy.get('@mm').find('.neve-mm-heading > span').should('be.visible').and('have.length', 4);
+
+		cy.get('@mm').find('.neve-mm-col > .sub-menu > .menu-item-has-children').as('dd');
+
+		cy.get('@dd').find('> a > .caret-wrap').click();
+		cy.get('@dd').find('.sub-menu').should('be.visible');
+		cy.get('@dd')
+			.find('.sub-menu a')
+			.should('contain', 'Submenu Link')
+			.and('be.visible')
+			.and('have.length', 2);
+	});
+});


### PR DESCRIPTION
### Summary
- fixes issue with dropdowns inside mobile-sidebar when using a mega-menu
- should be tested both with the class-based mega-menu and the PRO mega-menu feature
- adds cypress tests for the mega-menu in the free version

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- You can follow the steps described here: Codeinwp/neve-pro-addon#1779
- The dropdowns should be in working order

<!-- Issues that this pull request closes. -->
Closes  Codeinwp/neve-pro-addon#1779.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
