### PR TITLE
Add antialiasing on text

### DIFF
--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -16,6 +16,8 @@ body {
 	font-weight: var(--bodyFontWeight);
 	overflow-x: hidden;
 	direction: ltr;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
 }
 
 h1,


### PR DESCRIPTION
### Summary
Added the following code on the body selector:
```
-webkit-font-smoothing: antialiased;
-moz-osx-font-smoothing: grayscale;
```

### Will affect the visual aspect of the product
YES


### Test instructions
- Install the theme
- Import any startersite
- Open the console
- Enable / disable the -webkit-font-smoothing property that exist on body
- Check on Mozilla too

- 
- 

<!-- Issues that this pull request closes. -->
Closes #3408.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
