### PR TITLE
fix: woocommerce product addons alignment

### DIFF
--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -88,6 +88,10 @@
 	.group_table {
 		margin-bottom: $spacing-md;
 	}
+
+	.wc-pao-addons-container {
+		width: 100%;
+	}
 }
 
 .woocommerce table.shop_attributes {


### PR DESCRIPTION
### Summary
Added a width for the product addons container

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this patch
- Install the WooCommerce Product Add-ons plugin available on [this page](https://handbook.vertistudio.com/3rd-party-products/#woo-addons)
- Edit a product, and add some new fields - https://vertis.d.pr/fEqoXi
-Check the product page 

The issue with alignment should no longer be present.

<!-- Issues that this pull request closes. -->
Closes #3257
<!-- Should look like this: `Closes #1, #2, #3.` . -->
