### PR TITLE
style: ul & ol y-axis margins not applying in nested HTML tags inside content wrap

### DIFF
--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -59,8 +59,8 @@ pre {
 	--listPad: 20px;
 	--listStyle: disc;
 
-	> ul,
-	> ol {
+	ul,
+	ol {
 		margin: $spacing-lg 0;
 	}
 


### PR DESCRIPTION
### Summary
Applies Y-axis margin to `ul` & `ol` tags inside nested content.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add a list block inside a columns block;
- It should now have the same Y-axis margin as lists that are placed directly inside the content;

<!-- Issues that this pull request closes. -->
Closes #3326.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
