### PR TITLE
fix: solves performance module display for related 

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -280,9 +280,10 @@ class Woocommerce {
 				function () {
 					echo '<div class="nv-single-product-top">';
 				},
-				11
+				0
 			);
-			add_action( 'woocommerce_after_single_product_summary', [ $this, 'close_div' ], 1 );
+			// here the priority should always be to close earlier than the Neve PRO performance module opening div
+			add_action( 'woocommerce_after_single_product_summary', [ $this, 'close_div' ], -100 );
 			// Change default for shop columns WooCommerce option.
 			add_filter( 'default_option_woocommerce_catalog_columns', [ $this, 'change_default_shop_cols' ] );
 		}

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -280,7 +280,7 @@ class Woocommerce {
 				function () {
 					echo '<div class="nv-single-product-top">';
 				},
-				0
+				11
 			);
 			// here the priority should always be to close earlier than the Neve PRO performance module opening div
 			add_action( 'woocommerce_after_single_product_summary', [ $this, 'close_div' ], -100 );


### PR DESCRIPTION
### Summary
Solves the div opening and closing on a single product for the new skin.
This was a regression introduced by the fact that the divs were not closing in the correct order on the new skin.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
1. Import a WooCommerce starter-site
2. Enable the Performance module from PRO
3. The layout should not be affected

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1937.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
