### PR TITLE
Fix sidebar toggle

### DIFF
--- a/assets/scss/components/elements/_sidebar.scss
+++ b/assets/scss/components/elements/_sidebar.scss
@@ -10,7 +10,7 @@
 	margin-bottom: $spacing-md;
 	flex-grow: 1;
 
-	&.hide {
+	&.hide:not(.shop-sidebar) {
 		display: none;
 	}
 }
@@ -87,6 +87,10 @@
 
 		&.nv-left {
 			padding-right: 45px;
+		}
+
+		&.hide.shop-sidebar {
+			display: none;
 		}
 	}
 }

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -807,6 +807,30 @@ class Woocommerce {
 	}
 
 	/**
+	 * Check if we should render the mobile sidebar toggle.
+	 *
+	 * @return bool
+	 */
+	private function should_render_sidebar_toggle() {
+		if ( ! is_active_sidebar( 'shop-sidebar' ) ) {
+			return false;
+		}
+
+		$mod = 'neve_shop_archive_sidebar_layout';
+		if ( is_product() ) {
+			$mod = 'neve_single_product_sidebar_layout';
+		}
+
+		$default   = $this->sidebar_layout_alignment_default( $mod );
+		$theme_mod = apply_filters( 'neve_sidebar_position', get_theme_mod( $mod, $default ) );
+		if ( $theme_mod !== 'right' && $theme_mod !== 'left' ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
 	 * Does what it says.
 	 */
 	private function move_checkout_coupon() {

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -227,7 +227,7 @@ class Woocommerce {
 		 * Change product page sidebar default position
 		 * Priority 9 to allow meta control to override this value
 		 */
-		add_filter( 'neve_sidebar_position', array( $this, 'product_page_sidebar_default_position' ), 9 );
+		// add_filter( 'neve_sidebar_position', array( $this, 'product_page_sidebar_default_position' ), 9 );
 
 		// Remove WooCommerce wrap.
 		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
@@ -816,9 +816,15 @@ class Woocommerce {
 			return false;
 		}
 
-		$mod = 'neve_shop_archive_sidebar_layout';
-		if ( is_product() ) {
-			$mod = 'neve_single_product_sidebar_layout';
+		$new_skin         = neve_is_new_skin();
+		$advanced_options = get_theme_mod( 'neve_advanced_layout_options', $new_skin );
+
+		$mod = 'neve_default_sidebar_layout';
+		if ( $advanced_options === true ) {
+			$mod = 'neve_shop_archive_sidebar_layout';
+			if ( is_product() ) {
+				$mod = 'neve_single_product_sidebar_layout';
+			}
 		}
 
 		$default   = $this->sidebar_layout_alignment_default( $mod );

--- a/inc/customizer/defaults/layout.php
+++ b/inc/customizer/defaults/layout.php
@@ -76,11 +76,11 @@ trait Layout {
 	}
 
 	/**
-	 * Check if we should render the mobile sidebar toggle.
+	 * Check if the shop sidebar is off-canvas.
 	 *
 	 * @return bool
 	 */
-	private function should_render_sidebar_toggle() {
+	private function shop_sidebar_is_off_canvas() {
 		if ( ! is_active_sidebar( 'shop-sidebar' ) ) {
 			return false;
 		}

--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -51,10 +51,8 @@ class Layout_Sidebar extends Base_View {
 		$class_hide_sidebar_conditionally = '';
 
 		if ( $content_width >= 95 && ! $this->shop_sidebar_is_off_canvas() ) {
-			if ( is_customize_preview() ) {
-				// render the sidebar and hide it with CSS
-				$class_hide_sidebar_conditionally = 'hide';
-			} else {
+			$class_hide_sidebar_conditionally = 'hide';
+			if ( $context !== 'shop' && ! is_customize_preview() ) {
 				// do not load sidebar as SSR
 				return;
 			}

--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -50,7 +50,7 @@ class Layout_Sidebar extends Base_View {
 
 		$class_hide_sidebar_conditionally = '';
 
-		if ( $content_width >= 95 && $this->should_render_sidebar_toggle() === false ) {
+		if ( $content_width >= 95 && ! $this->shop_sidebar_is_off_canvas() ) {
 			if ( is_customize_preview() ) {
 				// render the sidebar and hide it with CSS
 				$class_hide_sidebar_conditionally = 'hide';

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -443,16 +443,8 @@ class Metabox_Settings {
 			return $position;
 		}
 
-		$has_content_width = get_post_meta( $post_id, self::ENABLE_CONTENT_WIDTH, true );
-		$meta_value        = get_post_meta( $post_id, self::SIDEBAR, true );
-		$sidebar_position  = empty( $meta_value ) || $meta_value === 'default' ? $position : $meta_value;
-
-		if ( $has_content_width === 'on' ) {
-			$content_width = get_post_meta( $post_id, self::CONTENT_WIDTH, true );
-			if ( $content_width >= 95 && $sidebar_position !== 'off-canvas' ) {
-				return 'full-width';
-			}
-		}
+		$meta_value       = get_post_meta( $post_id, self::SIDEBAR, true );
+		$sidebar_position = empty( $meta_value ) || $meta_value === 'default' ? $position : $meta_value;
 
 		return $sidebar_position;
 	}


### PR DESCRIPTION
### Summary
- Fix sidebar toggle on mobile

### Will affect the visual aspect of the product
NO

### Test instructions
- Import a starter site with WooCommerce
- Edit the shop page and Reset all options to default
- In Customizer change the shop sidebar to off-canvas
- Change the width to 95 or higher
- See if the sidebar is showing and if the toggle that opens the sidebar is working
- Test if everything is ok with other sidebar positions
- Test if the sidebar settings on the single page options overwrite the one from customizer
- Make sure the toggle for sidebar ( in left, right, or off-canvas position ) on mobile does not disappear
- 
<!-- Issues that this pull request closes. -->
Closes #3465.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
