### PR TITLE
Page cover

### DIFF
--- a/inc/views/cover_header.php
+++ b/inc/views/cover_header.php
@@ -75,32 +75,32 @@ class Cover_Header extends Base_View {
 			$cover_style = 'style="' . $cover_style . '"';
 		}
 
-		$hide_title = false;
 		if ( $context === 'page' ) {
 			$hide_title          = get_theme_mod( 'neve_page_hide_title', false );
 			$specific_hide_title = get_post_meta( get_the_ID(), 'neve_meta_disable_title', true );
-			if ( ! empty( $specific_hide_title ) ) {
-				$hide_title = $specific_hide_title === 'on';
+			$hide_title          = ! empty( $specific_hide_title ) ? $specific_hide_title === 'on' : $hide_title;
+			if ( $hide_title ) {
+				return;
 			}
 		}
 
 		echo '<div class="nv-post-cover" ' . wp_kses_post( $cover_style ) . '>';
 		echo '<div class="nv-overlay"></div>';
 		echo $container_mode === 'contained' ? '<div class="container">' : '';
+		echo '<div class="' . esc_attr( implode( ' ', $title_meta_wrap_classes ) ) . '">';
 
-		if ( ! $hide_title ) {
-			echo '<div class="' . esc_attr( implode( ' ', $title_meta_wrap_classes ) ) . '">';
-			if ( $meta_before === true ) {
-				Post_Layout::render_post_meta();
-			}
-			do_action( 'neve_before_post_title' );
-			echo '<h1 class="title entry-title">' . wp_kses_post( get_the_title() ) . '</h1>';
-			if ( $meta_before === false ) {
-				Post_Layout::render_post_meta();
-			}
-			echo '</div>';
+		if ( $meta_before === true ) {
+			Post_Layout::render_post_meta();
 		}
 
+		do_action( 'neve_before_post_title' );
+
+		echo '<h1 class="title entry-title">' . wp_kses_post( get_the_title() ) . '</h1>';
+		if ( $meta_before === false ) {
+			Post_Layout::render_post_meta();
+		}
+
+		echo '</div>';
 		echo $container_mode === 'contained' ? '</div>' : '';
 		echo '</div>';
 	}


### PR DESCRIPTION
### Summary
Hide the whole cover if the title is disabled from meta.

### Will affect visual aspect of the product
YES


### Test instructions
- Enable page cover
- Disable the title from a page meta
- Check the page, the cover should disappear, not just the title in that cover

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1758.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
