### PR TITLE
fix: react errors from radio-image control

### DIFF
--- a/assets/apps/components/src/Controls/RadioImage.js
+++ b/assets/apps/components/src/Controls/RadioImage.js
@@ -40,34 +40,47 @@ const RadioImage = ({ choices, onClick, value, label, documentation }) => {
 				{Object.keys(choices).map((choice, index) => {
 					const { name, image, url, upsellUrl } = choices[choice];
 					const divClass = classnames([
-						{ option: true, upsell: typeof upsellUrl !== 'undefined' },
+						{
+							option: true,
+							upsell: typeof upsellUrl !== 'undefined',
+						},
 					]);
 					const buttonClass = classnames([
-						{ active: choice === value,},
+						{ active: choice === value },
 					]);
 					return (
-						<>
-							<div className={divClass} key={index}>
-								{/*eslint-disable-next-line jsx-a11y/label-has-for */}
-								<label data-option={choice}>
-									{upsellUrl && <span class="dashicons dashicons-lock"></span>}
-									<button
-										className={buttonClass}
-										onClick={(e) => {
-											e.preventDefault();
-											onClick(choice);
-										}}
-									>
-										<img
-											src={image || url}
-											alt={name || `Option ${choice}`}
-										/>
-									</button>
-									{name && <span>{name}</span>}
-								</label>
-								{upsellUrl && <a class="upsell-btn" target="_blank" href={upsellUrl}>UNLOCK <span class="dashicons dashicons-external"></span></a>}
-							</div>
-						</>
+						<div className={divClass} key={index}>
+							{/*eslint-disable-next-line jsx-a11y/label-has-for */}
+							<label data-option={choice}>
+								{upsellUrl && (
+									<span className="dashicons dashicons-lock" />
+								)}
+								<button
+									className={buttonClass}
+									onClick={(e) => {
+										e.preventDefault();
+										onClick(choice);
+									}}
+								>
+									<img
+										src={image || url}
+										alt={name || `Option ${choice}`}
+									/>
+								</button>
+								{name && <span>{name}</span>}
+							</label>
+							{upsellUrl && (
+								<a
+									rel="external noopener noreferrer"
+									className="upsell-btn"
+									target="_blank"
+									href={upsellUrl}
+								>
+									UNLOCK
+									<span className="dashicons dashicons-external" />
+								</a>
+							)}
+						</div>
 					);
 				})}
 			</div>


### PR DESCRIPTION
### Summary
Fixes some errors inside the radio-image react controls initially introduced in PR https://github.com/Codeinwp/neve/pull/3270
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check that the locked layouts inside **WooCommerce** > **Checkout** still work as before;

<!-- Issues that this pull request closes. -->
Closes #3305
<!-- Should look like this: `Closes #1, #2, #3.` . -->
