### PR TITLE
refactor: utm_content param added to learn more buttons where in cust…

### DIFF
--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -216,7 +216,7 @@ class Upsells extends Base_Customizer {
 							[
 								'type'     => 'nv_simple_upsell_section',
 								'priority' => 10000,
-								'link'     => add_query_arg( 'utm_source', $args['panel'], 'https://themeisle.com/themes/neve/upgrade/?utm_medium=customizer&utm_campaign=neve' ),
+								'link'     => add_query_arg( 'utm_source', $args['panel'], 'https://themeisle.com/themes/neve/upgrade/?utm_medium=customizer&utm_campaign=neve&utm_content=learnmore' ),
 							]
 						),
 						'\Neve\Customizer\Controls\Simple_Upsell_Section'
@@ -233,7 +233,7 @@ class Upsells extends Base_Customizer {
 						$args,
 						[
 							'priority' => 10000,
-							'link'     => add_query_arg( 'utm_source', $args['section'], 'https://themeisle.com/themes/neve/upgrade/?utm_medium=customizer&utm_campaign=neve' ),
+							'link'     => add_query_arg( 'utm_source', $args['section'], 'https://themeisle.com/themes/neve/upgrade/?utm_medium=customizer&utm_campaign=neve&utm_content=learnmore' ),
 						]
 					),
 					'Neve\Customizer\Controls\Simple_Upsell'


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
**utm_content** param added with **learnmore** value to link of the learn more buttons where in the customizer

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- learn more button where in customizer(product catalog, checkout, single product, typography) URL should contains utm_content:learnmore param.

<!-- Issues that this pull request closes. -->
Closes codeinwp/neve-pro-addon#1787.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
