### PR TITLE
fix: phpstan action for gha

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -94,6 +94,11 @@ jobs:
     name: PHPStan
     runs-on: ubuntu-latest
     steps:
+      - name: Setup PHP version
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          extensions: simplexml, mysql
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Get Composer Cache Directory
@@ -110,7 +115,4 @@ jobs:
       - name: Install composer
         run: composer install --ignore-platform-reqs
       - name: PHPStan Static Analysis
-        uses: php-actions/phpstan@v2
-        with:
-          version: 0.12.99
-          memory_limit: 512M
+        run: composer phpstan -- --memory-limit=512M


### PR DESCRIPTION
### Summary
Changed the Github action for PHPStan

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->

### Test instructions
All tests should pass

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1696.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
