### PR TITLE
fix: improve support for SVG allow crop skipping

### DIFF
--- a/assets/apps/components/src/Common/MediaLibrary.js
+++ b/assets/apps/components/src/Common/MediaLibrary.js
@@ -14,9 +14,12 @@ const getAttachmentsCollection = (ids) => {
 };
 
 const mustBeCropped = (flexW, flexH, dstW, dstH, imgW, imgH) => {
+	// We might be working with a SVG
+	if (imgW === imgH && imgW === 0) {
+		return false;
+	}
 	// If the width and height are both flexible
 	// then the user does not need to crop the image.
-
 	if (true === flexW && true === flexH) {
 		return false;
 	}
@@ -46,7 +49,7 @@ const mustBeCropped = (flexW, flexH, dstW, dstH, imgW, imgH) => {
 		return false;
 	}
 
-	return true;
+	return false;
 };
 
 const calculateImageSelectOptions = (attachment, controller) => {
@@ -61,7 +64,7 @@ const calculateImageSelectOptions = (attachment, controller) => {
 	let xInit = parseInt(currentCropControl.params.width, 10);
 	let yInit = parseInt(currentCropControl.params.height, 10);
 
-	const ratio = xInit / yInit;
+	const ratio = 4 / 1;
 
 	controller.set(
 		'canSkipCrop',
@@ -86,23 +89,39 @@ const calculateImageSelectOptions = (attachment, controller) => {
 		yInit = xInit / ratio;
 	}
 
-	const x1 = (realWidth - xInit) / 2;
-	const y1 = (realHeight - yInit) / 2;
+	const x1 = parseFloat(((realWidth - xInit) / 2).toFixed(2));
+	const y1 = parseFloat(((realHeight - yInit) / 2).toFixed(2));
 
-	return {
+	const imgSelectOptions = {
 		handles: true,
 		keys: true,
 		instance: true,
-		persistent: true,
-		imageWidth: realWidth,
-		imageHeight: realHeight,
+		persistent: false,
+		imageWidth: parseFloat(realWidth.toFixed(2)),
+		imageHeight: parseFloat(realHeight.toFixed(2)),
 		minWidth: xImg > xInit ? xInit : xImg,
 		minHeight: yImg > yInit ? yInit : yImg,
 		x1,
 		y1,
-		x2: xInit + x1,
-		y2: yInit + y1,
+		x2: parseFloat((xInit + x1).toFixed(2)),
+		y2: parseFloat((yInit + y1).toFixed(2)),
 	};
+
+	if (flexHeight === false && flexWidth === false) {
+		imgSelectOptions.aspectRatio = 4 + ':' + 1;
+	}
+
+	if (true === flexHeight) {
+		delete imgSelectOptions.minHeight;
+		imgSelectOptions.maxWidth = realWidth;
+	}
+
+	if (true === flexWidth) {
+		delete imgSelectOptions.minWidth;
+		imgSelectOptions.maxHeight = realHeight;
+	}
+
+	return imgSelectOptions;
 };
 
 const setImageFromURL = (url, attachmentId, width, height) => {

--- a/assets/apps/components/src/Common/MediaLibrary.js
+++ b/assets/apps/components/src/Common/MediaLibrary.js
@@ -49,7 +49,7 @@ const mustBeCropped = (flexW, flexH, dstW, dstH, imgW, imgH) => {
 		return false;
 	}
 
-	return false;
+	return true;
 };
 
 const calculateImageSelectOptions = (attachment, controller) => {
@@ -64,7 +64,7 @@ const calculateImageSelectOptions = (attachment, controller) => {
 	let xInit = parseInt(currentCropControl.params.width, 10);
 	let yInit = parseInt(currentCropControl.params.height, 10);
 
-	const ratio = 4 / 1;
+	const ratio = xInit / yInit;
 
 	controller.set(
 		'canSkipCrop',

--- a/assets/apps/components/src/Common/MediaLibrary.js
+++ b/assets/apps/components/src/Common/MediaLibrary.js
@@ -55,9 +55,6 @@ const mustBeCropped = (flexW, flexH, dstW, dstH, imgW, imgH) => {
 const calculateImageSelectOptions = (attachment, controller) => {
 	const currentCropControl = controller.get('control');
 
-	const flexWidth = !!parseInt(currentCropControl.params.flex_width, 10);
-	const flexHeight = !!parseInt(currentCropControl.params.flex_height, 10);
-
 	const realWidth = attachment.get('width');
 	const realHeight = attachment.get('height');
 
@@ -66,17 +63,7 @@ const calculateImageSelectOptions = (attachment, controller) => {
 
 	const ratio = xInit / yInit;
 
-	controller.set(
-		'canSkipCrop',
-		!currentCropControl.mustBeCropped(
-			flexWidth,
-			flexHeight,
-			xInit,
-			yInit,
-			realWidth,
-			realHeight
-		)
-	);
+	controller.set('canSkipCrop', true);
 
 	const xImg = xInit;
 	const yImg = yInit;
@@ -92,7 +79,7 @@ const calculateImageSelectOptions = (attachment, controller) => {
 	const x1 = parseFloat(((realWidth - xInit) / 2).toFixed(2));
 	const y1 = parseFloat(((realHeight - yInit) / 2).toFixed(2));
 
-	const imgSelectOptions = {
+	return {
 		handles: true,
 		keys: true,
 		instance: true,
@@ -106,22 +93,6 @@ const calculateImageSelectOptions = (attachment, controller) => {
 		x2: parseFloat((xInit + x1).toFixed(2)),
 		y2: parseFloat((yInit + y1).toFixed(2)),
 	};
-
-	if (flexHeight === false && flexWidth === false) {
-		imgSelectOptions.aspectRatio = 4 + ':' + 1;
-	}
-
-	if (true === flexHeight) {
-		delete imgSelectOptions.minHeight;
-		imgSelectOptions.maxWidth = realWidth;
-	}
-
-	if (true === flexWidth) {
-		delete imgSelectOptions.minWidth;
-		imgSelectOptions.maxHeight = realHeight;
-	}
-
-	return imgSelectOptions;
 };
 
 const setImageFromURL = (url, attachmentId, width, height) => {

--- a/assets/scss/components/elements/navigation/_nav-brand.scss
+++ b/assets/scss/components/elements/navigation/_nav-brand.scss
@@ -12,6 +12,10 @@
 		max-width: var(--maxWidth);
 		display: block;
 		margin: 0 auto;
+
+		&[src$=".svg"] {
+			width: var(--maxWidth);
+		}
 	}
 
 	.title-with-logo {

--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -18,6 +18,7 @@ use HFG\Main;
 use Neve\Core\Dynamic_Css;
 use Neve\Core\Settings\Mods;
 use Neve\Core\Styles\Dynamic_Selector;
+use WP_Post;
 
 /**
  * Class Logo.
@@ -91,6 +92,53 @@ class Logo extends Abstract_Component {
 
 		// We use this filter to port changes to the logo from the templates on the new component.
 		add_filter( 'pre_set_theme_mod_custom_logo', [ $this, 'update_logo_theme_mod' ], 10, 2 );
+
+		// we remove the sizes for SVG
+		add_filter( 'wp_calculate_image_sizes', [ $this, 'filter_svg_logo_size' ], 10, 5 );
+		add_filter( 'wp_get_attachment_image_attributes', [ $this, 'clear_svg_size_attr' ], 10, 3 );
+	}
+
+	/**
+	 * Clear width and height attributes for SVG.
+	 *
+	 * @param array   $attr Attributes.
+	 * @param WP_Post $attachment The attachment.
+	 * @param string  $size The size.
+	 *
+	 * @return array
+	 */
+	final public function clear_svg_size_attr( $attr, $attachment, $size = 'thumbnail' ) {
+		if ( ! $attachment instanceof WP_Post ) {
+			return $attr;
+		}
+
+		$mime = get_post_mime_type( $attachment->ID );
+		if ( 'image/svg+xml' === $mime ) {
+			unset( $attr['width'] );
+			unset( $attr['height'] );
+		}
+
+		return $attr;
+	}
+
+	/**
+	 * Set the sizes for SVG.
+	 *
+	 * @param string $sizes The style sizes.
+	 * @param string $size The specified size.
+	 * @param string $image_src The source of the image.
+	 * @param array  $image_meta The meta for the image.
+	 * @param int    $attachment_id The attachment ID.
+	 *
+	 * @return string
+	 */
+	final public function filter_svg_logo_size( $sizes, $size, $image_src, $image_meta, $attachment_id ) {
+		$mime = get_post_mime_type( $attachment_id );
+		if ( 'image/svg+xml' === $mime ) {
+			return '';
+		}
+
+		return $sizes;
 	}
 
 	/**
@@ -209,6 +257,12 @@ class Logo extends Abstract_Component {
 			if( ! picture ) {
 				continue;
 			};
+			var fileExt = picture.src.slice((Math.max(0, picture.src.lastIndexOf(".")) || Infinity) + 1);
+			if ( fileExt === 'svg' ) {
+				picture.removeAttribute('width');
+				picture.removeAttribute('height');
+				picture.style = 'width: var(--maxWidth)';
+			}
 			var compId = picture.getAttribute('data-variant');
 			if ( compId && variants[compId] ) {
 				var isConditional = variants[compId]['same'];


### PR DESCRIPTION
### Summary
I've improved support for SVG, it should allow use of SVG inside the Logo and will allow crop skipping since it is not possible on SVG.

### Will affect visual aspect of the product
NO

### Test instructions
1. Upload a SVG using [SVG Support](https://wordpress.org/plugins/svg-support/) plugin.
2. Set the SVG as a LOGO, check that you are allowed to skip crop.
3. Check that all settings are applied correctly, eg. Size of Logo.

Closes #3350.
