### PR TITLE
Feat: Documentation Section in Customizer

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           php-version: '7.1'
           extensions: simplexml
+          tools: composer:v2.1
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Get Composer Cache Directory

--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -31,6 +31,7 @@ import { RepeaterControl } from './repeater/Control';
 import { RichTextControl } from './rich-text/Control';
 
 import './style.scss';
+import Documentation from './documentation-section/Documentation.tsx';
 import Instructions from './builder-instructions/Instructions.tsx';
 
 const { controlConstructor } = wp.customize;
@@ -72,6 +73,23 @@ const initDeviceSwitchers = () => {
 			detail: e.target.dataset.device,
 		});
 		document.dispatchEvent(event);
+	});
+};
+
+const initDocSection = () => {
+	const docs = document.querySelectorAll(
+		'.control-section.neve-documentation'
+	);
+
+	docs.forEach((node) => {
+		const slug = node.getAttribute('data-slug');
+		const section = wp.customize.section(slug);
+
+		if (!section) {
+			return;
+		}
+
+		render(<Documentation control={section} />, section.container[0]);
 	});
 };
 
@@ -169,6 +187,7 @@ const checkHasElementorTemplates = () => {
 };
 
 window.wp.customize.bind('ready', () => {
+	initDocSection();
 	initDynamicFields();
 	initQuickLinksSections();
 	bindDataAttrQuickLinks();

--- a/assets/apps/customizer-controls/src/documentation-section/Documentation.tsx
+++ b/assets/apps/customizer-controls/src/documentation-section/Documentation.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { WPCustomizeControl } from '../@types/customizer-control';
+
+type Props = {
+	control: WPCustomizeControl;
+};
+
+const Documentation: React.FC<Props> = ({ control }) => {
+	const { params } = control;
+	const { title, url } = params;
+
+	return (
+		<div className="documentation-inner">
+			{title && (
+				<div className="neve-customizer-heading">
+					<span className="accordion-heading">{params.title}</span>
+					{url && (
+						<Button
+							target="_blank"
+							rel="external noreferrer noopener"
+							href={url}
+							isSecondary
+						>
+							{__('Documentation', 'neve')}
+							<span className="components-visually-hidden">
+								{__('(opens in a new tab)', 'neve')}
+							</span>
+						</Button>
+					)}
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default Documentation;

--- a/assets/apps/customizer-controls/src/scss/_documentation.scss
+++ b/assets/apps/customizer-controls/src/scss/_documentation.scss
@@ -1,6 +1,7 @@
 .control-section.neve-documentation {
   display: block !important;
   margin-bottom: 0;
+  margin-top: -1px;
   .documentation-inner {
 	display: flex;
   }

--- a/assets/apps/customizer-controls/src/scss/_documentation.scss
+++ b/assets/apps/customizer-controls/src/scss/_documentation.scss
@@ -1,0 +1,24 @@
+.control-section.neve-documentation {
+  display: block !important;
+  margin-bottom: 0;
+  .documentation-inner {
+	display: flex;
+  }
+  .neve-customizer-heading {
+	padding: 7px 10px 7px 14px;
+	display: flex;
+	flex-grow: 1;
+	margin: auto;
+	letter-spacing: initial;
+	font-size: 14px;
+	font-weight: 600;
+
+	&:hover, &:focus-within {
+	  cursor: default;
+	}
+
+	.components-button {
+	  margin-left: auto;
+	}
+  }
+}

--- a/assets/apps/customizer-controls/src/style.scss
+++ b/assets/apps/customizer-controls/src/style.scss
@@ -14,4 +14,5 @@
 @import "scss/form-fields-section";
 @import "scss/controls-layout";
 @import "scss/repeater";
+@import "scss/documentation";
 

--- a/header-footer-grid/Core/Customizer.php
+++ b/header-footer-grid/Core/Customizer.php
@@ -242,7 +242,7 @@ class Customizer {
 		foreach ( $this->builders as $builder ) {
 			$builder->customize_register( $wp_customize );
 		}
-
+		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Documentation_Section' );
 		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Instructions_Section' );
 	}
 

--- a/inc/customizer/controls/react/documentation_section.php
+++ b/inc/customizer/controls/react/documentation_section.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * A section control for documentation.
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  22-12-{2021}
+ *
+ * @package neve/neve-pro
+ */
+namespace Neve\Customizer\Controls\React;
+
+/**
+ * Customizer section.
+ *
+ * @package    WordPress
+ * @subpackage Customize
+ * @since      4.1.0
+ * @see        WP_Customize_Section
+ */
+class Documentation_Section extends \WP_Customize_Section {
+	/**
+	 * Type of this section.
+	 *
+	 * @var string
+	 */
+	public $type = 'neve_documentation';
+
+	/**
+	 * Documentation URL.
+	 *
+	 * @var string
+	 */
+	public $url = '';
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 * @since 4.1.0
+	 */
+	public function json() {
+		$json        = parent::json();
+		$json['url'] = $this->url;
+		return $json;
+	}
+
+	/**
+	 * Render template.
+	 */
+	protected function render_template() {
+		?>
+		<li id="accordion-section-{{ data.id }}"
+			data-slug="{{data.id}}"
+			class="control-section control-section-{{ data.type }} neve-documentation">
+		</li>
+		<?php
+	}
+}

--- a/inc/customizer/options/main.php
+++ b/inc/customizer/options/main.php
@@ -11,8 +11,10 @@
 namespace Neve\Customizer\Options;
 
 use Neve\Core\Settings\Mods;
+use Neve\Customizer\Controls\React\Documentation_Section;
 use Neve\Customizer\Controls\React\Instructions_Section;
 use Neve\Customizer\Base_Customizer;
+use Neve\Customizer\Controls\Simple_Upsell;
 use Neve\Customizer\Types\Control;
 use Neve\Customizer\Types\Panel;
 use Neve\Customizer\Types\Section;
@@ -100,6 +102,22 @@ class Main extends Base_Customizer {
 						),
 					),
 				)
+			)
+		);
+
+		/**
+		 * Documentation Section Main
+		 */
+		$docs_url = 'https://docs.themeisle.com/article/946-neve-doc';
+		$this->wpc->add_section(
+			new Documentation_Section(
+				$this->wpc,
+				'neve_documentation',
+				[
+					'priority' => PHP_INT_MAX,
+					'title'    => esc_html__( 'Neve', 'neve' ),
+					'url'      => $docs_url,
+				]
 			)
 		);
 	}

--- a/inc/customizer/options/main.php
+++ b/inc/customizer/options/main.php
@@ -108,7 +108,7 @@ class Main extends Base_Customizer {
 		/**
 		 * Documentation Section Main
 		 */
-		$docs_url = 'https://docs.themeisle.com/article/946-neve-doc';
+		$docs_url = 'https://docs.themeisle.com/article/946-neve-doc?utm_medium=customizer&utm_source=docsbtn&utm_campaign=neve';
 		$this->wpc->add_section(
 			new Documentation_Section(
 				$this->wpc,


### PR DESCRIPTION
### Summary
Added a section in customizer on the main panel that links to the documentation for Neve

### Will affect visual aspect of the product
YES

![image](https://user-images.githubusercontent.com/23024731/147103824-8532fce6-a96b-437f-a475-15ed801c974f.png)

### Test instructions
1. Open Customizer check that the Section is present in both Free and Pro and that it links to the documentation in a new tab.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1716.
