### PR TITLE
Fix input focus on safari [#3366]

### DIFF
--- a/assets/scss/components/elements/form-elements/_inputs.scss
+++ b/assets/scss/components/elements/form-elements/_inputs.scss
@@ -29,8 +29,7 @@ select,
 textarea,
 [tabindex="-1"] {
 
-	&:focus,
-	&:focus-visible {
+	&:focus {
 		outline: 0;
 		box-shadow: 0 0 3px 0 var(--nv-secondary-accent);
 		--formFieldBorderColor: var(--nv-secondary-accent);


### PR DESCRIPTION
### Summary

The issue comes from `:focus-visible` pseudo-class. It seems that Safari supports it only in the latest version https://caniuse.com/?search=focus-visible. 

So what happens here is this: The SCSS is built and the result in CSS is something like:
```
input:read-write:focus, input:read-write:focus-visible ...{ 
 outline: 0;
 box-shadow: 0 0 3px 0 var(--nv-secondary-accent);
 --formFieldBorderColor: var(--nv-secondary-accent);
}
```

Because older versions of Safari don't know about `:focus-visible`, it just ignores the whole CSS block.

### Will affect visual aspect of the product
NO


### Test instructions
- Check focus on inputs, textareas, select fields


<!-- Issues that this pull request closes. -->
Closes #3366.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
