### PR TITLE
chore: fix sanitization for background customizer control

### DIFF
--- a/assets/apps/components/src/Controls/Background.js
+++ b/assets/apps/components/src/Controls/Background.js
@@ -14,33 +14,6 @@ import { MediaUpload } from '@wordpress/media-utils';
 import ColorControl from './ColorControl';
 
 const Background = ({ onChange, value, label, description }) => {
-	const getButtons = () => {
-		const types = ['color', 'image'];
-		const labels = {
-			color: __('Color', 'neve'),
-			image: __('Image', 'neve'),
-		};
-
-		const buttons = [];
-		types.map((type, index) => {
-			buttons.push(
-				<Button
-					key={index}
-					isPrimary={value.type === type}
-					isSecondary={value.type !== type}
-					onClick={() => {
-						onChange({ type });
-					}}
-				>
-					{labels[type]}
-				</Button>
-			);
-			return type;
-		});
-
-		return buttons;
-	};
-
 	const {
 		type,
 		colorValue,
@@ -52,15 +25,41 @@ const Background = ({ onChange, value, label, description }) => {
 		overlayOpacity,
 	} = value;
 
+	const getButtons = () => {
+		const types = ['color', 'image'];
+		const labels = {
+			color: __('Color', 'neve'),
+			image: __('Image', 'neve'),
+		};
+
+		const buttons = [];
+		types.forEach((buttonType, index) => {
+			buttons.push(
+				<Button
+					key={index}
+					isPrimary={value.type === buttonType}
+					isSecondary={value.type !== buttonType}
+					onClick={() => {
+						onChange({ type: buttonType });
+					}}
+				>
+					{labels[buttonType]}
+				</Button>
+			);
+		});
+
+		return (
+			<ButtonGroup className="neve-background-type-control">
+				{buttons}
+			</ButtonGroup>
+		);
+	};
+
 	return (
 		<div className="neve-background-control">
 			{label && <span className="customize-control-title">{label}</span>}
 			{description && <p>{description}</p>}
-			<div className="control--top-toolbar">
-				<ButtonGroup className="neve-background-type-control">
-					{getButtons()}
-				</ButtonGroup>
-			</div>
+			<div className="control--top-toolbar">{getButtons()}</div>
 			<div className="control--body">
 				{type === 'color' && (
 					<>

--- a/globals/sanitize-functions.php
+++ b/globals/sanitize-functions.php
@@ -144,6 +144,37 @@ function neve_sanitize_background( $value ) {
 		return new WP_Error();
 	}
 
+	if ( ! isset( $value['focusPoint'] ) ) {
+		$value['focusPoint'] = [
+			'x' => 0.5,
+			'y' => 0.5,
+		];
+	}
+
+	foreach ( $value['focusPoint'] as $coordinate => $val ) {
+		if ( is_numeric( $val ) ) {
+			continue;
+		}
+
+		$val = 0;
+
+		$value['focusPoint'][ $coordinate ] = $val;
+	}
+
+
+	$value['imageUrl']          = esc_url( $value['imageUrl'] );
+	$value['colorValue']        = neve_sanitize_colors( $value['colorValue'] );
+	$value['overlayColorValue'] = neve_sanitize_colors( $value['overlayColorValue'] );
+
+
+	$value['overlayOpacity'] = (int) $value['overlayOpacity'];
+	if ( $value['overlayOpacity'] > 100 || $value['overlayOpacity'] < 0 ) {
+		$value['overlayOpacity'] = 50;
+	}
+
+	$value['fixed']       = (bool) $value['fixed'];
+	$value['useFeatured'] = (bool) $value['useFeatured'];
+
 	return $value;
 }
 

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1217,7 +1217,7 @@ abstract class Abstract_Builder implements Builder {
 						'--bgPosition'       => [
 							Dynamic_Selector::META_KEY    => $this->control_id . '_' . $row_index . '_background',
 							Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
-								if ( empty( $value['focusPoint'] ) || empty( $value['focusPoint']['x'] ) || empty( $value['focusPoint']['y'] ) ) {
+								if ( ! $this->is_valid_focus_point( $value['focusPoint'] ) ) {
 									return '';
 								}
 

--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -420,7 +420,7 @@ class Header extends Abstract_Builder {
 					'--bgPosition'       => [
 						Dynamic_Selector::META_KEY    => $control_id,
 						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
-							if ( empty( $value['focusPoint'] ) || empty( $value['focusPoint']['x'] ) || empty( $value['focusPoint']['y'] ) ) {
+							if ( ! $this->is_valid_focus_point( $value['focusPoint'] ) ) {
 								return '';
 							}
 

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -109,4 +109,27 @@ trait Core {
 
 		return array();
 	}
+
+	/**
+	 * Checks that a focus point array is valid.
+	 *
+	 * @param array $input coordinates array [x=>number, y=>number].
+	 *
+	 * @return bool
+	 */
+	public function is_valid_focus_point( $input ) {
+		if ( ! is_array( $input ) ) {
+			return false;
+		}
+
+		if ( ! isset( $input['x'] ) || ! isset( $input['y'] ) ) {
+			return false;
+		}
+
+		if ( ! is_numeric( $input['x'] ) || ! is_numeric( $input['y'] ) ) {
+			return false;
+		}
+
+		return true;
+	}
 }


### PR DESCRIPTION
### Summary
Fixes sanitization for Background customizer control
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure WP_DEBUG is turned on;
- Inside customizer go to an HFB row settings panel;
- Set a background image and delete both of the values inside the position fields under the image;
- Save the customizer options;
- There should be no warning on the front end;
- Upon reloading the customizer, these values should be 0;

<!-- Issues that this pull request closes. -->
Closes #3300.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
