### PR TITLE
More scroll to top icons

### DIFF
--- a/assets/apps/components/src/Common/svg.js
+++ b/assets/apps/components/src/Common/svg.js
@@ -395,6 +395,91 @@ const SVG = {
 			/>
 		</svg>
 	),
+	sttIcon1: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			role="img"
+			width="15"
+			height="15"
+			preserveAspectRatio="xMidYMid meet"
+			viewBox="0 0 24 24"
+		>
+			<path
+				d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6l-6 6l1.41 1.41z"
+				fill="currentColor"
+			></path>
+		</svg>
+	),
+	sttIcon2: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			role="img"
+			width="15"
+			height="15"
+			preserveAspectRatio="xMidYMid meet"
+			viewBox="0 0 24 24"
+		>
+			<path
+				d="M7.41 18.41L6 17l6-6l6 6l-1.41 1.41L12 13.83l-4.59 4.58m0-6L6 11l6-6l6 6l-1.41 1.41L12 7.83l-4.59 4.58z"
+				fill="currentColor"
+			></path>
+		</svg>
+	),
+	sttIcon3: (
+		<svg width="15" height="15" aria-hidden="true" viewBox="0 0 448 512">
+			<path
+				fill="currentColor"
+				d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
+			/>
+		</svg>
+	),
+	sttIcon4: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			role="img"
+			width="15"
+			height="15"
+			preserveAspectRatio="xMidYMid meet"
+			viewBox="0 0 24 24"
+		>
+			<path
+				d="M15 20H9v-8H4.16L12 4.16L19.84 12H15v8z"
+				fill="currentColor"
+			></path>
+		</svg>
+	),
+	sttIcon5: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			role="img"
+			width="15"
+			height="15"
+			preserveAspectRatio="xMidYMid meet"
+			viewBox="0 0 24 24"
+		>
+			<path d="M7 15l5-5l5 5H7z" fill="currentColor"></path>
+		</svg>
+	),
+	sttIcon6: (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			aria-hidden="true"
+			role="img"
+			width="15"
+			height="15"
+			preserveAspectRatio="xMidYMid meet"
+			viewBox="0 0 24 24"
+		>
+			<path
+				d="M4.08 11.92L12 4l7.92 7.92l-1.42 1.41l-5.5-5.5V22h-2V7.83l-5.5 5.5l-1.42-1.41M12 4h10V2H2v2h10z"
+				fill="currentColor"
+			></path>
+		</svg>
+	),
 };
 
 export default SVG;

--- a/assets/apps/components/src/Common/svg.js
+++ b/assets/apps/components/src/Common/svg.js
@@ -397,87 +397,82 @@ const SVG = {
 	),
 	sttIcon1: (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			role="img"
+			xmlns="http://www.w3.org/2000/svg"
 			width="15"
 			height="15"
-			preserveAspectRatio="xMidYMid meet"
-			viewBox="0 0 24 24"
+			viewBox="0 0 15 15"
 		>
-			<path
-				d="M7.41 15.41L12 10.83l4.59 4.58L18 14l-6-6l-6 6l1.41 1.41z"
-				fill="currentColor"
-			></path>
+			<rect width="15" height="15" fill="none" />
+			<path d="M2,8.48l-.65-.65a.71.71,0,0,1,0-1L7,1.14a.72.72,0,0,1,1,0l5.69,5.7a.71.71,0,0,1,0,1L13,8.48a.71.71,0,0,1-1,0L8.67,4.94v8.42a.7.7,0,0,1-.7.7H7a.7.7,0,0,1-.7-.7V4.94L3,8.47a.7.7,0,0,1-1,0Z" />
 		</svg>
 	),
 	sttIcon2: (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			role="img"
+			xmlns="http://www.w3.org/2000/svg"
 			width="15"
 			height="15"
-			preserveAspectRatio="xMidYMid meet"
-			viewBox="0 0 24 24"
+			viewBox="0 0 15 15"
 		>
-			<path
-				d="M7.41 18.41L6 17l6-6l6 6l-1.41 1.41L12 13.83l-4.59 4.58m0-6L6 11l6-6l6 6l-1.41 1.41L12 7.83l-4.59 4.58z"
-				fill="currentColor"
-			></path>
+			<rect width="15" height="15" fill="none" />
+			<path d="M14,12a1,1,0,0,1-.73-.32L7.5,5.47,1.76,11.65a1,1,0,0,1-1.4,0A1,1,0,0,1,.3,10.3l6.47-7a1,1,0,0,1,1.46,0l6.47,7a1,1,0,0,1-.06,1.4A1,1,0,0,1,14,12Z" />
 		</svg>
 	),
 	sttIcon3: (
-		<svg width="15" height="15" aria-hidden="true" viewBox="0 0 448 512">
-			<path
-				fill="currentColor"
-				d="M34.9 289.5l-22.2-22.2c-9.4-9.4-9.4-24.6 0-33.9L207 39c9.4-9.4 24.6-9.4 33.9 0l194.3 194.3c9.4 9.4 9.4 24.6 0 33.9L413 289.4c-9.5 9.5-25 9.3-34.3-.4L264 168.6V456c0 13.3-10.7 24-24 24h-32c-13.3 0-24-10.7-24-24V168.6L69.2 289.1c-9.3 9.8-24.8 10-34.3.4z"
-			/>
+		<svg
+			aria-hidden="true"
+			role="img"
+			xmlns="http://www.w3.org/2000/svg"
+			width="15"
+			height="15"
+			viewBox="0 0 15 15"
+		>
+			<rect width="15" height="15" fill="none" />
+			<path d="M14.71,10.3l-6.48-7a1,1,0,0,0-1.46,0l-6.48,7A1,1,0,0,0,1,12H14a1,1,0,0,0,.73-1.68Z" />
 		</svg>
 	),
 	sttIcon4: (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			role="img"
+			xmlns="http://www.w3.org/2000/svg"
 			width="15"
 			height="15"
-			preserveAspectRatio="xMidYMid meet"
-			viewBox="0 0 24 24"
+			viewBox="0 0 15 15"
 		>
-			<path
-				d="M15 20H9v-8H4.16L12 4.16L19.84 12H15v8z"
-				fill="currentColor"
-			></path>
+			<rect width="15" height="15" fill="none" />
+			<path d="M13,15a1,1,0,0,1-.74-.32L7.5,9.46l-4.76,5.2A1,1,0,1,1,1.26,13.3l5.5-6a1,1,0,0,1,1.48,0l5.5,6a1,1,0,0,1-.06,1.42A1.05,1.05,0,0,1,13,15Z" />
+			<path d="M13,8a1,1,0,0,1-.74-.33L7.5,2.49,2.74,7.68A1,1,0,0,1,1.26,6.33l5.5-6a1,1,0,0,1,1.48,0l5.5,6A1,1,0,0,1,13,8Z" />
 		</svg>
 	),
 	sttIcon5: (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			role="img"
+			xmlns="http://www.w3.org/2000/svg"
 			width="15"
 			height="15"
-			preserveAspectRatio="xMidYMid meet"
-			viewBox="0 0 24 24"
+			viewBox="0 0 15 15"
 		>
-			<path d="M7 15l5-5l5 5H7z" fill="currentColor"></path>
+			<rect width="15" height="15" fill="none" />
+			<path d="M2,10.91l-.65-.65a.69.69,0,0,1,0-1L7,3.57a.72.72,0,0,1,1,0l5.69,5.7a.71.71,0,0,1,0,1l-.65.65a.71.71,0,0,1-1,0L8.67,7.37v6.56a.7.7,0,0,1-.7.7H7a.7.7,0,0,1-.7-.7V7.37L3,10.9A.69.69,0,0,1,2,10.91Z" />
+			<rect x="1" y="0.37" width="13" height="2" rx="0.4" />
 		</svg>
 	),
 	sttIcon6: (
 		<svg
-			xmlns="http://www.w3.org/2000/svg"
 			aria-hidden="true"
 			role="img"
+			xmlns="http://www.w3.org/2000/svg"
 			width="15"
 			height="15"
-			preserveAspectRatio="xMidYMid meet"
-			viewBox="0 0 24 24"
+			viewBox="0 0 15 15"
 		>
-			<path
-				d="M4.08 11.92L12 4l7.92 7.92l-1.42 1.41l-5.5-5.5V22h-2V7.83l-5.5 5.5l-1.42-1.41M12 4h10V2H2v2h10z"
-				fill="currentColor"
-			></path>
+			<rect width="15" height="15" fill="none" />
+			<path d="M7.86,1.93l5.83,10.2a.8.8,0,0,1-1.08,1.1L8,10.65a.83.83,0,0,0-.78,0L2.39,13.36a.79.79,0,0,1-1.1-1L6.45,2A.8.8,0,0,1,7.86,1.93Z" />
 		</svg>
 	),
 };

--- a/assets/apps/customizer-controls/src/radio-buttons/RadioButtonsComponent.js
+++ b/assets/apps/customizer-controls/src/radio-buttons/RadioButtonsComponent.js
@@ -148,6 +148,33 @@ const RadioButtonsComponent = ({ control }) => {
 						icon: SVG.paletteIconStyle4,
 					},
 				};
+			case 'scroll_to_top':
+				return {
+					'stt-icon-style-1': {
+						tooltip: __('Icon Style 1', 'neve'),
+						icon: SVG.sttIcon1,
+					},
+					'stt-icon-style-2': {
+						tooltip: __('Icon Style 2', 'neve'),
+						icon: SVG.sttIcon2,
+					},
+					'stt-icon-style-3': {
+						tooltip: __('Icon Style 3', 'neve'),
+						icon: SVG.sttIcon3,
+					},
+					'stt-icon-style-4': {
+						tooltip: __('Icon Style 4', 'neve'),
+						icon: SVG.sttIcon4,
+					},
+					'stt-icon-style-5': {
+						tooltip: __('Icon Style 5', 'neve'),
+						icon: SVG.sttIcon5,
+					},
+					'stt-icon-style-6': {
+						tooltip: __('Icon Style 6', 'neve'),
+						icon: SVG.sttIcon6,
+					},
+				};
 		}
 	};
 	const { label, large_buttons, showLabels } = control.params;

--- a/start.php
+++ b/start.php
@@ -16,6 +16,7 @@ function neve_run() {
 			'repeater_control'      => true,
 			'malformed_div_on_shop' => true,
 			'mega_menu'             => true,
+			'scroll_to_top_icons'   => true,
 		]
 	);
 	$vendor_file = trailingslashit( get_template_directory() ) . 'vendor/autoload.php';


### PR DESCRIPTION
### Summary
Adds 6 icon choices for scroll to top created by @mghenciu here: https://www.figma.com/file/QklXyJh0XHVzq2h4IpPNaz/Neve-options?node-id=2334%3A19104

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/10324144/148802896-43bec103-571f-4039-b069-029be6de5af3.png)
### Test instructions
<!-- Describe how this pull request can be tested. -->

- Switch between different icons, they should change the icon in the scroll to top button

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1575
<!-- Should look like this: `Closes #1, #2, #3.` . -->
