### PR TITLE
chore: update themeisle-sdk

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.24",
+            "version": "3.2.25",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "e5c171e33120fdf8ce6dd3a7bddad984583023f0"
+                "reference": "c51c7dd36e794d686dd0b622da23f03f6da543a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/e5c171e33120fdf8ce6dd3a7bddad984583023f0",
-                "reference": "e5c171e33120fdf8ce6dd3a7bddad984583023f0",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/c51c7dd36e794d686dd0b622da23f03f6da543a4",
+                "reference": "c51c7dd36e794d686dd0b622da23f03f6da543a4",
                 "shasum": ""
             },
             "require-dev": {
@@ -42,9 +42,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.24"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.25"
             },
-            "time": "2022-02-09T21:11:37+00:00"
+            "time": "2022-03-28T06:50:35+00:00"
         },
         {
             "name": "wptt/webfont-loader",


### PR DESCRIPTION
### Summary
Update SDK to fix the issue with the auto-update link not appearing

Closes Codeinwp/neve-pro-addon#1677.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
