### PR TITLE
fix: mini cart issues with Elementor [Codeinwp/neve-pro-addon#1863]

### DIFF
--- a/assets/scss/components/compat/woocommerce/_cart.scss
+++ b/assets/scss/components/compat/woocommerce/_cart.scss
@@ -37,7 +37,7 @@
 
 
 //<editor-fold desc="Product thumbnail">
-.product-thumbnail img {
+.product-thumbnail:not([class^="elementor"]) img {
 	min-width: 60px !important;
 }
 
@@ -110,7 +110,7 @@
 
 @mixin cart--tablet() {
 
-	.product-thumbnail img {
+	.product-thumbnail:not([class^="elementor"]) img {
 		min-width: 120px !important;
 	}
 

--- a/assets/scss/components/compat/woocommerce/_nav-cart.scss
+++ b/assets/scss/components/compat/woocommerce/_nav-cart.scss
@@ -132,10 +132,7 @@ $cart-width: 360px;
 		}
 
 		.buttons {
-			display: grid;
-			grid-template-columns: 1fr 1fr;
 			padding: 0 $spacing-md;
-			grid-column-gap: $spacing-md;
 			margin-bottom: $spacing-md;
 
 			&::before {
@@ -151,6 +148,12 @@ $cart-width: 360px;
 			}
 		}
 	}
+}
+
+.woocommerce-mini-cart__buttons {
+	display: grid;
+	grid-template-columns: 1fr 1fr;
+	grid-column-gap: $spacing-md;
 }
 
 //Menu mini cart positioning


### PR DESCRIPTION
I did some debugging here, and this is what I found:

Elementor PRO overrides the mini cart template from WooCoommerce. According to [their article](https://developers.elementor.com/elementor-pro-2-7-new-approach-to-woocommerce-mini-cart/), you can enable or disable the usage of that template by going to Dashboard > Elementor > Settings > Integrations tab > WooCommerce section and choose Enable or Disable.

- If the template is enabled and you condition the header with a mini cart made in Elementor to appear only on the shop page, when you're not on the shop page you'll see the mini cart affected. It will look like this and there's nothing we can do about it:
<img width="1920" alt="Screenshot 2022-04-15 at 11 43 37" src="https://user-images.githubusercontent.com/9929553/163554779-475491e9-1244-4033-bc75-c1e93a4339b8.png">
On the other hand, the mini cart on the shop page will look like this: 
<img width="1917" alt="Screenshot 2022-04-15 at 14 20 58" src="https://user-images.githubusercontent.com/9929553/163565045-b6f76b5b-2c61-495c-b898-542b9aa3f856.png">

- If the template is not enabled the mini cart will look normal on a page that is not using the mini cart from elementor:
<img width="1919" alt="Screenshot 2022-04-15 at 14 22 40" src="https://user-images.githubusercontent.com/9929553/163565162-04dee10e-899f-49b0-9afd-4ff632765985.png">
If the page is build with elementor, this is how it will look:
<img width="1918" alt="Screenshot 2022-04-15 at 14 52 16" src="https://user-images.githubusercontent.com/9929553/163567611-3d5cf17c-4154-45d0-9a1e-b447624e75c6.png">

NOTE: Make sure that after you enable or disable the usage of that template to add a new product in the cart so the cart would update.

I also tested with other themes and it's the same behavior.

This PR only fixes small issues like buttons alignment and some images that were to big.

Closes Codeinwp/neve-pro-addon#1863