### PR TITLE
Reset post custom content width when sidebar position changed

### DIFF
--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -249,7 +249,8 @@ class MetaFieldsManager extends Component {
 								if (value === 'left' || value === 'right') {
 									this.updateValues(
 										'neve_meta_content_width',
-										70
+										this.defaultState
+											.neve_meta_content_width
 									);
 								}
 							}}

--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -246,6 +246,12 @@ class MetaFieldsManager extends Component {
 							]}
 							onChange={(value) => {
 								this.updateValues('neve_meta_sidebar', value);
+								if (value === 'left' || value === 'right') {
+									this.updateValues(
+										'neve_meta_content_width',
+										70
+									);
+								}
 							}}
 						/>
 					</BaseControl>
@@ -367,6 +373,22 @@ class MetaFieldsManager extends Component {
 								max={100}
 								step="1"
 							/>
+							{this.props.metaValue('neve_meta_content_width') &&
+								this.props.metaValue(
+									'neve_meta_content_width'
+								) > 80 &&
+								(this.props.metaValue('neve_meta_sidebar') ===
+									'left' ||
+									this.props.metaValue(
+										'neve_meta_sidebar'
+									) === 'right') && (
+									<small>
+										{__(
+											'Setting the content width over 80 might affect the sidebar width.',
+											'neve'
+										)}
+									</small>
+								)}
 						</BaseControl>
 					) : (
 						''

--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -18,6 +18,7 @@ import {
 	ButtonGroup,
 	ToggleControl,
 	RangeControl,
+	Notice,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { maybeParseJson } from '@neve-wp/components';
@@ -383,12 +384,14 @@ class MetaFieldsManager extends Component {
 									this.props.metaValue(
 										'neve_meta_sidebar'
 									) === 'right') && (
-									<small>
-										{__(
-											'Setting the content width over 80 might affect the sidebar width.',
-											'neve'
-										)}
-									</small>
+									<Notice isDismissible={false}>
+										<small>
+											{__(
+												'Note: Setting the content width over 80% might affect the sidebar width. Sidebar will ultimately disappear at 95%.',
+												'neve'
+											)}
+										</small>
+									</Notice>
 								)}
 						</BaseControl>
 					) : (

--- a/assets/apps/metabox/src/editor.scss
+++ b/assets/apps/metabox/src/editor.scss
@@ -216,3 +216,12 @@
 		margin-bottom: -1px;
 	}
 }
+
+.nv-option-category {
+	.components-notice{
+		margin-left: 0;
+		.components-notice__content{
+			margin: 0;
+		}
+	}
+}


### PR DESCRIPTION

### Summary
Reset post custom content width when sidebar position changed and show a notice when content width is above 80

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://user-images.githubusercontent.com/10324144/154751491-cbf3f5a0-0442-4a67-9751-1390e7a6b63b.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this patch
- Try changing the post content width to any value
- If you switch to one of the sidebar layouts, the custom width value will reset to 70
- If you change the custom width to above 80 a notice will show informing that the sidebar width might be affected.

<!-- Issues that this pull request closes. -->
Closes #3370 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
