### PR TITLE
fix: react controls php warning #3406

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -469,7 +469,7 @@ abstract class Abstract_Builder implements Builder {
 				'tab'                   => SettingsManager::TAB_STYLE,
 				'section'               => $row_setting_id,
 				'label'                 => __( 'Row Background', 'neve' ),
-				'type'                  => 'neve_background_control',
+				'type'                  => '\Neve\Customizer\Controls\React\Background',
 				'live_refresh_selector' => $row_id === 'sidebar' ? $row_class . ' .header-menu-sidebar-bg' : $row_class,
 				'live_refresh_css_prop' => [
 					'cssVar'  => [

--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -255,7 +255,7 @@ class Header extends Abstract_Builder {
 				'section'               => $section_id,
 				'tab'                   => 'style',
 				'label'                 => esc_html__( 'Global', 'neve' ),
-				'type'                  => 'neve_background_control',
+				'type'                  => '\Neve\Customizer\Controls\React\Background',
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [

--- a/header-footer-grid/Core/Components/Button.php
+++ b/header-footer-grid/Core/Components/Button.php
@@ -135,7 +135,7 @@ class Button extends Abstract_Component {
 				'transport'             => 'post' . $this->get_class_const( 'COMPONENT_ID' ),
 				'sanitize_callback'     => 'neve_sanitize_button_appearance',
 				'label'                 => __( 'Appearance', 'neve' ),
-				'type'                  => 'neve_button_appearance',
+				'type'                  => '\Neve\Customizer\Controls\React\Button_Appearance',
 				'section'               => $this->section,
 				'conditional_header'    => $this->get_builder_id() === 'header',
 				'live_refresh_selector' => true,

--- a/inc/customizer/controls/react/background.php
+++ b/inc/customizer/controls/react/background.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Responsive_Range Control. Handles data passing from args to JS.
+ * Color Control. Handles data passing from args to JS.
  *
  * @package Neve\Customizer\Controls\React
  */
@@ -8,30 +8,29 @@
 namespace Neve\Customizer\Controls\React;
 
 /**
- * Class Responsive_Range
+ * Class Button_Appearance
  *
  * @package Neve\Customizer\Controls\React
  */
-class Responsive_Range extends \WP_Customize_Control {
+class Background extends \WP_Customize_Control {
 	/**
 	 * Control type.
 	 *
 	 * @var string
 	 */
-	public $type = 'neve_responsive_range_control';
+	public $type = 'neve_background_control';
 	/**
 	 * Additional arguments passed to JS.
 	 *
-	 * @var array
+	 * @var string
 	 */
-	public $input_attrs = [];
-
+	public $default = '';
 	/**
 	 * Send to JS.
 	 */
 	public function json() {
-		$json                = parent::json();
-		$json['input_attrs'] = $this->input_attrs;
+		$json            = parent::json();
+		$json['default'] = $this->default;
 		return $json;
 	}
 

--- a/inc/customizer/controls/react/builder.php
+++ b/inc/customizer/controls/react/builder.php
@@ -45,4 +45,15 @@ class Builder extends \WP_Customize_Control {
 
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/builder_columns.php
+++ b/inc/customizer/controls/react/builder_columns.php
@@ -97,4 +97,15 @@ class Builder_Columns extends \WP_Customize_Control {
 
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/button_appearance.php
+++ b/inc/customizer/controls/react/button_appearance.php
@@ -41,4 +41,15 @@ class Button_Appearance extends \WP_Customize_Control {
 		$json['defaultVals'] = $this->default_vals;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/color.php
+++ b/inc/customizer/controls/react/color.php
@@ -40,4 +40,15 @@ class Color extends \WP_Customize_Control {
 		$json['disableAlpha'] = $this->disable_alpha;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/conditional_selector.php
+++ b/inc/customizer/controls/react/conditional_selector.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Responsive_Range Control. Handles data passing from args to JS.
+ * Color Control. Handles data passing from args to JS.
  *
  * @package Neve\Customizer\Controls\React
  */
@@ -8,30 +8,29 @@
 namespace Neve\Customizer\Controls\React;
 
 /**
- * Class Responsive_Range
+ * Class Button_Appearance
  *
  * @package Neve\Customizer\Controls\React
  */
-class Responsive_Range extends \WP_Customize_Control {
+class Conditional_Selector extends \WP_Customize_Control {
 	/**
 	 * Control type.
 	 *
 	 * @var string
 	 */
-	public $type = 'neve_responsive_range_control';
+	public $type = 'neve_context_conditional_selector';
 	/**
 	 * Additional arguments passed to JS.
 	 *
-	 * @var array
+	 * @var string
 	 */
-	public $input_attrs = [];
-
+	public $default = '';
 	/**
 	 * Send to JS.
 	 */
 	public function json() {
-		$json                = parent::json();
-		$json['input_attrs'] = $this->input_attrs;
+		$json            = parent::json();
+		$json['default'] = $this->default;
 		return $json;
 	}
 

--- a/inc/customizer/controls/react/font_family.php
+++ b/inc/customizer/controls/react/font_family.php
@@ -33,4 +33,15 @@ class Font_Family extends \WP_Customize_Control {
 		$json['input_attrs'] = $this->input_attrs;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/global_colors.php
+++ b/inc/customizer/controls/react/global_colors.php
@@ -42,4 +42,15 @@ class Global_Colors extends \WP_Customize_Control {
 		$json['input_attrs']   = $this->input_attrs;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/heading.php
+++ b/inc/customizer/controls/react/heading.php
@@ -109,4 +109,15 @@ class Heading extends \WP_Customize_Control {
 
 		return $style;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/inline_select.php
+++ b/inc/customizer/controls/react/inline_select.php
@@ -58,4 +58,15 @@ class Inline_Select extends \WP_Customize_Control {
 		$json['changesOn']  = $this->changes_on;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/instructions_control.php
+++ b/inc/customizer/controls/react/instructions_control.php
@@ -56,6 +56,17 @@ class Instructions_Control extends \WP_Customize_Control {
 
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }
 
 

--- a/inc/customizer/controls/react/link_control.php
+++ b/inc/customizer/controls/react/link_control.php
@@ -60,4 +60,15 @@ class Link_Control extends \WP_Customize_Control {
 
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/logo_palette.php
+++ b/inc/customizer/controls/react/logo_palette.php
@@ -34,4 +34,15 @@ class Logo_Palette extends \WP_Customize_Control {
 		$json['input_attrs'] = $this->input_attrs;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/multiselect.php
+++ b/inc/customizer/controls/react/multiselect.php
@@ -33,4 +33,15 @@ class Multiselect extends \WP_Customize_Control {
 		$json['choices'] = $this->choices;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/nr_spacing.php
+++ b/inc/customizer/controls/react/nr_spacing.php
@@ -59,4 +59,15 @@ class Nr_Spacing extends \WP_Customize_Control {
 		$json['defaultVal'] = $this->default;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/ordering.php
+++ b/inc/customizer/controls/react/ordering.php
@@ -44,4 +44,15 @@ class Ordering extends \WP_Customize_Control {
 		$json['defaultOrder'] = $this->default_order;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/presets_selector.php
+++ b/inc/customizer/controls/react/presets_selector.php
@@ -44,4 +44,15 @@ class Presets_Selector extends \WP_Customize_Control {
 		$json['builder'] = $this->builder;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/radio_buttons.php
+++ b/inc/customizer/controls/react/radio_buttons.php
@@ -55,4 +55,15 @@ class Radio_Buttons extends \WP_Customize_Control {
 		$json['showLabels']    = $this->show_labels;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/radio_image.php
+++ b/inc/customizer/controls/react/radio_image.php
@@ -40,4 +40,15 @@ class Radio_Image extends \WP_Customize_Control {
 		$json['documentation'] = $this->documentation;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/range.php
+++ b/inc/customizer/controls/react/range.php
@@ -34,4 +34,15 @@ class Range extends \WP_Customize_Control {
 		$json['input_attrs'] = $this->input_attrs;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/repeater.php
+++ b/inc/customizer/controls/react/repeater.php
@@ -36,4 +36,15 @@ class Repeater extends \WP_Customize_Control {
 		$json['fields'] = $this->fields;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/responsive_radio_buttons.php
+++ b/inc/customizer/controls/react/responsive_radio_buttons.php
@@ -35,4 +35,15 @@ class Responsive_Radio_Buttons extends \WP_Customize_Control {
 		$json['choices'] = $this->choices;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/responsive_toggle.php
+++ b/inc/customizer/controls/react/responsive_toggle.php
@@ -33,4 +33,15 @@ class Responsive_Toggle extends \WP_Customize_Control {
 		$json['excluded'] = $this->excluded_devices;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/rich_text.php
+++ b/inc/customizer/controls/react/rich_text.php
@@ -34,4 +34,15 @@ class Rich_Text extends \WP_Customize_Control {
 		}
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/spacing.php
+++ b/inc/customizer/controls/react/spacing.php
@@ -42,4 +42,15 @@ class Spacing extends \WP_Customize_Control {
 		$json['default']     = $this->default;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/controls/react/typography.php
+++ b/inc/customizer/controls/react/typography.php
@@ -48,4 +48,15 @@ class Typography extends \WP_Customize_Control {
 		$json['font_family_control'] = $this->font_family_control;
 		return $json;
 	}
+
+	/**
+	 * This method overrides the default render
+	 * so that nothing is rendered.
+	 * Previously it would try to put an input element where the value was `esc_attr()`
+	 * This would trigger notices in PHP
+	 * It is not required to have a render as it is being handled by React.
+	 */
+	final public function render_content() {
+		// this is rendered from React
+	}
 }

--- a/inc/customizer/options/buttons.php
+++ b/inc/customizer/options/buttons.php
@@ -273,7 +273,8 @@ class Buttons extends Base_Customizer {
 						'section'      => $this->section_id,
 						'priority'     => 0,
 						'type'         => 'neve_button_appearance',
-					]
+					],
+					'\Neve\Customizer\Controls\React\Button_Appearance'
 				)
 			);
 

--- a/start.php
+++ b/start.php
@@ -23,6 +23,7 @@ function neve_run() {
 			'link_control'          => true,
 			'page_header_support'   => true,
 			'featured_post'         => true,
+			'php81_react_ctrls_fix' => true,
 		]
 	);
 	$vendor_file = trailingslashit( get_template_directory() ) . 'vendor/autoload.php';


### PR DESCRIPTION
### Summary
I changed the PHP react control classes to not execute the default render since the render is handled by JS.
Previously it was trying to do add an input that is replaced by JS, the input value for the default input was sanitized using `esc_attr()` this resulted in a PHP warning for an array to string conversion on components that use custom data as values.

Also added new Control classes that were not present, but are required to override the default behavior for the specific controls.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
1.  Enable WP debug mode. 
You can edit `wp-config.php` and add `define( 'WP_DEBUG', true );` and `define( 'WP_DEBUG_LOG', true );`
2. Open the Customizer
3. Check that no Warnings or Errors are logged while doing changes in the Customizer
Previously it would spawn warnings when Customizer loaded or you changed some Controls
4. Make sure all controls work as before and no regressions are present.


<!-- Issues that this pull request closes. -->
Closes #3406.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
