### PR TITLE
Product variations alignment

### DIFF
--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -155,9 +155,11 @@
 			}
 		}
 
-		tr:not(:last-child) {
+		tr{
+		  display: block;
+		  &:not(:last-child) {
 			margin-bottom: $spacing-xs;
-			display: block;
+		  }
 		}
 	}
 


### PR DESCRIPTION
### Summary
Fix the alignment of variations on the single product page

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->

### Test instructions

With just Neve installed:
- Create a variable product or import WooCommerce sample data
- Add 2 or 3 variations of a product
- Check on the product page and see if everything works

Enable Neve Pro
- Enable variation swatches submodule
- Change a variation to colors or labels
- Check the single product
- Enable variations on the shop and check there as well

<!-- Issues that this pull request closes. -->
Closes #3331.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
