### PR TITLE
Fix cart component offcanvas

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -379,6 +379,22 @@ abstract class Abstract_Component implements Component {
 	}
 
 	/**
+	 * Method to check that the component is active.
+	 *
+	 * @return bool
+	 */
+	protected function is_component_active() {
+		$builders = Main::get_instance()->get_builders();
+		foreach ( $builders as $builder ) {
+			if ( $builder->is_component_active( $this->get_id() ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Method to set protected properties for class.
 	 *
 	 * @param string $key The property key name.

--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -11,7 +11,6 @@
 
 namespace HFG\Core\Components;
 
-use HFG\Core\Settings\Config;
 use HFG\Core\Settings\Manager as SettingsManager;
 use HFG\Main;
 use Neve\Core\Styles\Dynamic_Selector;
@@ -84,6 +83,34 @@ class CartIcon extends Abstract_Component {
 		add_filter( 'neve_post_content', 'wpautop' );
 		add_filter( 'neve_post_content', 'shortcode_unautop' );
 		add_filter( 'neve_post_content', 'do_shortcode' );
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'load_scripts' ] );
+	}
+
+	/**
+	 * Load Component Scripts
+	 *
+	 * @return void
+	 */
+	public function load_scripts() {
+		if ( $this->is_component_active() ) {
+			wp_add_inline_script( 'neve-script', $this->toggle_cart_is_empty() );
+		}
+	}
+
+	/**
+	 * Inline script that removes the cart-is-empty class.
+	 *
+	 * @return string
+	 */
+	public function toggle_cart_is_empty() {
+		return '
+			(function($){
+				$(\'body\').on( \'added_to_cart\', function(){
+					document.querySelector( \'.responsive-nav-cart\' ).classList.remove(\'cart-is-empty\');
+				});
+			})(jQuery);
+		';
 	}
 
 	/**

--- a/header-footer-grid/Core/Components/PaletteSwitch.php
+++ b/header-footer-grid/Core/Components/PaletteSwitch.php
@@ -122,22 +122,6 @@ class PaletteSwitch extends Abstract_Component {
 	}
 
 	/**
-	 * Method to check that the component is active.
-	 *
-	 * @return bool
-	 */
-	private function is_component_active() {
-		$builders = Main::get_instance()->get_builders();
-		foreach ( $builders as $builder ) {
-			if ( $builder->is_component_active( $this->get_id() ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
-
-	/**
 	 * Get CSS to use as inline script
 	 *
 	 * @return string


### PR DESCRIPTION
### Summary
The off-canvas sidebar opens from that button, only if the class "cart-is-empty" is not present. When you add a product to the cart, it's added via ajax and the "cart-is-empty" class is not removed.

This PR fixes the behavior and it removes the `cart-is-empty` class when a product is added via ajax add to cart.

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->

### Test instructions
- Install neve and neve pro
- Set cart icon component in header with off-canvas layout
- Go to the shop page and have an empty cart
- Refresh the page
- Add a product to the cart
- Close the sidebar that opens
- Try to click on the cart icon, the sidebar should open


<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1745.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
