### PR TITLE
Fix: make dropdown arrow an actual button [ref #3258]

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -54,6 +54,13 @@
 		}
 	}
 
+	.caret-wrap {
+		background-color: unset;
+		color: unset;
+		outline: 0;
+		padding: 0;
+	}
+
 	.caret {
 		display: flex;
 		margin-left: 5px;

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -61,15 +61,12 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			return $title;
 		}
 
-		// We add tabindex for sidebar in order for the carret to  be focusable.
-		$expanded = strpos( $args->menu_id, 'sidebar' ) !== false ? 'tabindex="0"' : '';
-
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
 			$title = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
 
-			$title .= '<div ' . $expanded . ' class="caret-wrap ' . $item->menu_order . '">';
+			$title .= '<button class="caret-wrap ' . $item->menu_order . '">';
 			$title .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
-			$title .= '</div>';
+			$title .= '</button>';
 		}
 
 		return $title;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38 KB",
+			"limit": "39 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Made the dropdown arrow an actual button and removed the outline.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Have a dropdown sub-menu and test it both on desktop and mobile
- The arrow should look like before, but without the outline when focused

<!-- Issues that this pull request closes. -->
Closes #3258 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
