### PR TITLE
fix: change comment reply title tag to H2 [a11y][closes #2935]

### DIFF
--- a/assets/scss/components/elements/blog/_comments.scss
+++ b/assets/scss/components/elements/blog/_comments.scss
@@ -84,6 +84,8 @@
 
 .comments-title {
 	margin-bottom: $spacing-xxl;
+
+	@extend %nv-has-h4-typography;
 }
 
 

--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -47,7 +47,6 @@ class Comments extends Base_View {
 		}
 
 		if ( have_comments() ) {
-			$comment_title_tag     = neve_is_new_skin() ? 'h4' : 'h2';
 			$comments_wrap_classes = [ 'nv-comments-wrap' ];
 			$is_boxed              = get_theme_mod( 'neve_comments_boxed_layout', false );
 			if ( $is_boxed ) {
@@ -59,9 +58,9 @@ class Comments extends Base_View {
 
 				<div class="nv-comments-title-wrap">
 					<?php
-					echo '<' . esc_html( $comment_title_tag ) . ' class="comments-title">';
+					echo '<h2 class="comments-title">';
 					echo wp_kses_post( $this->get_comments_title() );
-					echo '</' . esc_html( $comment_title_tag ) . '>'
+					echo '</h2>'
 					?>
 				</div>
 
@@ -329,7 +328,7 @@ class Comments extends Base_View {
 	 * @return array
 	 */
 	public function leave_reply_title_tag( $args ) {
-		$tag = neve_is_new_skin() ? 'h4' : 'h3';
+		$tag = neve_is_new_skin() ? 'h2' : 'h3';
 
 		$args['title_reply_before'] = '<' . $tag . ' id="reply-title" class="comment-reply-title">';
 		$args['title_reply_after']  = '</' . $tag . '>';


### PR DESCRIPTION
### Summary
Changes the comment reply title to an H2 tag. 

Also updates the `# thoughts on X` heading to an H2 tag.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/15010186/152299930-65e152c7-6db9-4735-aa06-d06c85eb5626.png)
![image](https://user-images.githubusercontent.com/15010186/152300033-7f216696-d134-4938-a77e-58050e2a0250.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the comment from the `Leave a reply` heading and the comments heading;
- These should now be H2 level headings;
- The styles should still apply in the same manner as before;
- It should work just as before with and without comments;

<!-- Issues that this pull request closes. -->
Closes #2935.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
