### PR TITLE
Add option to have unitless line height

### DIFF
--- a/assets/apps/components/src/Controls/NumberControl.js
+++ b/assets/apps/components/src/Controls/NumberControl.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import SizingControl from './Sizing';
 import classnames from 'classnames';
 import ResponsiveControl from '../HOC/Responsive.js';
-
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
 const NumberControl = (props) => {
@@ -25,9 +25,19 @@ const NumberControl = (props) => {
 		if (!units) {
 			return '';
 		}
+
+		const labels = {
+			'—': __('No unit', 'neve'),
+		};
+
 		if (units.length === 1) {
 			return (
-				<Button className="alone active" isSmall disabled>
+				<Button
+					className="alone active"
+					title={labels[units[0]] || units[0]}
+					isSmall
+					disabled
+				>
 					{units[0]}
 				</Button>
 			);
@@ -43,6 +53,7 @@ const NumberControl = (props) => {
 					className={classnames({
 						active: activeUnit === unit,
 					})}
+					title={labels[unit] || unit}
 				>
 					{unit}
 				</Button>

--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -171,13 +171,18 @@ const Typeface = (props) => {
 			fontSize = { ...defaultFS };
 		}
 
+		const lowerStepUnits = ['em', '—'];
 		return (
 			<NumberControl
 				className="font-size"
 				label={__('Font Size', 'neve')}
 				default={defaultFS[currentDevice]}
 				value={fontSize[currentDevice]}
-				step={fontSize.suffix[currentDevice] === 'em' ? 0.1 : 1}
+				step={
+					lowerStepUnits.includes(fontSize.suffix[currentDevice])
+						? 0.1
+						: 1
+				}
 				units={fSUnit}
 				activeUnit={fontSize.suffix[currentDevice]}
 				hasResponsive

--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -171,18 +171,13 @@ const Typeface = (props) => {
 			fontSize = { ...defaultFS };
 		}
 
-		const lowerStepUnits = ['em', '—'];
 		return (
 			<NumberControl
 				className="font-size"
 				label={__('Font Size', 'neve')}
 				default={defaultFS[currentDevice]}
 				value={fontSize[currentDevice]}
-				step={
-					lowerStepUnits.includes(fontSize.suffix[currentDevice])
-						? 0.1
-						: 1
-				}
+				step={fontSize.suffix[currentDevice] === 'em' ? 0.1 : 1}
 				units={fSUnit}
 				activeUnit={fontSize.suffix[currentDevice]}
 				hasResponsive
@@ -212,11 +207,16 @@ const Typeface = (props) => {
 		if (!lineHeight) {
 			lineHeight = { ...defaultLH };
 		}
+		const lowerStepUnits = ['em', '—'];
 		return (
 			<NumberControl
 				className="line-height"
 				label={__('Line Height', 'neve')}
-				step={lineHeight.suffix[currentDevice] === 'em' ? 0.1 : 1}
+				step={
+					lowerStepUnits.includes(lineHeight.suffix[currentDevice])
+						? 0.1
+						: 1
+				}
 				default={defaultLH[currentDevice]}
 				value={lineHeight[currentDevice]}
 				units={lHunit}

--- a/assets/apps/customizer-controls/src/typeface/Typeface.js
+++ b/assets/apps/customizer-controls/src/typeface/Typeface.js
@@ -43,7 +43,7 @@ const Typeface = (props) => {
 		onChange,
 		refreshAfterReset = false,
 		fSUnit = ['em', 'px'],
-		lHunit = ['em', 'px'],
+		lHunit = ['em', 'px', '—'],
 		defaultFS = {
 			suffix: {
 				mobile: 'px',

--- a/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
+++ b/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
@@ -8,7 +8,7 @@ const TypefaceComponent = ({ control }) => {
 	let setVal = control.setting.get();
 	let defaultParams = {
 		size_units: ['em', 'px'],
-		line_height_units: ['em', 'px'],
+		line_height_units: ['em', 'px', '—'],
 		weight_default: 400,
 		text_transform: 'none',
 		size_default: {
@@ -70,7 +70,7 @@ const TypefaceComponent = ({ control }) => {
 
 	const emptyDefault = {
 		size_units: ['em', 'px'],
-		line_height_units: ['em', 'px'],
+		line_height_units: ['em', 'px', '-'],
 		weight_default: 'none',
 		text_transform: 'none',
 		size_default: {

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -273,7 +273,7 @@ class Css_Prop {
 			Font_Manager::add_google_font( $font, strval( $value ) );
 		}
 
-		return $suffix;
+		return $suffix === '—' ? '' : $suffix;
 	}
 
 	/**

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -139,7 +139,7 @@ class Typography extends Base_Customizer {
 					'live_refresh_selector' => 'body, .site-title',
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'       => [
+							'vars'     => [
 								'--bodyTextTransform' => 'textTransform',
 								'--bodyFontWeight'    => 'fontWeight',
 								'--bodyFontSize'      => [
@@ -156,8 +156,7 @@ class Typography extends Base_Customizer {
 									'responsive' => true,
 								],
 							],
-							'selector'   => 'body',
-							'unitlessEm' => true,
+							'selector' => 'body',
 						],
 					],
 				],

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -137,6 +137,29 @@ class Typography extends Base_Customizer {
 					'type'                  => 'neve_typeface_control',
 					'font_family_control'   => 'neve_body_font_family',
 					'live_refresh_selector' => 'body, .site-title',
+					'live_refresh_css_prop' => [
+						'cssVar' => [
+							'vars'       => [
+								'--bodyTextTransform' => 'textTransform',
+								'--bodyFontWeight'    => 'fontWeight',
+								'--bodyFontSize'      => [
+									'key'        => 'fontSize',
+									'responsive' => true,
+								],
+								'--bodyLineHeight'    => [
+									'key'        => 'lineHeight',
+									'responsive' => true,
+								],
+								'--bodyLetterSpacing' => [
+									'key'        => 'letterSpacing',
+									'suffix'     => 'px',
+									'responsive' => true,
+								],
+							],
+							'selector'   => 'body',
+							'unitlessEm' => true,
+						],
+					],
 				],
 				'\Neve\Customizer\Controls\React\Typography'
 			)


### PR DESCRIPTION
### Summary
Added the "Unitless" option for line-height property 

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->
https://vertis.d.pr/MOfxMK

### Test instructions
- In customizer go to typography -> general and change the unit for the line-height
- Check that everything works as expected (on both customizer and front-end )
- Do the same for heading controls
- Check the console to make sure there are no errors

<!-- Issues that this pull request closes. -->
Closes #3225.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
