### PR TITLE
If a recommended plugin is installed get its version locally 

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -467,15 +467,14 @@ class Main {
 		$hash         = get_transient( $this->plugins_cache_hash_key );
 		$current_hash = substr( md5( wp_json_encode( $this->useful_plugins ) ), 0, 5 );
 
-
 		if ( $available !== false && $hash === $current_hash ) {
 			$available = json_decode( $available, true );
-
 			foreach ( $available as $slug => $args ) {
 				$available[ $slug ]['cta']        = $this->plugin_helper->get_plugin_state( $slug );
 				$available[ $slug ]['path']       = $this->plugin_helper->get_plugin_path( $slug );
 				$available[ $slug ]['activate']   = $this->plugin_helper->get_plugin_action_link( $slug );
 				$available[ $slug ]['deactivate'] = $this->plugin_helper->get_plugin_action_link( $slug, 'deactivate' );
+				$available[ $slug ]['version']    = $this->plugin_helper->get_plugin_version( $slug, $available[ $slug ]['version'] );
 			}
 
 			return $available;

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -123,15 +123,15 @@ class Plugin_Helper {
 	 * @param string $slug plugin slug.
 	 * @return string | bool
 	 */
-	public function get_active_plugin_version( $slug, $default = false ) {
+	public function get_plugin_version( $slug, $default = false ) {
 		$plugin_file = $this->get_plugin_path( $slug );
 		if ( ! is_plugin_active( $plugin_file ) ) {
 			return $default;
 		}
 
-		$plugin_data = $this->get_plugin_details( $slug );
-		if ( ! empty( $plugin_data ) && property_exists( $plugin_data, 'version' ) ) {
-			return $plugin_data['version'];
+		$plugin_data = get_plugin_data( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file );
+		if ( ! empty( $plugin_data ) && array_key_exists( 'Version', $plugin_data ) ) {
+			return $plugin_data['Version'];
 		}
 		return $default;
 	}

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -129,7 +129,7 @@ class Plugin_Helper {
 			return $default;
 		}
 
-		$plugin_data = get_plugin_data( trailingslashit( WP_PLUGIN_DIR ) . $plugin_file );
+		$plugin_data = get_plugin_data( ABSPATH . 'wp-content/plugins/' . $plugin_file );
 		if ( ! empty( $plugin_data ) && array_key_exists( 'Version', $plugin_data ) ) {
 			return $plugin_data['Version'];
 		}

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -116,4 +116,23 @@ class Plugin_Helper {
 			esc_url( network_admin_url( 'plugins.php' ) )
 		);
 	}
+
+	/**
+	 * Get plugin version.
+	 *
+	 * @param string $slug plugin slug.
+	 * @return string | bool
+	 */
+	public function get_active_plugin_version( $slug, $default = false ) {
+		$plugin_file = $this->get_plugin_path( $slug );
+		if ( ! is_plugin_active( $plugin_file ) ) {
+			return $default;
+		}
+
+		$plugin_data = $this->get_plugin_details( $slug );
+		if ( ! empty( $plugin_data ) && property_exists( $plugin_data, 'version' ) ) {
+			return $plugin_data['version'];
+		}
+		return $default;
+	}
 }


### PR DESCRIPTION
### Summary
I updated the version of recommended plugins if a plugin is already installed.

### Will affect visual aspect of the product
NO

### Test instructions
- Get this PR
- Install Otter
- Check the version of otter in the recommended plugins tab
- Edit the version in otter's main file
- Check if the version in recommended plugins is updated
- Before this, the version wouldn't change

<!-- Issues that this pull request closes. -->
Closes #3250.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
