### PR TITLE
Fix shop sidebar offcanvas

### DIFF
--- a/assets/js/src/customizer-preview/app.js
+++ b/assets/js/src/customizer-preview/app.js
@@ -789,16 +789,37 @@ if (
 				wp.customize(id, function (value) {
 					value.bind(function (newval) {
 						const sidebar = $(self.contentWidths[id].sidebar);
-						if (newval >= 95) {
+
+						let isOffCanvas = false;
+						if (id === 'neve_shop_archive_content_width') {
+							const sidebarLayout = wp
+								.customize('neve_shop_archive_sidebar_layout')
+								.get();
+							if (
+								neveCustomizePreview.shopHasMetaSidebar ===
+									'no' &&
+								sidebarLayout === 'off-canvas'
+							) {
+								isOffCanvas = true;
+							}
+						}
+
+						if (isOffCanvas === false && newval >= 95) {
 							sidebar.addClass('hide');
 						} else {
 							sidebar.removeClass('hide');
 						}
 
-						const style = ` @media (min-width: 961px) {
-							${args.content} { max-width: ${newval}% !important; }
-							${args.sidebar} { max-width: ${100 - newval}% !important; }
-						}`;
+						let style = ` @media (min-width: 961px) {
+							${args.content} { max-width: ${newval}% !important; }`;
+
+						if (isOffCanvas === false) {
+							style += `${args.sidebar} { max-width: ${
+								100 - newval
+							}% !important; }`;
+						}
+
+						style += '}';
 
 						addCSS(id + '-css', style);
 					});

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -807,30 +807,6 @@ class Woocommerce {
 	}
 
 	/**
-	 * Check if we should render the mobile sidebar toggle.
-	 *
-	 * @return bool
-	 */
-	private function should_render_sidebar_toggle() {
-		if ( ! is_active_sidebar( 'shop-sidebar' ) ) {
-			return false;
-		}
-
-		$mod = 'neve_shop_archive_sidebar_layout';
-		if ( is_product() ) {
-			$mod = 'neve_single_product_sidebar_layout';
-		}
-
-		$default   = $this->sidebar_layout_alignment_default( $mod );
-		$theme_mod = apply_filters( 'neve_sidebar_position', get_theme_mod( $mod, $default ) );
-		if ( $theme_mod !== 'right' && $theme_mod !== 'left' ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
 	 * Does what it says.
 	 */
 	private function move_checkout_coupon() {

--- a/inc/customizer/defaults/layout.php
+++ b/inc/customizer/defaults/layout.php
@@ -74,4 +74,18 @@ trait Layout {
 	private function grid_columns_default() {
 		return neve_is_new_skin() ? '{"desktop":3,"tablet":2,"mobile":1}' : '{"desktop":1,"tablet":1,"mobile":1}';
 	}
+
+	/**
+	 * Check if we should render the mobile sidebar toggle.
+	 *
+	 * @return bool
+	 */
+	private function should_render_sidebar_toggle() {
+		if ( ! is_active_sidebar( 'shop-sidebar' ) ) {
+			return false;
+		}
+
+		$body_classes = apply_filters( 'body_class', [] );
+		return is_array( $body_classes ) && in_array( 'neve-off-canvas', $body_classes );
+	}
 }

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -176,7 +176,17 @@ class Loader {
 			NEVE_VERSION,
 			true
 		);
-		global $post_id;
+
+		$shop_has_meta = 'no';
+		$shop_id       = get_option( 'woocommerce_shop_page_id' );
+		if ( ! empty( $shop_id ) ) {
+			$meta = get_post_meta( $shop_id, 'neve_meta_sidebar', true );
+
+			if ( ! empty( $meta ) && $meta !== 'default' ) {
+				$shop_has_meta = 'yes';
+			}
+		}
+
 		wp_localize_script(
 			'neve-customizer-preview',
 			'neveCustomizePreview',
@@ -186,6 +196,7 @@ class Loader {
 					'currentFeaturedImage' => '',
 					'newBuilder'           => neve_is_new_builder(),
 					'newSkin'              => neve_is_new_skin(),
+					'shopHasMetaSidebar'   => $shop_has_meta,
 				)
 			)
 		);

--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -50,7 +50,7 @@ class Layout_Sidebar extends Base_View {
 
 		$class_hide_sidebar_conditionally = '';
 
-		if ( $content_width >= 95 ) {
+		if ( $content_width >= 95 && $this->should_render_sidebar_toggle() === false ) {
 			if ( is_customize_preview() ) {
 				// render the sidebar and hide it with CSS
 				$class_hide_sidebar_conditionally = 'hide';

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -151,6 +151,12 @@ class Metabox_Settings {
 			return (int) get_option( 'page_for_posts' );
 		}
 
+		// On shop page the returning id is the id of the first product. We need the id of the page.
+		// is_archive is true for shop page, so we need to check shop before is_archive
+		if ( class_exists( 'WooCommerce' ) && is_shop() ) {
+			return wc_get_page_id( 'shop' );
+		}
+
 		if ( is_archive() ) {
 			return false;
 		}
@@ -163,10 +169,6 @@ class Metabox_Settings {
 			return false;
 		}
 
-		// On shop page the returning id is the id of the first product. We need the id of the page.
-		if ( class_exists( 'WooCommerce' ) && is_shop() ) {
-			return wc_get_page_id( 'shop' );
-		}
 
 		global $post;
 		if ( empty( $post ) ) {

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -366,8 +366,8 @@ class Metabox_Settings {
 				max-width: ' . $desktop_value . ';
 			}
 			#content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .col{ max-width: ' . absint( $meta_value ) . '%' . esc_attr( $important ) . '; }
-			#content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap,
-			#content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap.shop-sidebar { max-width: ' . absint( $sidebar_width ) . '%' . esc_attr( $important ) . '; }
+			body:not(.neve-off-canvas) #content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap,
+			body:not(.neve-off-canvas) #content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap.shop-sidebar { max-width: ' . absint( $sidebar_width ) . '%' . esc_attr( $important ) . '; }
 		}
 		';
 
@@ -444,21 +444,17 @@ class Metabox_Settings {
 		}
 
 		$has_content_width = get_post_meta( $post_id, self::ENABLE_CONTENT_WIDTH, true );
+		$meta_value        = get_post_meta( $post_id, self::SIDEBAR, true );
+		$sidebar_position  = empty( $meta_value ) || $meta_value === 'default' ? $position : $meta_value;
 
 		if ( $has_content_width === 'on' ) {
 			$content_width = get_post_meta( $post_id, self::CONTENT_WIDTH, true );
-
-			if ( $content_width >= 95 ) {
+			if ( $content_width >= 95 && $sidebar_position !== 'off-canvas' ) {
 				return 'full-width';
 			}
 		}
 
-		$meta_value = get_post_meta( $post_id, self::SIDEBAR, true );
-		if ( empty( $meta_value ) || $meta_value === 'default' ) {
-			return $position;
-		}
-
-		return $meta_value;
+		return $sidebar_position;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Prevent shop sidebar to hide when content is >= 95% and the sidebar is off-canvas
While working on this, I noticed that if shop sidebar was set in customizer as off-canvas and on single shop page you choose right sidebar, the specific setting is not applying. This PR is a fix for that too.

### Will affect visual aspect of the product
NO


### Test instructions
- Import a startersite with WooCommerce
- Edit the shop page and Reset all options to default
- In Customizer change the shop sidebar to off-canvas
- Change the width to 95 or higher
- See if the sidebar is showing and if the toggle that opens the sidebar is working
- Test if everything is ok with other sidebar positions
- Test if the sidebar settings on the single page options overwrite the one from customizer

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1951.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
