### PR TITLE
fix: tinymce behaviour on empty tags #3334

### DIFF
--- a/assets/apps/customizer-controls/src/rich-text/RichText.js
+++ b/assets/apps/customizer-controls/src/rich-text/RichText.js
@@ -68,6 +68,7 @@ const RichText = ({
 				toolbar2,
 				style_formats_merge: true,
 				style_formats: [],
+				verify_html: false,
 			},
 		});
 
@@ -88,6 +89,7 @@ const RichText = ({
 						toolbar2,
 						style_formats_merge: true,
 						style_formats: [],
+						verify_html: false,
 					},
 				});
 


### PR DESCRIPTION
### Summary
Fixed an issue where tinymce would strip empty tags.
The `verify_html` option should not be required as the input is sanitized in WP upon save.

### Will affect visual aspect of the product
NO

### Test instructions
1. Add a Custm HTML component and go into `Code` view
2. Copy this `<a href="https://instagram.com/" target="_blank"><span class="dashicons dashicons-facebook"></span></a>` and check that after toggling to View the element is being rendered and is stil displayed in code view

Closes #3334.
