### PR TITLE
fix: page header support with mixed theme versions #3401

### DIFF
--- a/assets/apps/customizer-controls/src/builder/Control.js
+++ b/assets/apps/customizer-controls/src/builder/Control.js
@@ -2,6 +2,7 @@
 import HFGBuilderComponent from './HFGBuilderComponent.tsx';
 import { render } from '@wordpress/element';
 import React from 'react';
+import { isNull } from 'lodash';
 
 export const BuilderControl = wp.customize.Control.extend({
 	renderContent() {
@@ -10,9 +11,15 @@ export const BuilderControl = wp.customize.Control.extend({
 			`#accordion-section-${this.params.section}`
 		);
 		if (this.params.builderType === 'page_header') {
-			where = document.querySelector(
+			const pageHeaderComponents = document.querySelector(
 				`#customize-control-neve_pro_page_header_layout_components`
 			);
+			if (
+				!isNull(pageHeaderComponents) &&
+				pageHeaderComponents !== 'undefined'
+			) {
+				where = pageHeaderComponents;
+			}
 		}
 
 		const builderPortalMount = document.createElement('div');


### PR DESCRIPTION
### Summary
Changed the selector for the builder components on HFG for Page Header as to not trigger error on mixed versions (theme/pro addon) inside Customizer.

### Will affect visual aspect of the product
NO

### Test instructions
1. Use the `master` version of the Neve PRO with the build from here.
2. Check that Customizer is loading properly and no errors are thrown inside the console.

Previously an error was thrown, check the linked issue for more details.

<!-- Issues that this pull request closes. -->
Closes #3401.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
