### PR TITLE
chore: add padding for submenu items in sidebar menu

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -151,8 +151,7 @@
 
 			&.dropdown-open {
 				display: block;
-				padding-left: 20px;
-				padding-right: 20px;
+				padding-left: 10px;
 			}
 		}
 
@@ -160,8 +159,7 @@
 
 			> li > .sub-menu {
 				display: block;
-				padding-left: 20px;
-				padding-right: 20px;
+				padding-left: 10px;
 			}
 
 			> li > a {

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -151,6 +151,8 @@
 
 			&.dropdown-open {
 				display: block;
+				padding-left: 20px;
+				padding-right: 20px;
 			}
 		}
 
@@ -158,6 +160,8 @@
 
 			> li > .sub-menu {
 				display: block;
+				padding-left: 20px;
+				padding-right: 20px;
 			}
 
 			> li > a {


### PR DESCRIPTION
### Summary
These styles seem to have not been added when we moved to new skin, they exist in old skin: https://github.com/Codeinwp/neve/blob/v3.2.3/assets/scss/elements/navigation/_nav-menu.scss#L217-L220

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<img width="178" alt="image" src="https://user-images.githubusercontent.com/10324144/165178419-b6e706ff-ad6a-49b7-b214-1735c170edf1.png">

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Create a menu item with sub items
- Test mobile menu on mobile
- Test mobile menu on desktop 

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve/issues/3404
<!-- Should look like this: `Closes #1, #2, #3.` . -->
