### PR TITLE
Fix Klarna compatibility issue

### DIFF
--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -197,3 +197,6 @@
 	}
 }
 
+.nv-pay-kco form.checkout {
+	display: block;
+}

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -150,14 +150,13 @@ class Woocommerce {
 			return false;
 		}
 
-		// Klarna compatibility
-		if ( is_checkout() && class_exists( 'WC', false ) ) {
+		// Prevent doing any modifications on the checkout page if the payment method is Klarna.
+		if ( is_checkout() ) {
 			$payment_method = \WC()->session->get( 'chosen_payment_method' );
 			if ( $payment_method === 'kco' ) {
 				return false;
 			}
 		}
-
 
 		$is_shop_template    = Elementor::is_elementor_template( 'archive', 'product_archive' );
 		$is_product_template = Elementor::is_elementor_template( 'single', 'product' );

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -103,8 +103,29 @@ class Woocommerce {
 	 * Initialize the module.
 	 */
 	public function init() {
+		add_filter( 'body_class', array( $this, 'add_payment_method_class' ) );
 		add_action( 'wp', array( $this, 'register_hooks' ), 11 );
 		add_action( 'neve_react_controls_localization', array( $this, 'add_customizer_options' ) );
+	}
+
+	/**
+	 * Add payment method class on body.
+	 *
+	 * @param array $classes Body classes.
+	 *
+	 * @return array
+	 */
+	public function add_payment_method_class( $classes ) {
+		if ( ! class_exists( 'WooCommerce', false ) ) {
+			return $classes;
+		}
+
+		if ( ! is_checkout() ) {
+			return $classes;
+		}
+
+		$classes[] = 'nv-pay-' . \WC()->session->get( 'chosen_payment_method' );
+		return $classes;
 	}
 
 	/**
@@ -126,6 +147,12 @@ class Woocommerce {
 	 */
 	public function should_load() {
 		if ( ! class_exists( 'WooCommerce', false ) ) {
+			return false;
+		}
+
+		// Klarna compatibility
+		$payment_method = \WC()->session->get( 'chosen_payment_method' );
+		if ( is_checkout() && $payment_method === 'kco' ) {
 			return false;
 		}
 

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -151,10 +151,13 @@ class Woocommerce {
 		}
 
 		// Klarna compatibility
-		$payment_method = \WC()->session->get( 'chosen_payment_method' );
-		if ( is_checkout() && $payment_method === 'kco' ) {
-			return false;
+		if ( is_checkout() && class_exists( 'WC', false ) ) {
+			$payment_method = \WC()->session->get( 'chosen_payment_method' );
+			if ( $payment_method === 'kco' ) {
+				return false;
+			}
 		}
+
 
 		$is_shop_template    = Elementor::is_elementor_template( 'archive', 'product_archive' );
 		$is_product_template = Elementor::is_elementor_template( 'single', 'product' );

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -163,7 +163,8 @@ class Woocommerce {
 		$payment_method = WC()->session->get( 'chosen_payment_method' );
 		if ( ! $payment_method ) {
 			// If payment method is null, see if there is only one option;
-			$available_payment_methods = WC()->payment_gateways->get_available_payment_gateways();
+			$payment_gateways          = new WC_Payment_Gateways();
+			$available_payment_methods = $payment_gateways->get_available_payment_gateways();
 			if ( is_array( $available_payment_methods ) && count( $available_payment_methods ) === 1 ) {
 				return array_keys( $available_payment_methods )[0];
 			}

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -15,6 +15,7 @@ use Neve\Customizer\Defaults\Layout;
 use Neve\Views\Breadcrumbs;
 use Neve\Views\Layouts\Layout_Sidebar;
 use RankMath\Helper;
+use WC_Payment_Gateways;
 
 /**
  * Class Woocommerce
@@ -155,10 +156,15 @@ class Woocommerce {
 			return null;
 		}
 
+		if ( ! class_exists( 'WC_Payment_Gateways', false ) ) {
+			return null;
+		}
+
 		$payment_method = WC()->session->get( 'chosen_payment_method' );
 		if ( ! $payment_method ) {
 			// If payment method is null, see if there is only one option;
-			$available_payment_methods = WC()->payment_gateways->get_available_payment_gateways();
+			$payment_gateways          = new WC_Payment_Gateways();
+			$available_payment_methods = $payment_gateways->get_available_payment_gateways();
 			if ( is_array( $available_payment_methods ) && count( $available_payment_methods ) === 1 ) {
 				return array_keys( $available_payment_methods )[0];
 			}

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -156,15 +156,14 @@ class Woocommerce {
 			return null;
 		}
 
-		if ( ! class_exists( 'WC_Payment_Gateways', false ) ) {
+		if ( ! class_exists( 'WC_Payment_Gateways' ) ) {
 			return null;
 		}
 
 		$payment_method = WC()->session->get( 'chosen_payment_method' );
 		if ( ! $payment_method ) {
 			// If payment method is null, see if there is only one option;
-			$payment_gateways          = new WC_Payment_Gateways();
-			$available_payment_methods = $payment_gateways->get_available_payment_gateways();
+			$available_payment_methods = WC()->payment_gateways->get_available_payment_gateways();
 			if ( is_array( $available_payment_methods ) && count( $available_payment_methods ) === 1 ) {
 				return array_keys( $available_payment_methods )[0];
 			}


### PR DESCRIPTION
### Summary
Fixed the compatibility issue with [Klarna Checkout](https://woocommerce.com/products/klarna-checkout/).
What I did was to identify if the paying method is via Klarna and prevent any actions and changes for the checkout page.

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->
-> Before the fix: https://vertis.d.pr/ZpFyau
-> After the fix: https://vertis.d.pr/Uvu47D

### Test instructions
1. Install the provided plugin on a fresh instance
2. In [Klarna settings](https://vertis.d.pr/YkKk9K) set the following credentials for "API Credentials Europe":
username: PK55887_87674d4be58e
password: MWEe5XuMPmSe6tTa
3. There are multiple settings to do to make sure Klarna will work:
- Make sure you have the privacy policy page set in WooCommerce
- Make sure the currency is AUD, CAD, CHF, DKK, EUR, GBP, NOK, SEK, or USD
- Configure Klarna like this: https://vertis.d.pr/BPUwvB
4. Besides Klarna, add another payment method so you will be able to switch between them and test that too.
5. Test with other layouts of checkout pages from PRO ( stepped / vertical ). Make sure you test with https://github.com/Codeinwp/neve-pro-addon/pull/1927. Stepped checkout should not work if Klarna payment method is selected.

### Resources
[klarna-checkout-for-woocommerce.2.7.3.zip](https://github.com/Codeinwp/neve/files/8475392/klarna-checkout-for-woocommerce.2.7.3.zip)


<!-- Issues that this pull request closes. -->
Closes #3050.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
