### PR TITLE
fix: menu links to in-page sections have active color

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -43,7 +43,7 @@
 		display: block;
 		position: relative;
 
-		&.current-menu-item > a {
+		&.current-menu-item > a:not([href*="#"]) {
 			color: var(--activeColor);
 		}
 


### PR DESCRIPTION
### Summary
Links in menu to same page, that have hashes will not have the active-item color applied anymore.
<!-- Please describe the changes you made. -->


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Import copywriter demo;
- Change the primary menu active link color;
- Add the `Home` page to the menu;
- On the homepage, the only link that has an active color should be the `Home` link

<!-- Issues that this pull request closes. -->
Closes #3234.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
