### PR TITLE
Fix: Date in meta should not break

### DIFF
--- a/assets/scss/components/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/components/elements/blog/_blogpost-meta.scss
@@ -1,6 +1,8 @@
 @import "../../main/variables";
 
 .nv-meta-list {
+	display: flex;
+	flex-wrap: wrap;
 	margin-bottom: $spacing-md;
 	font-size: $text-sm;
 

--- a/assets/scss/components/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/components/elements/blog/_blogpost-meta.scss
@@ -1,14 +1,12 @@
 @import "../../main/variables";
 
 .nv-meta-list {
-	display: flex;
-	flex-wrap: wrap;
 	margin-bottom: $spacing-md;
 	font-size: $text-sm;
 
 	li,
 	span {
-		display: inline;
+		display: inline-block;
 
 		&:not(:last-child)::after {
 			content: "/";


### PR DESCRIPTION
### Summary
This should fix the date in the meta on the blog archive.

### Will affect visual aspect of the product

YES

### Screenshots <!-- if applicable -->

### Test instructions
- This https://snipboard.io/hlPAEc.jpg should not happen anymore
- If a date is too long, the whole date should be on a new row, not just the year or a part of it.
- Also check meta on a single post and make sure nothing breaks there.
- 
- 

<!-- Issues that this pull request closes. -->
Closes #3222.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
