### PR TITLE
Fix elementor duplicate select field arrow

### DIFF
--- a/assets/scss/components/elements/form-elements/_inputs.scss
+++ b/assets/scss/components/elements/form-elements/_inputs.scss
@@ -50,7 +50,7 @@ button {
 	opacity: 0.5;
 }
 
-select {
+select:not(.elementor-field-textual) {
 	min-height: 35px;
 	background-repeat: no-repeat;
 	background-position: right;

--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -23,7 +23,7 @@
 }
 
 .component-wrap {
-	display: flex;
+	display: block;
 	margin: 4px 0;
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38 KB",
+			"limit": "38.1 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
Excludes adding arrow background image on elementor select fields.  

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/10324144/150559131-5d3e3067-ae19-485c-9f7d-f44ee2c57834.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install Neve, Elementor, and Elementor Pro
- Create a form using the Form widget of Elementor Pro
- Create a select field and check its layout
- The duplicate arrow should be gone: https://vertis.d.pr/uAcfLr

<!-- Issues that this pull request closes. -->
Closes #3255
<!-- Should look like this: `Closes #1, #2, #3.` . -->
