### PR TITLE
Controls with values lower than 1 are not working

### DIFF
--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -292,7 +292,6 @@ class Css_Prop {
 		$suffix   = $suffix ? $suffix : 'px';
 		$template = '';
 
-
 		// Make sure that this is directional, even if an int value is provided.
 		if ( is_int( $value ) ) {
 			$directions = Config::$directional_keys;
@@ -310,11 +309,11 @@ class Css_Prop {
 		}, ARRAY_FILTER_USE_KEY );
 
 		if ( count( array_unique( $filtered ) ) === 1 ) {
-			if ( absint( $value['top'] ) === 0 ) {
+			if ( abs( $value['top'] ) === 0 ) {
 				$suffix = '';
 			}
 
-			if ( empty( $value['top'] ) && absint( $value['top'] ) !== 0 ) {
+			if ( empty( $value['top'] ) && abs( $value['top'] ) !== 0 ) {
 				return '';
 			}
 
@@ -324,10 +323,10 @@ class Css_Prop {
 		}
 
 		if ( count( array_unique( $filtered ) ) === 2 && $value['top'] === $value['bottom'] && $value['right'] === $value['left'] ) {
-			$top_suffix   = absint( $value['top'] ) === 0 ? '' : $suffix;
-			$right_suffix = absint( $value['right'] ) === 0 ? '' : $suffix;
+			$top_suffix   = abs( $value['top'] ) === 0 ? '' : $suffix;
+			$right_suffix = abs( $value['right'] ) === 0 ? '' : $suffix;
 
-			if ( empty( $value['top'] ) && absint( $value['top'] ) !== 0 && empty( $value['right'] ) && absint( $value['right'] ) ) {
+			if ( empty( $value['top'] ) && abs( $value['top'] ) !== 0 && empty( $value['right'] ) && abs( $value['right'] ) ) {
 				return '';
 			}
 
@@ -337,7 +336,7 @@ class Css_Prop {
 		}
 
 		foreach ( Config::$directional_keys as $direction ) {
-			if ( ! isset( $value[ $direction ] ) || absint( $value[ $direction ] ) === 0 ) {
+			if ( ! isset( $value[ $direction ] ) || abs( $value[ $direction ] ) === 0 ) {
 				$template .= '0 ';
 
 				continue;


### PR DESCRIPTION
### Summary
It seems that we allow values less than 1 for directional controls if the unit is set as EM.
Because we use `absint` function to sanitize the value, when setting any directional control with a value less than 1, `absint` will change that value to 0, `absint(0.9) = 0`.

In this PR I've replaced `absint` with `abs` to make sure the value is positive.

### Will affect the visual aspect of the product
NO


### Test instructions
- Have a form on a page. It can be any form. The user had the [Ghostkit](https://wordpress.org/plugins/ghostkit/) Form block.
- Go to customizer -> Form fields and for every control from there, set the unit in EM and the value less than 1.
- After you save in the customizer, make sure the changes apply on frontend too

<!-- Issues that this pull request closes. -->
Closes #3399.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
