### PR TITLE
Fix unitless line height

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -464,17 +464,11 @@ window.addEventListener('load', function () {
 									newValue.lineHeight &&
 									newValue.lineHeight[device]
 								) {
-									let suffix = '';
-									if (
-										newValue.lineHeight.suffix[device] &&
-										newValue.lineHeight.suffix[device] !==
-											'em'
-									) {
-										suffix =
-											newValue.lineHeight.suffix[device];
-									}
-
-									style += `line-height:${newValue.lineHeight[device]}${suffix};`;
+									style += `line-height:${
+										newValue.lineHeight[device]
+									}${
+										newValue.lineHeight.suffix[device] || ''
+									};`;
 								}
 								style += `}}`;
 							}

--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -464,11 +464,17 @@ window.addEventListener('load', function () {
 									newValue.lineHeight &&
 									newValue.lineHeight[device]
 								) {
-									style += `line-height:${
-										newValue.lineHeight[device]
-									}${
-										newValue.lineHeight.suffix[device] || ''
-									};`;
+									let suffix = '';
+									if (
+										newValue.lineHeight.suffix[device] &&
+										newValue.lineHeight.suffix[device] !==
+											'em'
+									) {
+										suffix =
+											newValue.lineHeight.suffix[device];
+									}
+
+									style += `line-height:${newValue.lineHeight[device]}${suffix};`;
 								}
 								style += `}}`;
 							}

--- a/assets/js/src/customizer-preview/css-var-handler.js
+++ b/assets/js/src/customizer-preview/css-var-handler.js
@@ -20,6 +20,7 @@ export class CSSVariablesHandler {
 			fallback = 'inherit',
 			dispatchWindowResize = false,
 			valueRemap,
+			unitlessEm,
 		} = params;
 
 		//Bail if no selectors or variables.
@@ -37,6 +38,7 @@ export class CSSVariablesHandler {
 		this.fallback = fallback;
 		this.timeout = null;
 		this.valueRemap = valueRemap;
+		this.unitlessEm = unitlessEm;
 
 		const css = this.getStyle();
 
@@ -68,7 +70,8 @@ export class CSSVariablesHandler {
 				vars,
 				this.value,
 				this.suffix,
-				this.fallback
+				this.fallback,
+				this.unitlessEm
 			);
 		}
 
@@ -161,7 +164,14 @@ export class CSSVariablesHandler {
 		return `${selector}{${vars}:${finalValue};}`;
 	}
 
-	getResponsiveVarCSS(selector, variable, value, suffix, fallback) {
+	getResponsiveVarCSS(
+		selector,
+		variable,
+		value,
+		suffix,
+		fallback,
+		unitlessEm = false
+	) {
 		const parsedValue = this.maybeParseJson(value);
 
 		if (parsedValue === undefined) {
@@ -179,6 +189,10 @@ export class CSSVariablesHandler {
 
 			if (parsedValue.suffix && parsedValue.suffix[device]) {
 				finalSuffix = parsedValue.suffix[device];
+			}
+
+			if (unitlessEm && finalSuffix === 'em') {
+				finalSuffix = '';
 			}
 
 			if (!parsedValue[device]) {
@@ -253,7 +267,15 @@ export class CSSVariablesHandler {
 	}
 
 	getComposedVarCSS() {
-		const { selector, vars, settingType, value, suffix, fallback } = this;
+		const {
+			selector,
+			vars,
+			settingType,
+			value,
+			suffix,
+			fallback,
+			unitlessEm,
+		} = this;
 
 		const isButton = this.isButtonSetting(settingType);
 
@@ -276,7 +298,8 @@ export class CSSVariablesHandler {
 						cssVar,
 						value[settingKey.key],
 						currentSuffix,
-						fallback
+						fallback,
+						unitlessEm
 					);
 					return false;
 				}

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -273,6 +273,10 @@ class Css_Prop {
 			Font_Manager::add_google_font( $font, strval( $value ) );
 		}
 
+		if ( isset( $meta[ Dynamic_Selector::META_IS_UNITLESS ] ) && $meta[ Dynamic_Selector::META_IS_UNITLESS ] ) {
+			$suffix = '';
+		}
+
 		return $suffix;
 	}
 

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -273,7 +273,7 @@ class Css_Prop {
 			Font_Manager::add_google_font( $font, strval( $value ) );
 		}
 
-		if ( isset( $meta[ Dynamic_Selector::META_IS_UNITLESS ] ) && $meta[ Dynamic_Selector::META_IS_UNITLESS ] ) {
+		if ( isset( $meta[ Dynamic_Selector::META_UNITLESS_EM ] ) && $meta[ Dynamic_Selector::META_UNITLESS_EM ] && $suffix === 'em' ) {
 			$suffix = '';
 		}
 

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -195,6 +195,7 @@ trait Css_Vars {
 				Dynamic_Selector::META_DEFAULT       => $default['lineHeight'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => '',
+				Dynamic_Selector::META_IS_UNITLESS	 => true,
 			],
 			'--bodyLetterSpacing'  => [
 				Dynamic_Selector::META_KEY           => $mod_key . '.letterSpacing',

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -195,7 +195,7 @@ trait Css_Vars {
 				Dynamic_Selector::META_DEFAULT       => $default['lineHeight'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => '',
-				Dynamic_Selector::META_IS_UNITLESS	 => true,
+				Dynamic_Selector::META_UNITLESS_EM	 => true,
 			],
 			'--bodyLetterSpacing'  => [
 				Dynamic_Selector::META_KEY           => $mod_key . '.letterSpacing',

--- a/inc/core/styles/dynamic_selector.php
+++ b/inc/core/styles/dynamic_selector.php
@@ -28,7 +28,7 @@ class Dynamic_Selector {
 	const META_DEVICE_ONLY   = 'device_only';
 	const META_FILTER        = 'filter';
 	const META_AS_JSON       = 'as_json';
-	const META_IS_UNITLESS   = 'unitless';
+	const META_UNITLESS_EM   = 'unitless_em';
 
 	const KEY_SELECTOR = 'selectors';
 	const KEY_RULES    = 'rules';

--- a/inc/core/styles/dynamic_selector.php
+++ b/inc/core/styles/dynamic_selector.php
@@ -28,6 +28,7 @@ class Dynamic_Selector {
 	const META_DEVICE_ONLY   = 'device_only';
 	const META_FILTER        = 'filter';
 	const META_AS_JSON       = 'as_json';
+	const META_IS_UNITLESS   = 'unitless';
 
 	const KEY_SELECTOR = 'selectors';
 	const KEY_RULES    = 'rules';

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -137,6 +137,29 @@ class Typography extends Base_Customizer {
 					'type'                  => 'neve_typeface_control',
 					'font_family_control'   => 'neve_body_font_family',
 					'live_refresh_selector' => 'body, .site-title',
+					'live_refresh_css_prop' => [
+						'cssVar' => [
+							'vars'       => [
+								'--bodyTextTransform' => 'textTransform',
+								'--bodyFontWeight'    => 'fontWeight',
+								'--bodyFontSize'      => [
+									'key'        => 'fontSize',
+									'responsive' => true,
+								],
+								'--bodyLineHeight'    => [
+									'key'        => 'lineHeight',
+									'responsive' => true,
+								],
+								'--bodyLetterSpacing' => [
+									'key'        => 'letterSpacing',
+									'suffix'     => 'px',
+									'responsive' => true,
+								],
+							],
+							'selector'   => 'body',
+							'unitlessEm' => true,
+						],
+					],
 				],
 				'\Neve\Customizer\Controls\React\Typography'
 			)


### PR DESCRIPTION
### Summary
Remove the 'em' unit for line height.

When users are choosing the 'em' unit, we just don't add the unit if the control has the parameter META_IS_UNITLESS set to true

Note that this is done just for the line height in the general typography and it will produce changes on the front end.

### Will affect visual aspect of the product
YES

### Screenshots <!-- if applicable -->
https://vertis.d.pr/NheUna

### Test instructions
- Add this PR
- Go to Customizer -> Typography -> General and change the line-height
- Check the console. the -bodyLineHeight should not have a unit when it's set to em neither in customizer on the front end
- The unit should be present when you choose "px"

cc. @Codeinwp/design-team 

<!-- Issues that this pull request closes. -->
Closes #3225.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
