### PR TITLE
fix: legacy search widget display on new skin

### DIFF
--- a/assets/scss/components/elements/_form-elements.scss
+++ b/assets/scss/components/elements/_form-elements.scss
@@ -7,6 +7,14 @@
 	margin: 0 !important;
 }
 
+.widget_search {
+
+	.search-form .search-submit,
+	.search-form .search-field {
+		height: auto;
+	}
+}
+
 .search-form {
 	display: flex;
 	max-width: 100%;


### PR DESCRIPTION
### Summary
Fixed the styles for the search widget prior to 5.8 on the new skin.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. You will need a version of WP under 5.8 I would recommend 5.7.2
2. Create a search widget inside the footer area
3. Increase the row size to 300
4. The search widget should display correctly.

The changes here will also fix widgets that have been ported from 5.7 to the new widget area from 5.8 onwards.

<!-- Issues that this pull request closes. -->
Closes #3265.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
