### PR TITLE
Feat: changed upsell section customizer

### DIFF
--- a/assets/apps/customizer-controls/src/builder-upsell/Upsells.tsx
+++ b/assets/apps/customizer-controls/src/builder-upsell/Upsells.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, Modal } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import { WPCustomizeControl } from '../@types/customizer-control';
+// @ts-ignore
+import FreePro from '../../../dashboard/src/Components/Content/FreePro';
+
+type Props = {
+	control: WPCustomizeControl;
+};
+
+const Upsells: React.FC<Props> = ({ control }) => {
+	const { params, id } = control;
+	const { features, url } = params;
+	const [isOpen, setOpen] = useState(false);
+	const openModal = () => setOpen(true);
+	const closeModal = () => setOpen(false);
+
+	return (
+		<div className="upsell-inner">
+			{params.title && (
+				<div className="neve-customizer-heading">
+					<span className="accordion-heading">{params.title}</span>
+					<Button
+						className="button button-primary"
+						onClick={openModal}
+					>
+						{__('Learn More', 'neve')}
+					</Button>
+					{isOpen && (
+						<Modal
+							style={{ width: '50%' }}
+							title={params.title}
+							onRequestClose={closeModal}
+						>
+							<div id="neve-upsell">
+								<div className="tab-content free-pro">
+									<FreePro
+										style={{ width: '100%' }}
+										features={features}
+										url={url}
+									/>
+								</div>
+							</div>
+						</Modal>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Upsells;

--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -32,6 +32,7 @@ import { RichTextControl } from './rich-text/Control';
 
 import './style.scss';
 import Instructions from './builder-instructions/Instructions.tsx';
+import Upsells from './builder-upsell/Upsells.tsx';
 
 const { controlConstructor } = wp.customize;
 
@@ -90,6 +91,21 @@ const initBlogPageFocus = () => {
 				);
 			}
 		});
+	});
+};
+
+const initUpsellSection = () => {
+	const upsell = document.querySelectorAll('.control-section.neve-upsell');
+
+	upsell.forEach((node) => {
+		const slug = node.getAttribute('data-slug');
+		const section = wp.customize.section(slug);
+
+		if (!section) {
+			return;
+		}
+
+		render(<Upsells control={section} />, section.container[0]);
 	});
 };
 
@@ -170,6 +186,7 @@ const checkHasElementorTemplates = () => {
 
 window.wp.customize.bind('ready', () => {
 	initDynamicFields();
+	initUpsellSection();
 	initQuickLinksSections();
 	bindDataAttrQuickLinks();
 	initBlogPageFocus();

--- a/assets/apps/customizer-controls/src/scss/_upsell.scss
+++ b/assets/apps/customizer-controls/src/scss/_upsell.scss
@@ -20,7 +20,7 @@
 
 .control-section.neve-upsell {
 	.neve-customizer-heading {
-	  max-width: 313px;
+	  max-width: 325px;
 	  padding-left: 25px;
 	  position: relative;
 

--- a/assets/apps/customizer-controls/src/scss/_upsell.scss
+++ b/assets/apps/customizer-controls/src/scss/_upsell.scss
@@ -1,0 +1,32 @@
+@import "./../../../dashboard/src/scss/vars";
+#neve-upsell {
+  width: 100%;
+  padding-top: 2px;
+
+  @import "./../../../dashboard/src/scss/content/free-pro";
+
+  .tab-content.free-pro .card.table .table-head th {
+	padding: 25px 25px;
+  }
+
+  .tab-content.free-pro .upsell.card p {
+	margin-right: 25px;
+  }
+
+  .tab-content.free-pro .card.table, .tab-content.free-pro .upsell.card {
+	max-width: 100%;
+  }
+}
+
+.control-section.neve-upsell {
+	.neve-customizer-heading {
+	  max-width: 313px;
+	  padding-left: 25px;
+	  position: relative;
+
+	  .components-button {
+		position: absolute;
+		right: 13px;
+	  }
+	}
+}

--- a/assets/apps/customizer-controls/src/style.scss
+++ b/assets/apps/customizer-controls/src/style.scss
@@ -14,4 +14,5 @@
 @import "scss/form-fields-section";
 @import "scss/controls-layout";
 @import "scss/repeater";
+@import "scss/upsell";
 

--- a/assets/apps/dashboard/src/Components/Content/FreePro.js
+++ b/assets/apps/dashboard/src/Components/Content/FreePro.js
@@ -1,7 +1,7 @@
 /* global neveDash */
 import FeatureRow from '../FeatureRow';
 
-import {__} from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
 const Pro = ({ features, url }) => {

--- a/assets/apps/dashboard/src/Components/Content/FreePro.js
+++ b/assets/apps/dashboard/src/Components/Content/FreePro.js
@@ -1,11 +1,15 @@
 /* global neveDash */
 import FeatureRow from '../FeatureRow';
 
-import { __ } from '@wordpress/i18n';
+import {__} from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
-const Pro = () => {
-	const { featureData } = neveDash;
+const Pro = ({ features, url }) => {
+	if (typeof neveDash !== 'undefined') {
+		const { featureData, upgradeURL } = neveDash;
+		features = featureData;
+		url = upgradeURL;
+	}
 	return (
 		<div className="col">
 			<table className="card table">
@@ -15,7 +19,7 @@ const Pro = () => {
 						<th className="indicator">Neve</th>
 						<th className="indicator">Neve Pro</th>
 					</tr>
-					{featureData.map((item, index) => (
+					{features.map((item, index) => (
 						<FeatureRow key={index} item={item} />
 					))}
 				</tbody>
@@ -31,7 +35,7 @@ const Pro = () => {
 				<Button
 					target="_blank"
 					rel="external noreferrer noopener"
-					href={neveDash.upgradeURL}
+					href={url}
 					isPrimary
 				>
 					{__('Get Neve Pro Now', 'neve')}

--- a/header-footer-grid/Core/Customizer.php
+++ b/header-footer-grid/Core/Customizer.php
@@ -244,6 +244,8 @@ class Customizer {
 		}
 
 		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Instructions_Section' );
+		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Upsell_Section' );
+
 	}
 
 

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -345,104 +345,12 @@ class Main {
 	}
 
 	/**
-	 * Get doc link.
-	 *
-	 * @param string $utm_term utm term to use for doc link.
-	 * @param string $url url to doc.
-	 * @return string
-	 */
-	private function get_doc_link( $utm_term, $url ) {
-		$args = [
-			'utm_medium'   => 'aboutneve',
-			'utm_source'   => 'freevspro',
-			'utm_campaign' => 'neve',
-			'utm_term'     => $utm_term,
-		];
-
-
-		return add_query_arg( $args, esc_url( $url ) );
-	}
-
-	/**
 	 * Get the pro features for the free v pro table.
 	 *
 	 * @return array
 	 */
 	private function get_free_pro_features() {
-		return [
-			[
-				'title'       => __( 'Header/Footer builder', 'neve' ),
-				'description' => __( 'Easily build your header and footer by dragging and dropping all the important elements in the real-time WordPress Customizer. More advanced options are available in PRO.', 'neve' ),
-				'inLite'      => true,
-				'docsLink'    => $this->get_doc_link( 'Header/Footer builder', 'https://docs.themeisle.com/category/1251-neve-header-builder' ),
-			],
-			[
-				'title'       => __( 'Page Builder Compatibility', 'neve' ),
-				'description' => __( 'Neve is fully compatible with Gutenberg, the new WordPress editor and for all of you page builder fans, Neve has full compatibility with Elementor, Beaver Builder, and all the other popular page builders.', 'neve' ),
-				'inLite'      => true,
-				'docsLink'    => $this->get_doc_link( 'Page Builder Compatibility', 'https://docs.themeisle.com/article/946-neve-doc#pagebuilders' ),
-			],
-			[
-				'title'       => __( 'Header Booster', 'neve' ),
-				'description' => __( 'Take the header builder to a new level with new awesome components: socials, contact, breadcrumbs, language switcher, multiple HTML, sticky and transparent menu, page header builder and many more.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Header Booster', 'https://docs.themeisle.com/article/1057-header-booster-documentation' ),
-			],
-			[
-				'title'       => __( 'Page Header Builder', 'neve' ),
-				'description' => __( 'The Page Header is the horizontal area that sits directly below the header and contains the page/post title. Easily design an attractive Page Header area using our dedicated builder.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Page Header Builder', 'https://docs.themeisle.com/article/1262-neve-page-header' ),
-			],
-			[
-				'title'       => __( 'Custom Layouts', 'neve' ),
-				'description' => __( 'Powerful Custom Layouts builder which allows you to easily create your own header, footer or custom content on any of the hook locations available in the theme.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Custom Layouts', 'https://docs.themeisle.com/article/1062-custom-layouts-module' ),
-			],
-			[
-				'title'       => __( 'Blog Booster', 'neve' ),
-				'description' => __( 'Give a huge boost to your entire blogging experience with features specially designed for increased user experience.', 'neve' ) . ' ' . __( 'Sharing, custom article sorting, comments integrations, number of minutes needed to read an article and many more.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Blog Booster', 'https://docs.themeisle.com/article/1059-blog-booster-documentation' ),
-			],
-			[
-				'title'       => __( 'Elementor Booster', 'neve' ),
-				'description' => __( 'Leverage the true flexibility of Elementor with powerful addons and templates that you can import with just one click.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Elementor Booster', 'https://docs.themeisle.com/article/1063-elementor-booster-module-documentation' ),
-			],
-			[
-				'title'       => __( 'WooCommerce Booster', 'neve' ),
-				'description' => __( 'Empower your online store with awesome new features, specially designed for a smooth WooCommerce integration.', 'neve' ) . ' ' . __( 'Wishlist, quick view, video products, advanced reviews, multiple dedicated layouts and many more.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'WooCommerce Booster', 'https://docs.themeisle.com/article/1058-woocommerce-booster-documentation' ),
-			],
-			[
-				'title'       => __( 'LifterLMS Booster', 'neve' ),
-				'description' => __( 'Make your LifterLMS pages look stunning with our PRO design options. Specially created to help you set up your online courses with minimum customizations.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'LifterLMS Booster', 'https://docs.themeisle.com/article/1084-lifterlms-booster-documentation' ),
-			],
-			[
-				'title'       => __( 'Typekit(Adobe) Fonts', 'neve' ),
-				'description' => __( "The module allows for an easy way of enabling new awesome Adobe (previous Typekit) Fonts in Neve's Typography options.", 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Typekit(Adobe) Fonts', 'https://docs.themeisle.com/article/1085-typekit-fonts-documentation' ),
-			],
-			[
-				'title'       => __( 'White Label', 'neve' ),
-				'description' => __( "For any developer or agency out there building websites for their own clients, we've made it easy to present the theme as your own.", 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'White Label', 'https://docs.themeisle.com/article/1061-white-label-module-documentation' ),
-			],
-			[
-				'title'       => __( 'Scroll To Top', 'neve' ),
-				'description' => __( 'Simple but effective module to help you navigate back to the top of the really long pages.', 'neve' ),
-				'inLite'      => false,
-				'docsLink'    => $this->get_doc_link( 'Scroll To Top', 'https://docs.themeisle.com/article/1060-scroll-to-top-module-documentation' ),
-			],
-		];
+		return ( new Upsell_Features() )->get_upsell_features();
 	}
 
 	/**

--- a/inc/admin/dashboard/upsell_features.php
+++ b/inc/admin/dashboard/upsell_features.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Description Holds the upsell features.
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  21-12-{2021}
+ *
+ * @package Neve
+ */
+namespace Neve\Admin\Dashboard;
+
+/**
+ * Class Upsell_Features
+ */
+class Upsell_Features {
+	/**
+	 * Get doc link.
+	 *
+	 * @param string $utm_term utm term to use for doc link.
+	 * @param string $url url to doc.
+	 * @return string
+	 */
+	private function get_doc_link( $utm_term, $url ) {
+		$args = [
+			'utm_medium'   => 'aboutneve',
+			'utm_source'   => 'freevspro',
+			'utm_campaign' => 'neve',
+			'utm_term'     => $utm_term,
+		];
+
+
+		return add_query_arg( $args, esc_url( $url ) );
+	}
+
+	/**
+	 * Get the pro features for the free v pro table.
+	 *
+	 * @return array
+	 */
+	final public function get_upsell_features() {
+		return [
+			[
+				'title'       => __( 'Header/Footer builder', 'neve' ),
+				'description' => __( 'Easily build your header and footer by dragging and dropping all the important elements in the real-time WordPress Customizer. More advanced options are available in PRO.', 'neve' ),
+				'inLite'      => true,
+				'docsLink'    => $this->get_doc_link( 'Header/Footer builder', 'https://docs.themeisle.com/category/1251-neve-header-builder' ),
+			],
+			[
+				'title'       => __( 'Page Builder Compatibility', 'neve' ),
+				'description' => __( 'Neve is fully compatible with Gutenberg, the new WordPress editor and for all of you page builder fans, Neve has full compatibility with Elementor, Beaver Builder, and all the other popular page builders.', 'neve' ),
+				'inLite'      => true,
+				'docsLink'    => $this->get_doc_link( 'Page Builder Compatibility', 'https://docs.themeisle.com/article/946-neve-doc#pagebuilders' ),
+			],
+			[
+				'title'       => __( 'Header Booster', 'neve' ),
+				'description' => __( 'Take the header builder to a new level with new awesome components: socials, contact, breadcrumbs, language switcher, multiple HTML, sticky and transparent menu, page header builder and many more.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Header Booster', 'https://docs.themeisle.com/article/1057-header-booster-documentation' ),
+			],
+			[
+				'title'       => __( 'Page Header Builder', 'neve' ),
+				'description' => __( 'The Page Header is the horizontal area that sits directly below the header and contains the page/post title. Easily design an attractive Page Header area using our dedicated builder.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Page Header Builder', 'https://docs.themeisle.com/article/1262-neve-page-header' ),
+			],
+			[
+				'title'       => __( 'Custom Layouts', 'neve' ),
+				'description' => __( 'Powerful Custom Layouts builder which allows you to easily create your own header, footer or custom content on any of the hook locations available in the theme.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Custom Layouts', 'https://docs.themeisle.com/article/1062-custom-layouts-module' ),
+			],
+			[
+				'title'       => __( 'Blog Booster', 'neve' ),
+				'description' => __( 'Give a huge boost to your entire blogging experience with features specially designed for increased user experience.', 'neve' ) . ' ' . __( 'Sharing, custom article sorting, comments integrations, number of minutes needed to read an article and many more.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Blog Booster', 'https://docs.themeisle.com/article/1059-blog-booster-documentation' ),
+			],
+			[
+				'title'       => __( 'Elementor Booster', 'neve' ),
+				'description' => __( 'Leverage the true flexibility of Elementor with powerful addons and templates that you can import with just one click.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Elementor Booster', 'https://docs.themeisle.com/article/1063-elementor-booster-module-documentation' ),
+			],
+			[
+				'title'       => __( 'WooCommerce Booster', 'neve' ),
+				'description' => __( 'Empower your online store with awesome new features, specially designed for a smooth WooCommerce integration.', 'neve' ) . ' ' . __( 'Wishlist, quick view, video products, advanced reviews, multiple dedicated layouts and many more.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'WooCommerce Booster', 'https://docs.themeisle.com/article/1058-woocommerce-booster-documentation' ),
+			],
+			[
+				'title'       => __( 'LifterLMS Booster', 'neve' ),
+				'description' => __( 'Make your LifterLMS pages look stunning with our PRO design options. Specially created to help you set up your online courses with minimum customizations.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'LifterLMS Booster', 'https://docs.themeisle.com/article/1084-lifterlms-booster-documentation' ),
+			],
+			[
+				'title'       => __( 'Typekit(Adobe) Fonts', 'neve' ),
+				'description' => __( "The module allows for an easy way of enabling new awesome Adobe (previous Typekit) Fonts in Neve's Typography options.", 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Typekit(Adobe) Fonts', 'https://docs.themeisle.com/article/1085-typekit-fonts-documentation' ),
+			],
+			[
+				'title'       => __( 'White Label', 'neve' ),
+				'description' => __( "For any developer or agency out there building websites for their own clients, we've made it easy to present the theme as your own.", 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'White Label', 'https://docs.themeisle.com/article/1061-white-label-module-documentation' ),
+			],
+			[
+				'title'       => __( 'Scroll To Top', 'neve' ),
+				'description' => __( 'Simple but effective module to help you navigate back to the top of the really long pages.', 'neve' ),
+				'inLite'      => false,
+				'docsLink'    => $this->get_doc_link( 'Scroll To Top', 'https://docs.themeisle.com/article/1060-scroll-to-top-module-documentation' ),
+			],
+		];
+	}
+}

--- a/inc/customizer/controls/react/upsell_section.php
+++ b/inc/customizer/controls/react/upsell_section.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Description Upsell Section
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  20-12-{2021}
+ *
+ * @package neve/neve-pro
+ */
+namespace Neve\Customizer\Controls\React;
+
+/**
+ * Customizer section.
+ *
+ * @package    WordPress
+ * @subpackage Customize
+ * @since      4.1.0
+ * @see        WP_Customize_Section
+ */
+class Upsell_Section extends \WP_Customize_Section {
+	/**
+	 * Type of this section.
+	 *
+	 * @var string
+	 */
+	public $type = 'neve_upsell';
+
+	/**
+	 * Options passed to control.
+	 *
+	 * @var array
+	 */
+	public $features = [];
+
+	/**
+	 * Upgrade URL.
+	 *
+	 * @var string
+	 */
+	public $url = '';
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 * @since 4.1.0
+	 */
+	public function json() {
+		$json             = parent::json();
+		$json['features'] = $this->features;
+		$json['url']      = $this->url;
+		return $json;
+	}
+
+	/**
+	 * Render template.
+	 */
+	protected function render_template() {
+		?>
+		<li id="accordion-section-{{ data.id }}"
+			data-slug="{{data.id}}"
+			class="control-section control-section-{{ data.type }} neve-upsell">
+		</li>
+		<?php
+	}
+}

--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -7,7 +7,9 @@
 
 namespace Neve\Customizer\Options;
 
+use Neve\Admin\Dashboard\Upsell_Features;
 use Neve\Customizer\Base_Customizer;
+use Neve\Customizer\Controls\React\Instructions_Section;
 use Neve\Customizer\Types\Section;
 use Neve\Customizer\Types\Control;
 
@@ -65,6 +67,19 @@ class Upsells extends Base_Customizer {
 	private function section_upsells() {
 		$this->add_section(
 			new Section(
+				'neve_free_pro_upsell',
+				array(
+					'priority' => -100,
+					'title'    => esc_html__( 'View PRO Features', 'neve' ),
+					'features' => ( new Upsell_Features() )->get_upsell_features(),
+					'url'      => esc_url( apply_filters( 'neve_upgrade_link_from_child_theme_filter', 'https://themeisle.com/themes/neve/upgrade/?utm_medium=aboutneve&utm_source=freevspro&utm_campaign=neve' ) ),
+				),
+				'Neve\Customizer\Controls\React\Upsell_Section'
+			)
+		);
+
+		$this->add_section(
+			new Section(
 				'neve_upsells_section',
 				array(
 					'priority' => 10,
@@ -85,7 +100,7 @@ class Upsells extends Base_Customizer {
 					'sanitize_callback' => 'sanitize_text_field',
 				),
 				array(
-					'section'            => 'neve_upsells_section',
+					'section'            => 'neve_free_pro_upsell',
 					'priority'           => 100,
 					'options'            => array(
 						esc_html__( 'Header Booster', 'neve' ),


### PR DESCRIPTION
### Summary
Changed the Customizer upsell section as specified [here](https://github.com/Codeinwp/neve-pro-addon/issues/1721)
This is now not required as mentioned [here](https://github.com/Codeinwp/neve-pro-addon/issues/1721#issuecomment-998780124)

A new PR was created for this here: https://github.com/Codeinwp/neve/pull/3284

### Will affect visual aspect of the product
YES

![image](https://user-images.githubusercontent.com/23024731/146928341-e2fa05df-70d0-4f2a-b1a2-54de4bb9aa97.png)

![image](https://user-images.githubusercontent.com/23024731/146928367-f0d56904-dfd6-4453-a183-3faa34acd251.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Open Customizer with Neve Pro deactivated
2. Check the upsell section and the links

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1721.
