### PR TITLE
Feat: Display only the weights that are available for the selected font

### DIFF
--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -1,3 +1,4 @@
+/* global NeveReactCustomize */
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InlineSelect, NumberControl } from '@neve-wp/components';
@@ -8,6 +9,7 @@ const Typeface = (props) => {
 
 	const {
 		label,
+		fontFamily,
 		withTextTransform = true,
 		value = {
 			fontSize: {
@@ -106,22 +108,39 @@ const Typeface = (props) => {
 			fontWeight = 'none';
 		}
 
+		const { fontVariants, systemFontVariants } = NeveReactCustomize;
+		const allFontVariants = { ...fontVariants, ...systemFontVariants };
+		const defaultOptions = [
+			{ value: 'none', label: __('None', 'neve') },
+			{ value: 100, label: '100' },
+			{ value: 200, label: '200' },
+			{ value: 300, label: '300' },
+			{ value: 400, label: '400' },
+			{ value: 500, label: '500' },
+			{ value: 600, label: '600' },
+			{ value: 700, label: '700' },
+			{ value: 800, label: '800' },
+			{ value: 900, label: '900' },
+		];
+
+		let options;
+		if (allFontVariants[fontFamily] !== undefined) {
+			options = allFontVariants[fontFamily]
+				.filter((fv) => !fv.includes('italic'))
+				.reduce(
+					(acc, curr) => [
+						...acc,
+						{ value: parseInt(curr), label: curr },
+					],
+					[{ value: 'none', label: __('None', 'neve') }]
+				);
+		}
+
 		return (
 			<InlineSelect
 				label={__('Weight', 'neve')}
 				value={fontWeight}
-				options={[
-					{ value: 'none', label: __('None', 'neve') },
-					{ value: 100, label: '100' },
-					{ value: 200, label: '200' },
-					{ value: 300, label: '300' },
-					{ value: 400, label: '400' },
-					{ value: 500, label: '500' },
-					{ value: 600, label: '600' },
-					{ value: 700, label: '700' },
-					{ value: 800, label: '800' },
-					{ value: 900, label: '900' },
-				]}
+				options={options ? options : defaultOptions}
 				onChange={(nextValue) => {
 					onChange({ fontWeight: nextValue });
 					if (nextValue === 'none' && refreshAfterReset) {

--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -1,5 +1,5 @@
 /* global NeveReactCustomize */
-import { useState } from '@wordpress/element';
+import { useState, useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { InlineSelect, NumberControl } from '@neve-wp/components';
 import PropTypes from 'prop-types';
@@ -9,7 +9,7 @@ const Typeface = (props) => {
 
 	const {
 		label,
-		fontFamily,
+		fontFamilyControl,
 		withTextTransform = true,
 		value = {
 			fontSize: {
@@ -70,6 +70,20 @@ const Typeface = (props) => {
 			desktop: '',
 		},
 	} = props;
+
+	const [fontFamily, setFontFamily] = useState(
+		wp.customize.control(fontFamilyControl)
+			? wp.customize.control(fontFamilyControl).setting()
+			: ''
+	);
+
+	useEffect(() => {
+		window.wp.customize.bind('change', (setting) => {
+			if (setting.id === fontFamilyControl) {
+				setFontFamily(setting.get());
+			}
+		});
+	}, []);
 
 	const renderTextTransform = () => {
 		if (!withTextTransform) {

--- a/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
+++ b/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
@@ -1,4 +1,4 @@
-/*eslint camelcase: ["error", {allow: ["text_transform","weight_default","refresh_on_reset","font_family","letter_spacing_default","line_height_units","disable_transform","size_default","size_units","line_height_default"]}]*/
+/*eslint camelcase: ["error", {allow: ["text_transform","weight_default","refresh_on_reset","font_family_control","letter_spacing_default","line_height_units","disable_transform","size_default","size_units","line_height_default"]}]*/
 import PropTypes from 'prop-types';
 import { useState } from '@wordpress/element';
 
@@ -146,7 +146,7 @@ const TypefaceComponent = ({ control }) => {
 		});
 	};
 
-	const { label, font_family, refresh_on_reset } = control.params;
+	const { label, font_family_control, refresh_on_reset } = control.params;
 	const {
 		disable_transform,
 		size_default,
@@ -160,7 +160,7 @@ const TypefaceComponent = ({ control }) => {
 		<Typeface
 			label={label}
 			value={value}
-			fontFamily={font_family}
+			fontFamilyControl={font_family_control}
 			withTextTransform={disable_transform}
 			defaultFS={size_default}
 			fSUnit={size_units}

--- a/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
+++ b/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
@@ -1,4 +1,4 @@
-/*eslint camelcase: ["error", {allow: ["text_transform","weight_default","refresh_on_reset","letter_spacing_default","line_height_units","disable_transform","size_default","size_units","line_height_default"]}]*/
+/*eslint camelcase: ["error", {allow: ["text_transform","weight_default","refresh_on_reset","font_family","letter_spacing_default","line_height_units","disable_transform","size_default","size_units","line_height_default"]}]*/
 import PropTypes from 'prop-types';
 import { useState } from '@wordpress/element';
 
@@ -146,7 +146,7 @@ const TypefaceComponent = ({ control }) => {
 		});
 	};
 
-	const { label, refresh_on_reset } = control.params;
+	const { label, font_family, refresh_on_reset } = control.params;
 	const {
 		disable_transform,
 		size_default,
@@ -160,6 +160,7 @@ const TypefaceComponent = ({ control }) => {
 		<Typeface
 			label={label}
 			value={value}
+			fontFamily={font_family}
 			withTextTransform={disable_transform}
 			defaultFS={size_default}
 			fSUnit={size_units}

--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -271,33 +271,38 @@ function neve_kses_svg( $input ) {
 /**
  * Get standard fonts
  *
+ * @param bool $with_variants should fetch variants.
+ *
  * @return array
  */
-function neve_get_standard_fonts() {
-	return apply_filters(
-		'neve_standard_fonts_array',
-		array(
-			'Arial, Helvetica, sans-serif',
-			'Arial Black, Gadget, sans-serif',
-			'Bookman Old Style, serif',
-			'Comic Sans MS, cursive',
-			'Courier, monospace',
-			'Georgia, serif',
-			'Garamond, serif',
-			'Impact, Charcoal, sans-serif',
-			'Lucida Console, Monaco, monospace',
-			'Lucida Sans Unicode, Lucida Grande, sans-serif',
-			'MS Sans Serif, Geneva, sans-serif',
-			'MS Serif, New York, sans-serif',
-			'Palatino Linotype, Book Antiqua, Palatino, serif',
-			'Tahoma, Geneva, sans-serif',
-			'Times New Roman, Times, serif',
-			'Trebuchet MS, Helvetica, sans-serif',
-			'Verdana, Geneva, sans-serif',
-			'Paratina Linotype',
-			'Trebuchet MS',
-		)
+function neve_get_standard_fonts( $with_variants = false ) {
+	$fonts = array(
+		'Arial, Helvetica, sans-serif'                     => array( '400', '700', '400italic', '700italic' ),
+		'Arial Black, Gadget, sans-serif'                  => array( '900', '900italic' ),
+		'Bookman Old Style, serif'                         => array( '400', '700', '400italic', '700italic' ),
+		'Comic Sans MS, cursive'                           => array( '400', '700', '400italic', '700italic' ),
+		'Courier, monospace'                               => array( '400', '700', '400italic', '700italic' ),
+		'Georgia, serif'                                   => array( '400', '700', '400italic', '700italic' ),
+		'Garamond, serif'                                  => array( '400', '700', '400italic', '700italic' ),
+		'Impact, Charcoal, sans-serif'                     => array( '400', '700', '400italic', '700italic' ),
+		'Lucida Console, Monaco, monospace'                => array( '400', '700', '400italic', '700italic' ),
+		'Lucida Sans Unicode, Lucida Grande, sans-serif'   => array( '400', '700', '400italic', '700italic' ),
+		'MS Sans Serif, Geneva, sans-serif'                => array( '400', '700', '400italic', '700italic' ),
+		'MS Serif, New York, sans-serif'                   => array( '400', '700', '400italic', '700italic' ),
+		'Palatino Linotype, Book Antiqua, Palatino, serif' => array( '400', '700', '400italic', '700italic' ),
+		'Tahoma, Geneva, sans-serif'                       => array( '400', '700', '400italic', '700italic' ),
+		'Times New Roman, Times, serif'                    => array( '400', '700', '400italic', '700italic' ),
+		'Trebuchet MS, Helvetica, sans-serif'              => array( '400', '700', '400italic', '700italic' ),
+		'Verdana, Geneva, sans-serif'                      => array( '400', '700', '400italic', '700italic' ),
+		'Paratina Linotype'                                => array( '400', '700', '400italic', '700italic' ),
+		'Trebuchet MS'                                     => array( '400', '700', '400italic', '700italic' ),
 	);
+
+	if ( $with_variants ) {
+		return apply_filters( 'neve_standard_fonts_with_variants_array', $fonts );
+	}
+
+	return apply_filters( 'neve_standard_fonts_array', array_keys( $fonts ) );
 }
 
 /**

--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -933,13 +933,14 @@ abstract class Abstract_Component implements Component {
 					'default'               => $this->typography_default,
 					'sanitize_callback'     => 'neve_sanitize_typography_control',
 					'options'               => [
-						'input_attrs' => array(
+						'input_attrs'         => array(
 							'size_units'             => [ 'em', 'px' ],
 							'weight_default'         => $this->typography_default['fontWeight'],
 							'size_default'           => $this->typography_default['fontSize'],
 							'line_height_default'    => $this->typography_default['lineHeight'],
 							'letter_spacing_default' => $this->typography_default['letterSpacing'],
 						),
+						'font_family_control' => $this->get_id() . '_' . self::FONT_FAMILY_ID,
 					],
 				]
 			);

--- a/inc/customizer/controls/react/typography.php
+++ b/inc/customizer/controls/react/typography.php
@@ -32,19 +32,19 @@ class Typography extends \WP_Customize_Control {
 	 */
 	public $refresh_on_reset = false;
 	/**
-	 * The font family for which the setting are changed
+	 * The control that holds the font family used by this control
 	 *
 	 * @var string
 	 */
-	public $font_family = '';
+	public $font_family_control = '';
 
 	/**
 	 * Send to JS.
 	 */
 	public function to_json() {
 		parent::to_json();
-		$this->json['input_attrs']      = is_array( $this->input_attrs ) ? wp_json_encode( $this->input_attrs ) : $this->input_attrs;
-		$this->json['refresh_on_reset'] = $this->refresh_on_reset;
-		$this->json['font_family']      = $this->font_family;
+		$this->json['input_attrs']         = is_array( $this->input_attrs ) ? wp_json_encode( $this->input_attrs ) : $this->input_attrs;
+		$this->json['refresh_on_reset']    = $this->refresh_on_reset;
+		$this->json['font_family_control'] = $this->font_family_control;
 	}
 }

--- a/inc/customizer/controls/react/typography.php
+++ b/inc/customizer/controls/react/typography.php
@@ -31,6 +31,12 @@ class Typography extends \WP_Customize_Control {
 	 * @var bool
 	 */
 	public $refresh_on_reset = false;
+	/**
+	 * The font family for which the setting are changed
+	 *
+	 * @var string
+	 */
+	public $font_family = '';
 
 	/**
 	 * Send to JS.
@@ -39,5 +45,6 @@ class Typography extends \WP_Customize_Control {
 		parent::to_json();
 		$this->json['input_attrs']      = is_array( $this->input_attrs ) ? wp_json_encode( $this->input_attrs ) : $this->input_attrs;
 		$this->json['refresh_on_reset'] = $this->refresh_on_reset;
+		$this->json['font_family']      = $this->font_family;
 	}
 }

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -128,6 +128,7 @@ class Loader {
 						'Google' => neve_get_google_fonts(),
 					),
 					'fontVariants'                  => neve_get_google_fonts( true ),
+					'systemFontVariants'            => neve_get_standard_fonts( true ),
 					'hideConditionalHeaderSelector' => ! neve_can_use_conditional_header(),
 					'dashUpdatesMessage'            => sprintf( 'Please %s to the latest version of Neve Pro to manage the conditional headers.', '<a href="' . esc_url( admin_url( 'update-core.php' ) ) . '">' . __( 'update', 'neve' ) . '</a>' ),
 					'bundlePath'                    => get_template_directory_uri() . '/assets/apps/customizer-controls/build/',

--- a/inc/customizer/options/buttons.php
+++ b/inc/customizer/options/buttons.php
@@ -127,7 +127,7 @@ class Buttons extends Base_Customizer {
 						),
 					),
 					'type'                  => 'neve_typeface_control',
-					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
+					'font_family_control'   => 'neve_body_font_family',
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => [

--- a/inc/customizer/options/buttons.php
+++ b/inc/customizer/options/buttons.php
@@ -127,6 +127,7 @@ class Buttons extends Base_Customizer {
 						),
 					),
 					'type'                  => 'neve_typeface_control',
+					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => [

--- a/inc/customizer/options/form_fields.php
+++ b/inc/customizer/options/form_fields.php
@@ -423,6 +423,7 @@ class Form_Fields extends Base_Customizer {
 						),
 					),
 					'type'                  => 'neve_typeface_control',
+					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
 					'refresh_on_reset'      => true,
 					'live_refresh_selector' => '
 						form input:read-write,
@@ -523,6 +524,7 @@ class Form_Fields extends Base_Customizer {
 						],
 					],
 					'type'                  => 'neve_typeface_control',
+					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
 					'refresh_on_reset'      => true,
 					'live_refresh_selector' => 'form label, body .wpforms-container .wpforms-field-label, .woocommerce form .form-row label',
 					'live_refresh_css_prop' => [

--- a/inc/customizer/options/form_fields.php
+++ b/inc/customizer/options/form_fields.php
@@ -423,7 +423,7 @@ class Form_Fields extends Base_Customizer {
 						),
 					),
 					'type'                  => 'neve_typeface_control',
-					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
+					'font_family_control'   => 'neve_body_font_family',
 					'refresh_on_reset'      => true,
 					'live_refresh_selector' => '
 						form input:read-write,
@@ -524,7 +524,7 @@ class Form_Fields extends Base_Customizer {
 						],
 					],
 					'type'                  => 'neve_typeface_control',
-					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
+					'font_family_control'   => 'neve_body_font_family',
 					'refresh_on_reset'      => true,
 					'live_refresh_selector' => 'form label, body .wpforms-container .wpforms-field-label, .woocommerce form .form-row label',
 					'live_refresh_css_prop' => [

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -292,9 +292,6 @@ class Typography extends Base_Customizer {
 	 * Add controls for blog typography.
 	 */
 	private function controls_typography_blog() {
-		$heading_font_family = get_theme_mod( 'neve_headings_font_family', '' );
-		$body_font_family    = get_theme_mod( 'neve_body_font_family', '' );
-
 		$controls = array(
 			'neve_archive_typography_post_title'         => array(
 				'label'                 => __( 'Post title', 'neve' ),

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -135,7 +135,7 @@ class Typography extends Base_Customizer {
 						'letter_spacing_default' => $defaults['letterSpacing'],
 					),
 					'type'                  => 'neve_typeface_control',
-					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
+					'font_family_control'   => 'neve_body_font_family',
 					'live_refresh_selector' => 'body, .site-title',
 				],
 				'\Neve\Customizer\Controls\React\Typography'
@@ -257,7 +257,7 @@ class Typography extends Base_Customizer {
 							'letter_spacing_default' => $default_values['letterSpacing'],
 						),
 						'type'                  => 'neve_typeface_control',
-						'font_family'           => get_theme_mod( 'neve_headings_font_family', '' ),
+						'font_family_control'   => 'neve_headings_font_family',
 						'live_refresh_selector' => $selectors[ $heading_id ],
 						'live_refresh_css_prop' => [
 							'cssVar' => [
@@ -300,38 +300,38 @@ class Typography extends Base_Customizer {
 				'label'                 => __( 'Post title', 'neve' ),
 				'category_label'        => __( 'Blog Archive', 'neve' ),
 				'priority'              => 10,
-				'font_family'           => $heading_font_family,
+				'font_family_control'   => 'neve_headings_font_family',
 				'live_refresh_selector' => '.blog .blog-entry-title, .archive .blog-entry-title',
 			),
 			'neve_archive_typography_post_excerpt'       => array(
 				'label'                 => __( 'Post excerpt', 'neve' ),
 				'priority'              => 20,
-				'font_family'           => $body_font_family,
+				'font_family_control'   => 'neve_body_font_family',
 				'live_refresh_selector' => '.blog .entry-summary, .archive .entry-summary, .blog .post-pages-links',
 			),
 			'neve_archive_typography_post_meta'          => array(
 				'label'                 => __( 'Post meta', 'neve' ),
 				'priority'              => 30,
-				'font_family'           => $body_font_family,
+				'font_family_control'   => 'neve_body_font_family',
 				'live_refresh_selector' => '.blog .nv-meta-list li, .archive .nv-meta-list li',
 			),
 			'neve_single_post_typography_post_title'     => array(
 				'label'                 => __( 'Post title', 'neve' ),
 				'category_label'        => __( 'Single Post', 'neve' ),
 				'priority'              => 40,
-				'font_family'           => $heading_font_family,
+				'font_family_control'   => 'neve_headings_font_family',
 				'live_refresh_selector' => '.single h1.entry-title',
 			),
 			'neve_single_post_typography_post_meta'      => array(
 				'label'                 => __( 'Post meta', 'neve' ),
 				'priority'              => 50,
-				'font_family'           => $body_font_family,
+				'font_family_control'   => 'neve_body_font_family',
 				'live_refresh_selector' => '.single .nv-meta-list li',
 			),
 			'neve_single_post_typography_comments_title' => array(
 				'label'                 => __( 'Comments reply title', 'neve' ),
 				'priority'              => 60,
-				'font_family'           => $heading_font_family,
+				'font_family_control'   => 'neve_headings_font_family',
 				'live_refresh_selector' => '.single .comment-reply-title',
 			),
 		);
@@ -372,7 +372,7 @@ class Typography extends Base_Customizer {
 						'priority'              => $control_settings['priority'] += 1,
 						'section'               => 'neve_typography_blog',
 						'type'                  => 'neve_typeface_control',
-						'font_family'           => $control_settings['font_family'],
+						'font_family_control'   => $control_settings['font_family_control'],
 						'live_refresh_selector' => neve_is_new_skin() ? true : $control_settings['live_refresh_selector'],
 						'live_refresh_css_prop' => [
 							'cssVar' => [

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -135,6 +135,7 @@ class Typography extends Base_Customizer {
 						'letter_spacing_default' => $defaults['letterSpacing'],
 					),
 					'type'                  => 'neve_typeface_control',
+					'font_family'           => get_theme_mod( 'neve_body_font_family', '' ),
 					'live_refresh_selector' => 'body, .site-title',
 				],
 				'\Neve\Customizer\Controls\React\Typography'
@@ -256,6 +257,7 @@ class Typography extends Base_Customizer {
 							'letter_spacing_default' => $default_values['letterSpacing'],
 						),
 						'type'                  => 'neve_typeface_control',
+						'font_family'           => get_theme_mod( 'neve_headings_font_family', '' ),
 						'live_refresh_selector' => $selectors[ $heading_id ],
 						'live_refresh_css_prop' => [
 							'cssVar' => [
@@ -290,37 +292,46 @@ class Typography extends Base_Customizer {
 	 * Add controls for blog typography.
 	 */
 	private function controls_typography_blog() {
+		$heading_font_family = get_theme_mod( 'neve_headings_font_family', '' );
+		$body_font_family    = get_theme_mod( 'neve_body_font_family', '' );
+
 		$controls = array(
 			'neve_archive_typography_post_title'         => array(
 				'label'                 => __( 'Post title', 'neve' ),
 				'category_label'        => __( 'Blog Archive', 'neve' ),
 				'priority'              => 10,
+				'font_family'           => $heading_font_family,
 				'live_refresh_selector' => '.blog .blog-entry-title, .archive .blog-entry-title',
 			),
 			'neve_archive_typography_post_excerpt'       => array(
 				'label'                 => __( 'Post excerpt', 'neve' ),
 				'priority'              => 20,
+				'font_family'           => $body_font_family,
 				'live_refresh_selector' => '.blog .entry-summary, .archive .entry-summary, .blog .post-pages-links',
 			),
 			'neve_archive_typography_post_meta'          => array(
 				'label'                 => __( 'Post meta', 'neve' ),
 				'priority'              => 30,
+				'font_family'           => $body_font_family,
 				'live_refresh_selector' => '.blog .nv-meta-list li, .archive .nv-meta-list li',
 			),
 			'neve_single_post_typography_post_title'     => array(
 				'label'                 => __( 'Post title', 'neve' ),
 				'category_label'        => __( 'Single Post', 'neve' ),
 				'priority'              => 40,
+				'font_family'           => $heading_font_family,
 				'live_refresh_selector' => '.single h1.entry-title',
 			),
 			'neve_single_post_typography_post_meta'      => array(
 				'label'                 => __( 'Post meta', 'neve' ),
 				'priority'              => 50,
+				'font_family'           => $body_font_family,
 				'live_refresh_selector' => '.single .nv-meta-list li',
 			),
 			'neve_single_post_typography_comments_title' => array(
 				'label'                 => __( 'Comments reply title', 'neve' ),
 				'priority'              => 60,
+				'font_family'           => $heading_font_family,
 				'live_refresh_selector' => '.single .comment-reply-title',
 			),
 		);
@@ -361,6 +372,7 @@ class Typography extends Base_Customizer {
 						'priority'              => $control_settings['priority'] += 1,
 						'section'               => 'neve_typography_blog',
 						'type'                  => 'neve_typeface_control',
+						'font_family'           => $control_settings['font_family'],
 						'live_refresh_selector' => neve_is_new_skin() ? true : $control_settings['live_refresh_selector'],
 						'live_refresh_css_prop' => [
 							'cssVar' => [


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
When selecting the font weight, only the ones that are supported for the used font family are displayed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The following controls should display the available weights for the selected body font family: 
    1. Buttons -> Button Text
    2. Form Fields -> Input Text and Form Labels
    3. Typography -> General
    4. Typography -> Blog -> Blog Archive -> Post Excerpt  and Post Meta
    5. Typography -> Blog -> Single Post  -> Post Meta

- And the following for the heading font family:
    1. Typography -> Headings
    2. Typography -> Blog -> Blog Archive -> Post Title
    3. Typography -> Blog -> Single Post  -> Post Title and Comments Reply Title
    
The HFG components that use a font family selector should also be checked: menus, custom html, contact, and copyright.

Let me know if I missed any font-related control.

<!-- Issues that this pull request closes. -->
Closes #2631.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
