### PR TITLE
Fix/palette switcher bug

### DIFF
--- a/assets/apps/customizer-controls/src/builder/HFGBuilder.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilder.tsx
@@ -78,14 +78,12 @@ const HFGBuilder: React.FC<Props> = ({
 	);
 
 	const updateSidebarItems = () => {
-		console.log( getSidebarItems() );
 		setSidebarItems([...getSidebarItems()]);
 	};
 
 	const explicitlyUpdateSidebarItemsWithThisValue = (
 		explicitVal: BuilderContentInterface
 	) => {
-		console.log( explicitVal );
 		setSidebarItems([...getSidebarItems(explicitVal)]);
 	};
 
@@ -149,42 +147,32 @@ const HFGBuilder: React.FC<Props> = ({
 			update[slot] = updateItems;
 			nextItems[row][slot] = updateItems;
 
-			console.log( nextItems[row][slot] );
-
 			const finalValue = { ...value, [device]: nextItems };
 			onChange(finalValue);
 		}
 	};
 
-	// const itemRemovedEvent = ( id: string ) => {
-	// 	window.document.dispatchEvent(
-	// 		new window.CustomEvent('neve-changed-builder-value', {
-	// 		detail: {
-	// 			value: mods[builderKeySlug],
-	// 			id: 'header'
-	// 		}
-	// 	}));
-	// }
+	const itemRemovedCleanup = (id: string) => {
+		if (id === '') {
+			return;
+		}
+		if (id === 'header_palette_switch') {
+			localStorage.removeItem('neve_user_theme');
+			window.wp.customize.previewer.refresh();
+		}
+	};
 
 	const removeItem: RemoveItem = (row, slot, indexToRemove) => {
 		const nextItems = { ...value[device] };
 		if (row === 'sidebar') {
+			itemRemovedCleanup(nextItems[row][indexToRemove].id);
 			nextItems[row].splice(indexToRemove, 1);
 			const finalValue = { ...value, [device]: nextItems };
 			onChange(finalValue);
 			return false;
 		}
 
-		console.log( builder );
-		console.log( row );
-		console.log( slot );
-		console.log( indexToRemove );
-		console.log( nextItems[row][slot] );
-		console.log( nextItems[row][slot][indexToRemove] );
-		if (nextItems[row][slot][indexToRemove].id === 'header_palette_switch') {
-			localStorage.removeItem('neve_user_theme');
-			//window.wp.customize.previewer.refresh();
-		}
+		itemRemovedCleanup(nextItems[row][slot][indexToRemove].id);
 
 		nextItems[row][slot].splice(indexToRemove, 1);
 
@@ -278,8 +266,6 @@ const HFGBuilder: React.FC<Props> = ({
 				const { detail } = e;
 				if (!detail) return false;
 				const { id, value: builderValue } = detail;
-				console.log( id );
-				console.log( builderValue );
 				let actualValue = builderValue;
 
 				if (!actualValue) {

--- a/assets/apps/customizer-controls/src/builder/HFGBuilder.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilder.tsx
@@ -78,12 +78,14 @@ const HFGBuilder: React.FC<Props> = ({
 	);
 
 	const updateSidebarItems = () => {
+		console.log( getSidebarItems() );
 		setSidebarItems([...getSidebarItems()]);
 	};
 
 	const explicitlyUpdateSidebarItemsWithThisValue = (
 		explicitVal: BuilderContentInterface
 	) => {
+		console.log( explicitVal );
 		setSidebarItems([...getSidebarItems(explicitVal)]);
 	};
 
@@ -147,10 +149,22 @@ const HFGBuilder: React.FC<Props> = ({
 			update[slot] = updateItems;
 			nextItems[row][slot] = updateItems;
 
+			console.log( nextItems[row][slot] );
+
 			const finalValue = { ...value, [device]: nextItems };
 			onChange(finalValue);
 		}
 	};
+
+	// const itemRemovedEvent = ( id: string ) => {
+	// 	window.document.dispatchEvent(
+	// 		new window.CustomEvent('neve-changed-builder-value', {
+	// 		detail: {
+	// 			value: mods[builderKeySlug],
+	// 			id: 'header'
+	// 		}
+	// 	}));
+	// }
 
 	const removeItem: RemoveItem = (row, slot, indexToRemove) => {
 		const nextItems = { ...value[device] };
@@ -159,6 +173,17 @@ const HFGBuilder: React.FC<Props> = ({
 			const finalValue = { ...value, [device]: nextItems };
 			onChange(finalValue);
 			return false;
+		}
+
+		console.log( builder );
+		console.log( row );
+		console.log( slot );
+		console.log( indexToRemove );
+		console.log( nextItems[row][slot] );
+		console.log( nextItems[row][slot][indexToRemove] );
+		if (nextItems[row][slot][indexToRemove].id === 'header_palette_switch') {
+			localStorage.removeItem('neve_user_theme');
+			//window.wp.customize.previewer.refresh();
 		}
 
 		nextItems[row][slot].splice(indexToRemove, 1);
@@ -253,6 +278,8 @@ const HFGBuilder: React.FC<Props> = ({
 				const { detail } = e;
 				if (!detail) return false;
 				const { id, value: builderValue } = detail;
+				console.log( id );
+				console.log( builderValue );
 				let actualValue = builderValue;
 
 				if (!actualValue) {

--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -31,6 +31,14 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 			return;
 		}
 
+		if (
+			next.search('header_palette_switch') === -1 &&
+			localStorage.getItem('neve_user_theme')
+		) {
+			localStorage.removeItem('neve_user_theme');
+			window.wp.customize.previewer.refresh();
+		}
+
 		setValue(nextValue);
 		control.setting.set(next);
 	};

--- a/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
@@ -40,7 +40,6 @@ const SidebarContent: React.FC<Props> = ({ items }) => {
 								.sort((a, b) => {
 									return a.id < b.id ? -1 : 1;
 								});
-							console.log( nextState );
 							setSidebarItems(nextState);
 						}}
 					>

--- a/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/SidebarContent.tsx
@@ -40,6 +40,7 @@ const SidebarContent: React.FC<Props> = ({ items }) => {
 								.sort((a, b) => {
 									return a.id < b.id ? -1 : 1;
 								});
+							console.log( nextState );
 							setSidebarItems(nextState);
 						}}
 					>

--- a/assets/apps/customizer-controls/src/inline-select/InlineSelectComponent.js
+++ b/assets/apps/customizer-controls/src/inline-select/InlineSelectComponent.js
@@ -32,6 +32,11 @@ const InlineSelectComponent = ({ control }) => {
 		});
 
 		// Listen on value change and update select settings with current global colors
+		wp.customize.bind('change', function (setting) {
+			if (setting && setting.id === changesOn) {
+				window.wp.customize.previewer.refresh();
+			}
+		});
 		window.wp.customize.control(changesOn, (customizeControl) => {
 			customizeControl.setting.bind('changed', (nextValue) => {
 				const currentGlobalColors = nextValue.palettes;


### PR DESCRIPTION
### Summary
Cleanup on palette switch component remove from Customizer

### Will affect visual aspect of the product
NO

### Screenshots

### Test instructions
1. Add the palette switcher component
2. Toggle to the dark mode or white if default was dark
3. Remove the component with the closing button or by dragging it outside.
4. The Customizer should refresh and the page should revert to the default theme white/dark

Closes #3348.