### PR TITLE
fix: stripping of spaces from footer copyright component

### DIFF
--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -23,7 +23,7 @@
 }
 
 .component-wrap {
-	display: flex;
+	display: block;
 	margin: 4px 0;
 }
 

--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -23,7 +23,7 @@
 }
 
 .component-wrap {
-	display: block;
+	display: flex;
 	margin: 4px 0;
 }
 

--- a/header-footer-grid/templates/components/component-copyright.php
+++ b/header-footer-grid/templates/components/component-copyright.php
@@ -15,6 +15,8 @@ use HFG\Core\Components\Copyright;
 $content = component_setting( Copyright::CONTENT_ID );
 ?>
 <div class="component-wrap">
-	<?php echo wp_kses_post( balanceTags( parse_dynamic_tags( $content ), true ) ); ?>
+	<div>
+		<?php echo wp_kses_post( balanceTags( parse_dynamic_tags( $content ), true ) ); ?>
+	</div>
 </div>
 


### PR DESCRIPTION
### Summary
fix stripping of spaces from copyright component

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions

- Add the copyright component in the footer
- Add the following text to the copyright component:
` <a href="https://themeisle.com/themes/neve/" rel="nofollow">Neve</a> powered by <a href="http://wordpress.org" rel="nofollow">WordPress</a>
`
- Check the frontend, with this fix the spaces should be present. Without this fix the spaces are stripped

<!-- Issues that this pull request closes. -->
Closes #3325
<!-- Should look like this: `Closes #1, #2, #3.` . -->
