### PR TITLE
set card external link color

### DIFF
--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -61,6 +61,10 @@
 		}
 	  }
 	}
+
+	.components-external-link{
+		color: #2271b1;
+	}
 }
 
 @mixin card--laptop() {

--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -63,7 +63,7 @@
 	}
 
 	.components-external-link{
-		color: #2271b1;
+		color: $blue;
 	}
 }
 


### PR DESCRIPTION
### Summary
By default the external link pulls the color from WP admin css, this change specifies an external link color for cards component so it's not changed by the admin theme

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Change the WordPress admin profile theme to the modern theme: https://prnt.sc/26js45b
- The external link in the Templates Cloud card should not change color

<!-- Issues that this pull request closes. -->
Closes #3266
<!-- Should look like this: `Closes #1, #2, #3.` . -->
