### PR TITLE
fix: added flex-wrap for compatibilities #3161

### DIFF
--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -46,6 +46,7 @@
 
 	.woocommerce-variation-add-to-cart {
 		display: flex;
+		flex-wrap: wrap;
 	}
 
 	.quantity input {


### PR DESCRIPTION
### Summary
Changed the compatibility style for WooCommerce, it was missing the `flex-wrap` property to allow items to flow on a new row if required.

It looked like an issue only on some products that were not using the main style.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Previously:
![image](https://user-images.githubusercontent.com/23024731/160080029-46c3d6c7-1a0c-47e0-99e3-099eabe70c80.png)

After changes:
![image](https://user-images.githubusercontent.com/23024731/160080094-0aac9245-f603-4bd1-925c-e025549b3488.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. enable the new skin in the customization section
2. install the plugin Booking Activities
3. create a product variation that has a booking
4. Choose a product variation type (Activity)
5. Check the booking display on the item


<!-- Issues that this pull request closes. -->
Closes #3161.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
