### PR TITLE
keep upsells when license is invalid

### DIFF
--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -14,6 +14,7 @@ namespace HFG\Core\Builder;
 use HFG\Core\Customizer\Header_Presets;
 use HFG\Main;
 use Neve\Core\Styles\Dynamic_Selector;
+use Neve\Core\Theme_Info;
 use Neve\Customizer\Controls\React\Presets_Selector;
 use HFG\Core\Settings\Manager as SettingsManager;
 use WP_Customize_Control;
@@ -25,6 +26,7 @@ use WP_Customize_Manager;
  * @package HFG\Core\Builder
  */
 class Header extends Abstract_Builder {
+	use Theme_Info;
 
 	/**
 	 * Builder name.
@@ -542,7 +544,7 @@ class Header extends Abstract_Builder {
 	 * @return array
 	 */
 	protected function get_upsell_components() {
-		if ( defined( 'NEVE_PRO_VERSION' ) ) {
+		if ( $this->has_valid_addons() ) {
 			return [];
 		}
 

--- a/inc/core/theme_info.php
+++ b/inc/core/theme_info.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * Theme Info trait.
+ *
+ * @package Neve\Core
+ */
+
+namespace Neve\Core;
+
+/**
+ * Theme_Info trait
+ */
+trait Theme_Info {
+	/**
+	 * Check validity of addons plugin.
+	 *
+	 * @return bool
+	 */
+	private function has_valid_addons() {
+		if ( ! defined( 'NEVE_PRO_BASEFILE' ) ) {
+			return false;
+		}
+
+		$option_name = basename( dirname( NEVE_PRO_BASEFILE ) );
+		$option_name = str_replace( '-', '_', strtolower( trim( $option_name ) ) );
+		$status      = get_option( $option_name . '_license_data' );
+
+		if ( ! $status ) {
+			return false;
+		}
+
+		if ( ! isset( $status->license ) ) {
+			return false;
+		}
+
+		if ( $status->license === 'not_active' || $status->license === 'invalid' ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -7,6 +7,7 @@
 
 namespace Neve\Customizer\Options;
 
+use Neve\Core\Theme_Info;
 use Neve\Customizer\Base_Customizer;
 use Neve\Customizer\Types\Section;
 use Neve\Customizer\Types\Control;
@@ -18,14 +19,16 @@ use Neve\Customizer\Types\Control;
  */
 class Upsells extends Base_Customizer {
 
+	use Theme_Info;
+
 	/**
 	 * Init function
 	 *
 	 * @return bool|void
 	 */
 	public function init() {
-		if ( defined( 'NEVE_PRO_VERSION' ) ) {
-			return false;
+		if ( $this->has_valid_addons() ) {
+			return;
 		}
 
 		parent::init();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -11,6 +11,7 @@ parameters:
         - %currentWorkingDirectory%/header-footer-grid/functions-template.php
     bootstrapFiles:
         - %currentWorkingDirectory%/inc/core/styles/generator.php
+        - %currentWorkingDirectory%/inc/core/theme_info.php
         - %currentWorkingDirectory%/vendor/wptt/webfont-loader/wptt-webfont-loader.php
         - %currentWorkingDirectory%/vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
         - %currentWorkingDirectory%/tests/php/static-analysis-stubs/config.php


### PR DESCRIPTION
### Summary
Customizer upsells should still be visible if no license has been activated, or the license is invalid
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install the version from this PR; 
- Add the pro version without a license;
- The upsells should still be visible;

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1674.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
