### PR TITLE
chore: align external icon for purchase history link

### DIFF
--- a/assets/apps/dashboard/src/Components/LicenseCard.js
+++ b/assets/apps/dashboard/src/Components/LicenseCard.js
@@ -4,12 +4,8 @@ import Toast from './Toast';
 import classnames from 'classnames';
 
 import { __ } from '@wordpress/i18n';
-import { Button, Dashicon, ExternalLink } from '@wordpress/components';
-import {
-	Fragment,
-	useState,
-	createInterpolateElement,
-} from '@wordpress/element';
+import { Button, Dashicon } from '@wordpress/components';
+import { Fragment, useState } from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -26,7 +22,7 @@ const LicenseCard = ({ isVisible, setSettings, changeLicense, license }) => {
 
 	const { valid, expiration } = license;
 	const { whiteLabel, strings } = neveDash;
-	const { licenseCardHeading } = strings;
+	const { licenseCardHeading, licenseCardDescription } = strings;
 
 	if (!isVisible) {
 		return null;
@@ -70,23 +66,12 @@ const LicenseCard = ({ isVisible, setSettings, changeLicense, license }) => {
 		<aside className="sidebar card license">
 			<div className="sidebar-section">
 				{licenseCardHeading && <h4>{licenseCardHeading}</h4>}
-				{!whiteLabel && (
-					<p>
-						{typeof createInterpolateElement !== 'undefined' &&
-							createInterpolateElement(
-								__(
-									'Enter your license from <external_link>ThemeIsle</external_link> purchase history in order to get plugin updates.',
-									'neve'
-								),
-								{
-									external_link: (
-										<ExternalLink href="https://store.themeisle.com/">
-											#dumptext
-										</ExternalLink>
-									),
-								}
-							)}
-					</p>
+				{!whiteLabel && licenseCardDescription && (
+					<p
+						dangerouslySetInnerHTML={{
+							__html: licenseCardDescription,
+						}}
+					/>
 				)}
 				<form
 					className="license-form"

--- a/assets/apps/dashboard/src/Components/LicenseCard.js
+++ b/assets/apps/dashboard/src/Components/LicenseCard.js
@@ -4,8 +4,12 @@ import Toast from './Toast';
 import classnames from 'classnames';
 
 import { __ } from '@wordpress/i18n';
-import { Button, Dashicon } from '@wordpress/components';
-import { Fragment, useState } from '@wordpress/element';
+import { Button, Dashicon, ExternalLink } from '@wordpress/components';
+import {
+	Fragment,
+	useState,
+	createInterpolateElement,
+} from '@wordpress/element';
 import { withDispatch, withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 
@@ -22,7 +26,7 @@ const LicenseCard = ({ isVisible, setSettings, changeLicense, license }) => {
 
 	const { valid, expiration } = license;
 	const { whiteLabel, strings } = neveDash;
-	const { licenseCardHeading, licenseCardDescription } = strings;
+	const { licenseCardHeading } = strings;
 
 	if (!isVisible) {
 		return null;
@@ -66,12 +70,23 @@ const LicenseCard = ({ isVisible, setSettings, changeLicense, license }) => {
 		<aside className="sidebar card license">
 			<div className="sidebar-section">
 				{licenseCardHeading && <h4>{licenseCardHeading}</h4>}
-				{!whiteLabel && licenseCardDescription && (
-					<p
-						dangerouslySetInnerHTML={{
-							__html: licenseCardDescription,
-						}}
-					/>
+				{!whiteLabel && (
+					<p>
+						{typeof createInterpolateElement !== 'undefined' &&
+							createInterpolateElement(
+								__(
+									'Enter your license from <external_link>ThemeIsle</external_link> purchase history in order to get plugin updates.',
+									'neve'
+								),
+								{
+									external_link: (
+										<ExternalLink href="https://store.themeisle.com/">
+											#dumptext
+										</ExternalLink>
+									),
+								}
+							)}
+					</p>
 				)}
 				<form
 					className="license-form"

--- a/assets/apps/dashboard/src/scss/components/_sidebar.scss
+++ b/assets/apps/dashboard/src/scss/components/_sidebar.scss
@@ -21,7 +21,10 @@
 
   a {
     color: $blue;
-	display: inline-block;
+    display: inline-block;
+    svg{
+      vertical-align: bottom;
+    }
   }
 }
 

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -230,7 +230,7 @@ class Main {
 				'licenseCardDescription'        => sprintf(
 				// translators: store name (Themeisle)
 					__( 'Enter your license from %1$s purchase history in order to get plugin updates', 'neve' ),
-					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
+					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
 				),
 			],
 			'changelog'               => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -226,12 +226,6 @@ class Main {
 				'licenseCardHeading'            => sprintf( __( '%s license', 'neve' ), wp_kses_post( $plugin_name_addon ) ),
 				/* translators: %s - "Neve Pro Addon" */
 				'updateOldPro'                  => sprintf( __( 'Please update %s to the latest version and then refresh this page to have access to the options.', 'neve' ), wp_kses_post( $plugin_name_addon ) ),
-				/* translators: %1$s - Author link - Themeisle */
-				'licenseCardDescription'        => sprintf(
-				// translators: store name (Themeisle)
-					__( 'Enter your license from %1$s purchase history in order to get plugin updates', 'neve' ),
-					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
-				),
 			],
 			'changelog'               => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),
 			'onboarding'              => [],

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -226,6 +226,12 @@ class Main {
 				'licenseCardHeading'            => sprintf( __( '%s license', 'neve' ), wp_kses_post( $plugin_name_addon ) ),
 				/* translators: %s - "Neve Pro Addon" */
 				'updateOldPro'                  => sprintf( __( 'Please update %s to the latest version and then refresh this page to have access to the options.', 'neve' ), wp_kses_post( $plugin_name_addon ) ),
+				/* translators: %1$s - Author link - Themeisle */
+				'licenseCardDescription'        => sprintf(
+				// translators: store name (Themeisle)
+					__( 'Enter your license from %1$s purchase history in order to get plugin updates', 'neve' ),
+					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
+				),
 			],
 			'changelog'               => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),
 			'onboarding'              => [],

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -230,7 +230,7 @@ class Main {
 				'licenseCardDescription'        => sprintf(
 				// translators: store name (Themeisle)
 					__( 'Enter your license from %1$s purchase history in order to get plugin updates', 'neve' ),
-					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" class="components-external-link__icon css-6wogo1-StyledIcon etxm6pv0" role="img" aria-hidden="true" focusable="false"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
+					'<a target="_blank" rel="external noreferrer noopener" href="https://store.themeisle.com/">ThemeIsle<span class="components-visually-hidden">' . esc_html__( '(opens in a new tab)', 'neve' ) . '</span><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="20" height="20" class="components-external-link__icon" role="img" aria-hidden="true" focusable="false" style="fill: #0073AA"><path d="M18.2 17c0 .7-.6 1.2-1.2 1.2H7c-.7 0-1.2-.6-1.2-1.2V7c0-.7.6-1.2 1.2-1.2h3.2V4.2H7C5.5 4.2 4.2 5.5 4.2 7v10c0 1.5 1.2 2.8 2.8 2.8h10c1.5 0 2.8-1.2 2.8-2.8v-3.6h-1.5V17zM14.9 3v1.5h3.7l-6.4 6.4 1.1 1.1 6.4-6.4v3.7h1.5V3h-6.3z"></path></svg></a>'
 				),
 			],
 			'changelog'               => $this->cl_handler->get_changelog( get_template_directory() . '/CHANGELOG.md' ),


### PR DESCRIPTION
### Summary
Fix position of external link icon

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

<img width="257" alt="image" src="https://user-images.githubusercontent.com/10324144/166000219-9317dca9-34dc-4ee5-8fde-4cfa68b33ae8.png">


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Installing this patch should fix the position issue for the external link icon: https://vertis.d.pr/YSXccp

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/1957
<!-- Should look like this: `Closes #1, #2, #3.` . -->
