### PR TITLE
fix: limit title lenght display Codeinwp/neve-pro-addon#1851

### DIFF
--- a/assets/apps/customizer-controls/src/scss/_repeater.scss
+++ b/assets/apps/customizer-controls/src/scss/_repeater.scss
@@ -71,6 +71,10 @@ $text-color: #50575e;
 	  color: $text-color;
 	  font-size: 14px;
 	  font-weight: 600;
+	  overflow: hidden;
+	  text-overflow: ellipsis;
+	  white-space: nowrap;
+	  max-width: 12vw;
 	}
   }
 


### PR DESCRIPTION
### Summary
I changed the css for Repeater component so that titles that are very long in case the user decides to add html will display cleaner and will be caped.
This is also a supporting change for  Codeinwp/neve-pro-addon#1851

### Will affect visual aspect of the product
YES

### Screenshots
![image](https://user-images.githubusercontent.com/23024731/155133910-d295c5e5-3b57-4b38-9628-7d5ed351917a.png)


### Test instructions
1.  Add the contact component.
2. Add a very long content
3. Check that the title is not overflowing.

Closes Codeinwp/neve-pro-addon#1851.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
