### PR TITLE
fix: allow additional classes on mega-menu column items [closes #3153]

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -97,7 +97,13 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		}
 
 		if ( isset( $item->title ) && $item->title === 'divider' ) {
-			$output .= '<li role="presentation" class="neve-mm-divider">';
+			$classes = [ 'neve-mm-divider' ];
+
+			if ( isset( $item->classes ) ) {
+				$classes = array_merge( $classes, $item->classes );
+			}
+
+			$output .= '<li role="presentation" class="' . esc_attr( join( ' ', $classes ) ) . '">';
 
 			return;
 		}
@@ -154,19 +160,6 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		}
 
 		if ( in_array( 'neve-mm-heading', $item->classes, true ) ) {
-			add_filter(
-				'nav_menu_css_class',
-				function ( $classes, $nav_item, $args, $depth ) use ( $item ) {
-					if ( $nav_item !== $item ) {
-						return $classes;
-					}
-
-					return array( 'neve-mm-heading' );
-				},
-				10,
-				4
-			);
-
 			if ( $item->url === '#' ) {
 				add_filter(
 					'walker_nav_menu_start_el',

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -103,7 +103,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		}
 
 		if ( isset( $item->classes ) && in_array( 'neve-mm-col', $item->classes, true ) ) {
-			$output .= '<li class="neve-mm-col">';
+			$output .= '<li class="' . esc_attr( join( ' ', $item->classes ) ) . '">';
 
 			return;
 		}


### PR DESCRIPTION
### Summary
Allows additional classes on the mega-menu columns.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a mega-menu with the documentation [here](https://docs.themeisle.com/article/964-neve-mega-menu-setup);  
- Try adding additional classes to the column elements. These should appear inside the inspector on the front-end;
- It should work with both the free version and the pro version using both mega-menu approaches;

<!-- Issues that this pull request closes. -->
Closes #3153.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
