### PR TITLE
fix: smaller selectors for scss

### DIFF
--- a/assets/scss/components/elements/_form-elements.scss
+++ b/assets/scss/components/elements/_form-elements.scss
@@ -9,8 +9,8 @@
 
 .widget_search {
 
-	.search-form .search-submit,
-	.search-form .search-field {
+	.search-submit,
+	.search-field {
 		height: auto;
 	}
 }

--- a/assets/scss/components/elements/_form-elements.scss
+++ b/assets/scss/components/elements/_form-elements.scss
@@ -7,14 +7,6 @@
 	margin: 0 !important;
 }
 
-.widget_search {
-
-	.search-submit,
-	.search-field {
-		height: auto;
-	}
-}
-
 .search-form {
 	display: flex;
 	max-width: 100%;

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -75,6 +75,24 @@ class Footer extends Abstract_Builder {
 		$this->devices = [
 			'desktop' => __( 'Footer', 'neve' ),
 		];
+
+		/**
+		 * Fix legacy search widget display in footer
+		 * Only applies for versions < 5.8
+		 */
+		add_filter(
+			'dynamic_sidebar_params',
+			function ( $params ) {
+				$processed_params = [];
+				foreach ( $params as $param ) {
+					if ( isset( $param['widget_name'] ) && $param['widget_name'] === 'Search' ) {
+						$param['before_widget'] = '<style type="text/css">.widget_search .search-form .search-submit, .widget_search .search-form .search-field { height: auto; }</style>' . $param['before_widget'];
+					}
+					array_push( $processed_params, $param );
+				}
+				return $processed_params;
+			} 
+		);
 	}
 
 	/**

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -86,7 +86,7 @@ class Footer extends Abstract_Builder {
 				$processed_params        = [];
 				$has_legacy_search_style = apply_filters( 'neve_has_legacy_search_style_filter', false );
 				foreach ( $params as $param ) {
-					if ( isset( $param['widget_name'] ) && $param['widget_name'] === 'Search' && $has_legacy_search_style === false ) {
+					if ( isset( $param['before_widget'] ) && strpos( $param['before_widget'], 'widget_search' ) !== false && $has_legacy_search_style === false ) {
 						$param['before_widget'] = '<style type="text/css">.widget_search .search-form .search-submit, .widget_search .search-form .search-field { height: auto; }</style>' . $param['before_widget'];
 						add_filter( 'neve_has_legacy_search_style_filter', '__return_true' );
 					}

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -83,15 +83,17 @@ class Footer extends Abstract_Builder {
 		add_filter(
 			'dynamic_sidebar_params',
 			function ( $params ) {
-				$processed_params = [];
+				$processed_params        = [];
+				$has_legacy_search_style = apply_filters( 'neve_has_legacy_search_style_filter', false );
 				foreach ( $params as $param ) {
-					if ( isset( $param['widget_name'] ) && $param['widget_name'] === 'Search' ) {
+					if ( isset( $param['widget_name'] ) && $param['widget_name'] === 'Search' && $has_legacy_search_style === false ) {
 						$param['before_widget'] = '<style type="text/css">.widget_search .search-form .search-submit, .widget_search .search-form .search-field { height: auto; }</style>' . $param['before_widget'];
+						add_filter( 'neve_has_legacy_search_style_filter', '__return_true' );
 					}
 					array_push( $processed_params, $param );
 				}
 				return $processed_params;
-			} 
+			}
 		);
 	}
 


### PR DESCRIPTION
### Summary
Made selectors for legacy smaller so as to keep the size of the bundle under the limit.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
1. Use the same steps as described here: https://github.com/Codeinwp/neve/pull/3451#issue-1220926380
2. Check that it works with legacy and for the new component the height is adjusted accordingly.

<!-- Issues that this pull request closes. -->
Closes #3265.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
