### PR TITLE
fix: grouped header items next to mega-menu not clickable

### DIFF
--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -136,6 +136,4 @@
 // Make sure the component is static if main row and has a nav
 .header--row .builder-item.has-nav {
 	position: static;
-	// Needed to fix grouped components not being interactive
-	z-index: 1;
 }

--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -136,4 +136,6 @@
 // Make sure the component is static if main row and has a nav
 .header--row .builder-item.has-nav {
 	position: static;
+	// Needed to fix grouped components not being interactive
+	z-index: 1;
 }

--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -37,6 +37,11 @@
 	text-transform: var(--textTransform, var(--bodyTextTransform));
 	padding: var(--padding, 0);
 	margin: var(--margin, 0);
+	position: relative;
+
+	&.has_menu {
+		position: unset;
+	}
 }
 
 .inherit-ff {

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1575,6 +1575,11 @@ abstract class Abstract_Builder implements Builder {
 						if ( strpos( $component_slug, 'primary-menu' ) === false && strpos( $component_slug, 'secondary-menu' ) === false ) {
 							continue;
 						}
+
+						if ( strpos( $component_slug, 'primary-menu' ) !== false && ! in_array( 'has-nav', $component_group['classes'], true ) ) {
+							$component_group['classes'][] = 'has-nav';
+						}
+
 						$component_group['classes'][] = 'has-' . $component_slug;
 					}
 				}


### PR DESCRIPTION
### Summary
- fixes issue with grouped components adjacent to mega-menu not being clickable;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Set up a mega-menu with the pro version or with classes;
- Add a button next to it in customizer; 
- The button should be clickable

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1796.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
