### PR TITLE
fix: accessing undefined property on object

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
+++ b/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
@@ -7,13 +7,15 @@ import { Button } from '@wordpress/components';
 import { withSelect } from '@wordpress/data';
 
 const StarterSitesUnavailable = ({ templatesPluginData }) => {
-	const { assets, tpcPath, tpcAdminURL, isOnboarding } = neveDash;
+	const { assets, tpcPath, tpcAdminURL, isOnboarding, pluginsURL } = neveDash;
 	const tpcRedirect = tpcAdminURL + (isOnboarding ? '&onboarding=yes' : '');
 	const [installing, setInstalling] = useState(false);
 	const [activating, setActivating] = useState(false);
 	const [updating, setUpdating] = useState(false);
 	const [error, setError] = useState(false);
-	const [currentState, setCurrentState] = useState(templatesPluginData.cta);
+	const [currentState, setCurrentState] = useState(
+		templatesPluginData?.cta || 'install'
+	);
 	const installPlugin = () => {
 		setInstalling(true);
 		wp.updates.ajax('install-plugin', {
@@ -41,7 +43,13 @@ const StarterSitesUnavailable = ({ templatesPluginData }) => {
 		setInstalling(false);
 		setActivating(true);
 		setCurrentState('activate');
-		const activationURL = templatesPluginData.activate;
+		const activationURL = templatesPluginData?.activate || '';
+
+		if (!activationURL) {
+			window.location.href = pluginsURL;
+
+			return;
+		}
 
 		get(activationURL, true).then((r) => {
 			if (r.ok) {
@@ -86,7 +94,7 @@ const StarterSitesUnavailable = ({ templatesPluginData }) => {
 						: __('Install and Activate')}
 				</Button>
 			),
-			activate: (
+			activate: templatesPluginData?.activate && (
 				<Button
 					disabled={activating}
 					isPrimary={!activating}

--- a/assets/apps/dashboard/src/utils/common.js
+++ b/assets/apps/dashboard/src/utils/common.js
@@ -58,8 +58,11 @@ const tabs = {
 };
 
 const { plugins } = neveDash;
-const activeTPC = plugins['templates-patterns-collection'].cta === 'deactivate';
+const activeTPC =
+	plugins['templates-patterns-collection'] &&
+	plugins['templates-patterns-collection'].cta === 'deactivate';
 const properTPC =
+	plugins['templates-patterns-collection'] &&
 	compareVersions(
 		plugins['templates-patterns-collection'].version,
 		'1.0.10'

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -239,6 +239,7 @@ class Main {
 			'hidePluginsTab'          => apply_filters( 'neve_hide_useful_plugins', ! array_key_exists( 'useful_plugins', $old_about_config ) ),
 			'tpcPath'                 => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
 			'tpcAdminURL'             => admin_url( 'themes.php?page=tiob-starter-sites' ),
+			'pluginsURL'              => esc_url( admin_url( 'plugins.php' ) ),
 		];
 
 		if ( defined( 'NEVE_PRO_PATH' ) ) {


### PR DESCRIPTION
### Summary
Fixes edge case where some plugins are not defined in the `neveDash` constant inside the dashboard.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to `inc/admin/dashboard/main.php`;
- Comment line 48 (`'templates-patterns-collection',`);
- Go into the dashboard, the page should load fine;

<!-- Issues that this pull request closes. -->
Closes #3419.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
