### PR TITLE
chore: remove global color palette support on fluent crm admin screen

### DIFF
--- a/inc/compatibility/generic.php
+++ b/inc/compatibility/generic.php
@@ -23,6 +23,10 @@ class Generic {
 		if ( class_exists( 'Mega_Menu', false ) ) {
 			add_filter( 'megamenu_themes', array( $this, 'max_megamenu_theme' ) );
 		}
+
+		if ( defined( 'FLUENTCRM' ) ) {
+			$this->fcrm_disable_global_color_palette();
+		}
 	}
 
 	/**
@@ -60,4 +64,30 @@ class Generic {
 		return $themes;
 	}
 
+	/**
+	 * FluentCRM compatibility.
+	 *
+	 * Disables global color palette for the FluentCRM editing screen.
+	 *
+	 * @return void
+	 */
+	public function fcrm_disable_global_color_palette() {
+		if ( ! is_admin() ) {
+			return;
+		}
+
+		if ( ! isset( $_GET['page'] ) ) {
+			return;
+		}
+
+		if ( $_GET['page'] !== 'fluentcrm-admin' ) {
+			return;
+		}
+		add_action(
+			'init',
+			function () {
+				remove_theme_support( 'editor-color-palette' );
+			}
+		);
+	}
 }


### PR DESCRIPTION
### Summary
Removes global color palette on FluentCRM admin screens.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install Fluent CRM;
- Go here: `/wp-admin/admin.php?page=fluentcrm-admin#/email/templates` and create a new template;
- Our global colors should not be visible here;
- Global colors should however work just fine everywhere else (in the post editor, widgets screen);
- As explained [here](https://github.com/Codeinwp/neve/issues/3070#issuecomment-1009370816), this is not really our fault;

<!-- Issues that this pull request closes. -->
Closes #3070.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
