### PR TITLE
fix: root css properties outputted twice when using dark mode toggle

### DIFF
--- a/header-footer-grid/Core/Components/PaletteSwitch.php
+++ b/header-footer-grid/Core/Components/PaletteSwitch.php
@@ -251,7 +251,7 @@ class PaletteSwitch extends Abstract_Component {
 			return '';
 		}
 
-		$css                                 .= ' ';
+		$style                                = ' ';
 		$auto_adjust                          = Mods::get( $this->get_id() . '_' . self::AUTO_ADJUST, 0 );
 		list( $palette_light, $palette_dark ) = $this->get_light_dark_palettes();
 
@@ -266,7 +266,7 @@ class PaletteSwitch extends Abstract_Component {
 		}
 
 		if ( $auto_adjust && ! is_customize_preview() ) {
-			$css .= '
+			$style .= '
 				/* Light mode */
 				@media (prefers-color-scheme: light) {
 				  :root{
@@ -283,7 +283,7 @@ class PaletteSwitch extends Abstract_Component {
 			';
 		}
 
-		return $css . '
+		$style .= '
 		[data-neve-theme="light"], html.neve-light-theme {
 			' . $light_css . '
 		}
@@ -291,6 +291,8 @@ class PaletteSwitch extends Abstract_Component {
 			' . $dark_css . '
 		}
 		';
+
+		return $style;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The color palette and fallback font `:root` CSS properties were outputted twice when using the palette switcher inside HFB.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add the palette switcher to the header;
- The switch should still work fine;
- It should still work fine with the `Automatically adjust color scheme` option inside the customizer;
- In the inspector, when scrolling the styles panel all the way down (like in the issue screenshot), the root variables should not be available twice;

<!-- Issues that this pull request closes. -->
Closes #3317.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
