### PR TITLE
Content shifting for fancybox [#1468]

### DIFF
--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -2,7 +2,6 @@
 
 html {
 	font-size: 100%;
-	overflow-x: hidden;
 }
 
 body {


### PR DESCRIPTION
### Summary
Here's what is happening:

In order to prevent the page from scrolling behind the lightbox that they open, they add `overflow:hidden` on `body`. Now, to prevent content shifting ( the scrollbar should disappear due to `overflow:hidden` ) , they are adding a `margin-right: 17px` on the body tag.
In our case, we have an `overflow-x:  hidden` on the `html` tag as well and that keeps the scrollbar active, and those 17px they add are making the content shift.

What I did here was to remove the `overflow-x:  hidden` from HTML tag. We have the `overflow-x: hidden;` on the body tag too and if we remove the one on the HTML tag, nothing should happen.

### Will affect the visual aspect of the product
NO


### Test instructions
- On a Windows OS ( you can replicate it on https://browserstack.com/ ) install Neve and [Fancybox](https://ro.wordpress.org/plugins/fancybox-for-wordpress/)
- Create a gallery in one of your posts. **Make sure you set this option, else fancybox won't work https://vertis.d.pr/LVDZxC**
- Click on an image from your gallery
- The content should not shift like it does here https://www.loom.com/share/09e7e8a19f1b477da2380dc0bd5f9b5c

<!-- Issues that this pull request closes. -->
Closes #1468.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
