### PR TITLE
chore: fix mobile sticky when not in global header context #3428

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -7,34 +7,38 @@
 	}
 }
 
-#header-grid.global-styled:not(.neve-transparent-header) {
+#header-grid {
 
-	&.has-sticky-rows--desktop {
+	&.has-sticky-rows--desktop.global-styled:not(.neve-transparent-header),
+	&.has-sticky-rows--mobile.global-styled:not(.neve-transparent-header) {
 		position: fixed;
 	}
 
-	background: var(--bgColor);
-	position: relative;
-	background-image: var(--bgImage, none);
-	background-position: var(--bgPosition, center);
-	background-repeat: no-repeat;
-	background-size: cover;
-	background-attachment: var(--bgAttachment);
+	&.global-styled:not(.neve-transparent-header) {
 
-	&::before {
-		display: block;
-		width: 100%;
-		top: 0;
-		bottom: 0;
-		position: absolute;
-		content: "";
-		background-color: var(--overlayColor);
-		opacity: var(--bgOverlayOpacity);
-	}
+		background: var(--bgColor);
+		position: relative;
+		background-image: var(--bgImage, none);
+		background-position: var(--bgPosition, center);
+		background-repeat: no-repeat;
+		background-size: cover;
+		background-attachment: var(--bgAttachment);
 
-	.header--row,
-	.header--row-inner {
-		background: none;
+		&::before {
+			display: block;
+			width: 100%;
+			top: 0;
+			bottom: 0;
+			position: absolute;
+			content: "";
+			background-color: var(--overlayColor);
+			opacity: var(--bgOverlayOpacity);
+		}
+
+		.header--row,
+		.header--row-inner {
+			background: none;
+		}
 	}
 }
 

--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -9,15 +9,13 @@
 
 #header-grid {
 
-	&.has-sticky-rows--desktop.global-styled:not(.neve-transparent-header),
-	&.has-sticky-rows--mobile.global-styled:not(.neve-transparent-header) {
-		position: fixed;
+	&.global-styled:not(.neve-transparent-header):not(.has-sticky-rows--mobile):not(.has-sticky-rows--desktop) {
+		position: relative;
 	}
 
 	&.global-styled:not(.neve-transparent-header) {
 
 		background: var(--bgColor);
-		position: relative;
 		background-image: var(--bgImage, none);
 		background-position: var(--bgPosition, center);
 		background-repeat: no-repeat;


### PR DESCRIPTION
### Summary
Fix the mobile sticky header when not in the global header context.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
1. Go to Customizer -> Header -> Global Header Settings -> Style -> Enable Advanced Options, and set to off.
![image](https://user-images.githubusercontent.com/23024731/162920375-ea9e211d-5fc3-4b7b-82f9-d8d709e9b18e.png)
2. Set the Main row of the Header to Sticky only for Mobile, it should be sticky on Mobile and Normal on Desktop
3. Check that it also works when is set sticky for Desktop and Normal for Mobile and both set to Sticky.

<!-- Issues that this pull request closes. -->
Closes #3428.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
