### PR TITLE
Fix shop sidebar

### DIFF
--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -159,6 +159,11 @@ class Metabox_Settings {
 			return false;
 		}
 
+		// On shop page the returning id is the id of the first product. We need the id of the page.
+		if ( class_exists( 'WooCommerce' ) && is_shop() ) {
+			return wc_get_page_id( 'shop' );
+		}
+
 		global $post;
 		if ( empty( $post ) ) {
 			return false;


### PR DESCRIPTION
### Summary
The function right [here](https://github.com/Codeinwp/neve/blob/master/inc/views/pluggable/metabox_settings.php#L149) returns the post/page ID using `global $post;`. On the shop page, the global post is alternated by WooCommerce as the shop page is not only a page but an archive too. In this case the global $post returns the id of the last product added and not for the page id causing the custom meta not to override the settings from the customizer. This PR fixes that.

### Will affect visual aspect of the product
YES

### Screenshots <!-- if applicable -->

### Test instructions
- Import Jewelrey starter site
- Try to place the sidebar left in customizer and right in custom post meta. It should not work
- Add this PR and check if this is working
- Check the off-canvas layout form customizer too. Select it from the Customizer and remove it from the custom meta.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1790
<!-- Should look like this: `Closes #1, #2, #3.` . -->
