### PR TITLE
chore: open Get Neve Pro button in new tab

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -87,7 +87,7 @@ const Start = (props) => {
 								href={neveDash.startSitesgetNeveProURL}
 								isSecondary
 							>
-								<span class="components-visually-hidden">
+								<span className="components-visually-hidden">
 									(opens in a new tab)
 								</span>
 								{__('Get Neve Pro', 'neve')}

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -87,10 +87,10 @@ const Start = (props) => {
 								href={neveDash.startSitesgetNeveProURL}
 								isSecondary
 							>
-								<span className="components-visually-hidden">
-									(opens in a new tab)
-								</span>
 								{__('Get Neve Pro', 'neve')}
+								<span className="components-visually-hidden">
+									{__('(opens in a new tab)', 'neve')}
+								</span>
 							</Button>
 						)}
 					</div>

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -82,9 +82,14 @@ const Start = (props) => {
 						)}
 						{!neveDash.isValidLicense && (
 							<Button
+								target="_blank"
+								rel="external noreferrer noopener"
 								href={neveDash.startSitesgetNeveProURL}
 								isSecondary
 							>
+								<span class="components-visually-hidden">
+									(opens in a new tab)
+								</span>
 								{__('Get Neve Pro', 'neve')}
 							</Button>
 						)}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Opens Get Neve Pro button in a new tab when clicked.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/10324144/148816931-22a72111-35b6-407f-ae49-b1999f6e87a1.png)

### Test instructions
- Click the "Get Neve Pro" button, it should open in a new tab

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1739
<!-- Should look like this: `Closes #1, #2, #3.` . -->
