### PR TITLE
fix: elementor list styles & CSS size improvements [closes #3364]

### DIFF
--- a/assets/scss/components/compat/_elementor.scss
+++ b/assets/scss/components/compat/_elementor.scss
@@ -1,23 +1,20 @@
 //List fixes
-.neve-main .elementor-text-editor {
+.elementor-widget-text-editor {
+	--listPad: #{$spacing-sm};
+	--listStyle: disc;
+}
 
-	ul,
-	ol {
-		padding-left: $spacing-sm;
-	}
+// Fix scroll snap
+body.elementor-page {
 
-	ul {
-		list-style: inherit;
+	.wrapper {
+		overflow: visible;
 	}
 }
 
-body.elementor-page {
+.elementor {
 
 	select {
 		background-image: none;
-  }
-  
-	.wrapper {
-		overflow: visible;
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38 KB",
+			"limit": "38.1 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
Fixes Elementor text widget list style issues.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a text widget inside Elementor;
2. Add `ul`/`ol` lists;
3. They should have padding and proper list styles;

<!-- Issues that this pull request closes. -->
Closes #3364.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
