### PR TITLE
feat: add dashboard cards for woocommerce and block editor boosters

### DIFF
--- a/assets/apps/dashboard/src/Components/Card.js
+++ b/assets/apps/dashboard/src/Components/Card.js
@@ -11,9 +11,11 @@ const Card = (props) => {
 		children,
 		classNames,
 		dashicon,
+		lockIcon,
 	} = props;
 	return (
 		<div className={classnames(['card', classNames])}>
+			{lockIcon && <Icon className="icon dashicon" icon="lock" />}
 			<div className="card-header">
 				{icon &&
 					(dashicon ? (

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -114,6 +114,7 @@ const Start = (props) => {
 					<Card
 						icon={neveDash.assets + 'template-cloud.svg'}
 						title="Templates Cloud"
+						lockIcon={!pro}
 						description={__(
 							'Boost productivity and speed up your workflow by saving all your designs and share them automatically to all your sites in 1-click.',
 							'neve'
@@ -129,6 +130,40 @@ const Start = (props) => {
 								{__('Learn how to use Templates Cloud', 'neve')}
 							</ExternalLink>
 						)}
+					</Card>
+				</>
+			)}
+			{!pro && (
+				<>
+					<Card
+						classNames="woo-card"
+						icon="cart"
+						dashicon={true}
+						lockIcon={true}
+						title={__('WooCommerce Booster', 'neve')}
+						description={__(
+							'Empower your online store with awesome new features, specially designed for smooth WooCommerce integration.',
+							'neve'
+						)}
+					>
+						<ExternalLink href="https://docs.themeisle.com/article/1058-woocommerce-booster-documentation">
+							{__('Learn more', 'neve')}
+						</ExternalLink>
+					</Card>
+					<Card
+						classNames="block-editor-card"
+						icon="block-default"
+						dashicon={true}
+						lockIcon={true}
+						title={__('Block Editor Booster', 'neve')}
+						description={__(
+							'Enhance your Gutenberg experience with new blocks, including Business Hours, Popup, Review Comparison Table and more.',
+							'neve'
+						)}
+					>
+						<ExternalLink href="https://docs.themeisle.com/article/1473-neve-block-editor-booster-module">
+							{__('Learn more', 'neve')}
+						</ExternalLink>
 					</Card>
 				</>
 			)}

--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -142,7 +142,7 @@ const Start = (props) => {
 						lockIcon={true}
 						title={__('WooCommerce Booster', 'neve')}
 						description={__(
-							'Empower your online store with awesome new features, specially designed for smooth WooCommerce integration.',
+							'Empower your online store with awesome new features, specially designed for a smooth WooCommerce integration.',
 							'neve'
 						)}
 					>

--- a/assets/apps/dashboard/src/scss/components/_card.scss
+++ b/assets/apps/dashboard/src/scss/components/_card.scss
@@ -8,6 +8,14 @@
 	padding: 30px 40px;
 	align-self: flex-start;
 	flex-grow: 0;
+	position: relative;
+
+	.dashicons-lock {
+		position: absolute;
+		top: 10px;
+		right: 10px;
+		color: rgba(0, 115, 170, 0.2);
+	}
 
 	.card-header {
 		flex-direction: row;
@@ -23,10 +31,10 @@
 			margin-right: 10px;
 
 			&.dashicon {
-				width: 33px;
-				height: 33px;
+				width: 40px;
+				height: 40px;
 				fill: $blue;
-				font-size: 33px;
+				font-size: 40px;
 				color: $blue;
 			}
 		}
@@ -36,9 +44,11 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-		a, button {
-		  align-self: flex-start;
-		  margin-top: auto;
+
+		a,
+		button {
+			align-self: flex-start;
+			margin-top: auto;
 		}
 	}
 
@@ -52,24 +62,28 @@
 	}
 
 	.card-button-wrap {
-	  display: flex;
-	  margin-top: auto;
-	  a {
-		margin-left: 10px;
-		&:first-child {
-		  margin: 0;
+		display: flex;
+		margin-top: auto;
+
+		a {
+			margin-left: 10px;
+
+			&:first-child {
+				margin: 0;
+			}
 		}
-	  }
 	}
 }
 
 @mixin card--laptop() {
+
 	.card {
 		margin: 0 0 20px;
 	}
 }
 
 @mixin card--desktop() {
+
 	.card {
 		padding: 20px 30px;
 		margin: 0 0 20px;
@@ -77,6 +91,7 @@
 }
 
 @mixin card--desktop-large() {
+
 	.card {
 		padding: 30px 40px;
 		margin: 0 0 30px;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added two new cards on the Start page of the Neve dashboard: WooCommerce Booster and Block Editor Booster.
Also, added a lock icon for those cards that describe pro features.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/39873395/151428445-a733de95-74d0-4363-8c28-aeb482366ccd.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to Neve dashboard, on the Start page
- These new cards should be displayed when the user is not pro ( WooCommerce Booster and Block Editor Booster)
- The Templates Cloud card should have the lock icon only when the user is not pro

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1673.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
