### PR TITLE
[Fix] header elements runs when elementor header replace the theme's header

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -19,6 +19,7 @@ use HFG\Core\Interfaces\Component;
 use HFG\Core\Settings;
 use HFG\Core\Settings\Manager as SettingsManager;
 use HFG\Traits\Core;
+use Neve\Compatibility\Elementor;
 use Neve\Core\Settings\Config;
 use Neve\Core\Styles\Dynamic_Selector;
 use Neve\Customizer\Controls\React\Instructions_Section;
@@ -844,6 +845,16 @@ abstract class Abstract_Builder implements Builder {
 	 * @return bool Is used?
 	 */
 	public function is_component_active( $component_id ) {
+
+		/**
+		 * If a component is part of header or footer but the header or footer are replaced by Elementor
+		 * the component should not run.
+		 */
+		$location = $this->get_id();
+		if ( in_array( $location, [ 'header', 'footer' ] ) && Elementor::is_elementor_template( $location ) ) {
+			return false;
+		}
+
 		if ( empty( $this->active_components ) ) {
 			$components = [];
 

--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -107,7 +107,10 @@ class CartIcon extends Abstract_Component {
 		return '
 			(function($){
 				$(\'body\').on( \'added_to_cart\', function(){
-					document.querySelector( \'.responsive-nav-cart\' ).classList.remove(\'cart-is-empty\');
+					var responsiveCart = document.querySelector( \'.responsive-nav-cart\' );
+					if ( responsiveCart ) {
+						responsiveCart.classList.remove(\'cart-is-empty\');
+					}
 				});
 			})(jQuery);
 		';

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -303,7 +303,7 @@ class Elementor extends Page_Builder_Base {
 	 * @param  string $cond Template showing condition it can be product_archive, product etc.
 	 * @return bool
 	 */
-	public static function is_elementor_template( $location, $cond ) {
+	public static function is_elementor_template( $location, $cond = '' ) {
 		if ( ! did_action( 'elementor_pro/init' ) ) {
 			return false;
 		}
@@ -313,6 +313,10 @@ class Elementor extends Page_Builder_Base {
 		$conditions_manager = \ElementorPro\Plugin::instance()->modules_manager->get_modules( 'theme-builder' )->get_conditions_manager();
 
 		$documents = $conditions_manager->get_documents_for_location( $location );
+
+		if ( empty( $cond ) ) {
+			return ! empty( $documents );
+		}
 
 		foreach ( $documents as $document ) {
 			$conditions = $conditions_manager->get_document_conditions( $document );


### PR DESCRIPTION
### Summary
Prevent components from running if the header/footer are replaced by Elementor Pro

### Will affect visual aspect of the product
NO


### Test instructions
- Add the cart component in the header in the customizer
- Create a header in Elementor pro
- Try to add a product to cart ( there should not be any errors in console )
- Disable the header from Elementor
- The mini cart should still work
- Try to have both a header and a footer in elementor and check if any errors are present

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1823.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
