### PR TITLE
fix: solve customizer display old skin

### DIFF
--- a/inc/customizer/options/base_layout_single.php
+++ b/inc/customizer/options/base_layout_single.php
@@ -86,12 +86,14 @@ abstract class Base_Layout_Single extends Base_Customizer {
 	 * @return void
 	 */
 	public function add_controls() {
-		if ( ! neve_is_new_skin() ) {
+		if ( ! neve_is_new_skin() && $this->post_type !== 'post' ) {
 			return;
 		}
 		$this->create_section();
-		$this->add_header_layout_subsection();
-		$this->add_header_layout_controls();
+		if ( neve_is_new_skin() ) {
+			$this->add_header_layout_subsection();
+			$this->add_header_layout_controls();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Fixxed Single Post section not being displayed for old skin.

### Will affect visual aspect of the product
NO


### Test instructions
1. Check that on the old skin in Customizer > Layout > Single Post is being displayed
2. Check that this works with Free and PRO

<!-- Issues that this pull request closes. -->
Closes #3299
