### PR TITLE
Fix meta hide title

### DIFF
--- a/views/page-header.php
+++ b/views/page-header.php
@@ -10,7 +10,10 @@ if ( ! empty( $title_style ) ) {
 }
 
 $hide_title          = get_theme_mod( 'neve_page_hide_title', false );
-$specific_hide_title = get_post_meta( get_the_ID(), 'neve_meta_disable_title', true );
+$current_page        = get_queried_object();
+$pid                 = $current_page instanceof WP_Post ? $current_page->ID : get_the_ID();
+$specific_hide_title = get_post_meta( $pid, 'neve_meta_disable_title', true );
+
 if ( ! empty( $specific_hide_title ) ) {
 	$hide_title = $specific_hide_title === 'on';
 }


### PR DESCRIPTION
### Summary
The `get_the_ID()` function was returning the id of the first post instead of the ID of the blog page. I've replaced `get_the_ID()` with `get_queried_object()` function.

### Will affect the visual aspect of the product
NO


### Test instructions
1. Create a fresh WP instance
2. Install Neve (3.2.2) & Neve Pro
3. Import the [Business demo](https://demosites.io/business-gb/)
4. Go on the Blog page
5. You should not see 2 Page Titles anymore
6. Try with blog page and other pages from both customizer and meta  ( make sure the pages don't have the "Page Builder Full Width" template as we don't display the title on that template )
7. Try with posts.

<!-- Issues that this pull request closes. -->
Closes #3432.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
