### PR TITLE
Remove secondary button style added in Neve

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -48,6 +48,9 @@ const Start = (props) => {
 		);
 	};
 
+	const ConditionalWrapper = ({ condition, wrapper, children }) =>
+		condition ? wrapper(children) : children;
+
 	return (
 		<>
 			{!starterSitesHidden && (
@@ -59,12 +62,12 @@ const Start = (props) => {
 					{!neveDash.isValidLicense && (
 						<p>{neveDash.strings.starterSitesCardUpsellMessage}</p>
 					)}
-					<div
-						className={
-							!neveDash.isValidLicense
-								? 'card-button-group'
-								: 'card-button'
-						}
+
+					<ConditionalWrapper
+						condition={!neveDash.isValidLicense}
+						wrapper={(children) => (
+							<div className="card-button-group">{children}</div>
+						)}
 					>
 						{tabs['starter-sites'] ? (
 							<Button
@@ -88,7 +91,7 @@ const Start = (props) => {
 								{__('Get Neve Pro', 'neve')}
 							</Button>
 						)}
-					</div>
+					</ConditionalWrapper>
 				</Card>
 			)}
 			<Card

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -48,9 +48,6 @@ const Start = (props) => {
 		);
 	};
 
-	const ConditionalWrapper = ({ condition, wrapper, children }) =>
-		condition ? wrapper(children) : children;
-
 	return (
 		<>
 			{!starterSitesHidden && (
@@ -63,12 +60,7 @@ const Start = (props) => {
 						<p>{neveDash.strings.starterSitesCardUpsellMessage}</p>
 					)}
 
-					<ConditionalWrapper
-						condition={!neveDash.isValidLicense}
-						wrapper={(children) => (
-							<div className="card-button-group">{children}</div>
-						)}
-					>
+					<div className="card-button-wrap">
 						{tabs['starter-sites'] ? (
 							<Button
 								isPrimary
@@ -91,7 +83,7 @@ const Start = (props) => {
 								{__('Get Neve Pro', 'neve')}
 							</Button>
 						)}
-					</ConditionalWrapper>
+					</div>
 				</Card>
 			)}
 			<Card

--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -51,10 +51,15 @@
 		margin: 15px 0 25px;
 	}
 
-  	.card-button-group {
-	  display: grid;
-	  grid-template-columns: min-content min-content;
-	  column-gap: 10px;
+	.card-button-wrap {
+	  display: flex;
+	  margin-top: auto;
+	  a {
+		margin-left: 10px;
+		&:first-child {
+		  margin: 0;
+		}
+	  }
 	}
 }
 

--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -36,16 +36,9 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-
 		a, button {
-			align-self: flex-start;
-			margin-right: 10px;
-			margin-top: auto;
-
-			&.is-secondary {
-				outline: 1px solid;
-				font-weight: 800;
-			}
+		  align-self: flex-start;
+		  margin-top: auto;
 		}
 	}
 
@@ -58,16 +51,11 @@
 		margin: 15px 0 25px;
 	}
 
-	.card-button {
-		margin-top: 60px;
+  	.card-button-group {
+	  display: grid;
+	  grid-template-columns: min-content min-content;
+	  column-gap: 10px;
 	}
-
-	.card-button-group {
-		.components-button.is-secondary {
-			margin-top: 10px;
-		}
-	}
-
 }
 
 @mixin card--laptop() {


### PR DESCRIPTION
### Summary
- I removed the custom style added for the secondary button from the Starter sites card
- I refactored the component so the buttons would have a wrapper only if the pro is active and there are two buttons
- Changed the CSS to display grid to easily add a gap between buttons

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
- Check the Starter sites card when pro is not active and check the secondary button. It should look like other secondary buttons
- Check the Starter sites card when pro is active. The button should hold its position ( bottom of the card )

<!-- Issues that this pull request closes. -->
Closes #3311.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
