### PR TITLE
Fix/css vars case

### DIFF
--- a/assets/js/src/customizer-preview/css-var-handler.js
+++ b/assets/js/src/customizer-preview/css-var-handler.js
@@ -107,15 +107,15 @@ export class CSSVariablesHandler {
 		} = value;
 
 		const definitions = {
-			'--bgImage': 'unset',
-			'--overlayColor': 'unset',
-			'--bgOverlayOpacity': 'unset',
-			'--bgAttachment': 'unset',
-			'--bgPosition': 'unset',
+			'--bgimage': 'unset',
+			'--overlaycolor': 'unset',
+			'--bgoverlayopacity': 'unset',
+			'--bgattachment': 'unset',
+			'--bgposition': 'unset',
 		};
 
 		if (type === 'color') {
-			definitions['--bgColor'] = colorValue;
+			definitions['--bgcolor'] = colorValue;
 		} else {
 			const { currentFeaturedImage } = window.neveCustomizePreview;
 
@@ -132,11 +132,11 @@ export class CSSVariablesHandler {
 
 			const focus = `${(x * 100).toFixed(0)}% ${(y * 100).toFixed(0)}%`;
 
-			definitions['--bgImage'] = hasImage ? `url("${finalUrl}")` : 'none';
-			definitions['--overlayColor'] = overlayColorValue || 'transparent';
-			definitions['--bgOverlayOpacity'] = `${overlayOpacity / 100}`;
-			definitions['--bgAttachment'] = fixed ? 'fixed' : 'unset';
-			definitions['--bgPosition'] = focus;
+			definitions['--bgimage'] = hasImage ? `url("${finalUrl}")` : 'none';
+			definitions['--overlaycolor'] = overlayColorValue || 'transparent';
+			definitions['--bgoverlayopacity'] = `${overlayOpacity / 100}`;
+			definitions['--bgattachment'] = fixed ? 'fixed' : 'unset';
+			definitions['--bgposition'] = focus;
 		}
 
 		const properties = Object.entries(definitions)

--- a/assets/scss/components/compat/_elementor.scss
+++ b/assets/scss/components/compat/_elementor.scss
@@ -1,7 +1,7 @@
 //List fixes
 .elementor-widget-text-editor {
-	--listPad: #{$spacing-sm};
-	--listStyle: disc;
+	--listpad: #{$spacing-sm};
+	--liststyle: disc;
 }
 
 // Fix scroll snap

--- a/assets/scss/components/compat/edd/_nav_cart.scss
+++ b/assets/scss/components/compat/edd/_nav_cart.scss
@@ -5,21 +5,21 @@
 	align-items: center;
 
 	&:hover {
-		color: var(--hoverColor, var(--color));
+		color: var(--hovercolor, var(--color));
 	}
 
 	.nv-cart {
 		display: flex;
 
 		svg {
-			width: var(--iconSize);
-			height: var(--iconSize);
+			width: var(--iconsize);
+			height: var(--iconsize);
 		}
 	}
 
 	.edd-cart-icon-label {
 		margin-right: $spacing-xxs;
-		font-size: var(--labelSize);
+		font-size: var(--labelsize);
 	}
 
 	.edd-cart-count {

--- a/assets/scss/components/compat/woocommerce/_account.scss
+++ b/assets/scss/components/compat/woocommerce/_account.scss
@@ -41,13 +41,13 @@ body.woocommerce-account {
 	}
 
 	table.my_account_orders {
-		font-size: var(--bodyFontSize);
+		font-size: var(--bodyfontsize);
 	}
 
 	table {
 		border: 0 !important;
-		--primaryBtnFs: 0.9em;
-		--primaryBtnPadding: 8px 30px;
+		--primarybtnfs: 0.9em;
+		--primarybtnpadding: 8px 30px;
 
 		td {
 			border: 0 !important;

--- a/assets/scss/components/compat/woocommerce/_account.scss
+++ b/assets/scss/components/compat/woocommerce/_account.scss
@@ -9,7 +9,7 @@ body.woocommerce-account {
 	}
 
 	.woocommerce > h2 {
-		font-size: var(--h4FontSize);
+		font-size: var(--h4fontsize);
 		margin-bottom: 0;
 	}
 
@@ -37,7 +37,7 @@ body.woocommerce-account {
 	}
 
 	h2 {
-		--h2FontSize: var(--h3FontSize);
+		--h2fontsize: var(--h3fontsize);
 	}
 
 	table.my_account_orders {

--- a/assets/scss/components/compat/woocommerce/_buttons.scss
+++ b/assets/scss/components/compat/woocommerce/_buttons.scss
@@ -13,7 +13,7 @@
 		align-items: center;
 		justify-content: center;
 		width: auto;
-		padding: var(--secondaryBtnPadding);
+		padding: var(--secondarybtnpadding);
 	}
 
 	li a.added_to_cart {

--- a/assets/scss/components/compat/woocommerce/_cart.scss
+++ b/assets/scss/components/compat/woocommerce/_cart.scss
@@ -64,7 +64,7 @@
 
 	td {
 		background: transparent !important;
-		font-size: var(--bodyFontSize);
+		font-size: var(--bodyfontsize);
 		padding: $spacing-xs 0;
 		border: 0;
 
@@ -141,8 +141,8 @@
 		tr:last-child {
 
 			.button {
-				--secondaryBtnPadding: 15px 40px;
-				--primaryBtnPadding: 18px 40px;
+				--secondarybtnpadding: 15px 40px;
+				--primarybtnpadding: 18px 40px;
 				margin-left: auto;
 			}
 		}
@@ -218,7 +218,7 @@
 	}
 
 	.order-total {
-		font-size: var(--bodyFontSize);
+		font-size: var(--bodyfontsize);
 
 		th {
 			font-weight: 700 !important;
@@ -243,7 +243,7 @@
 	.wc-proceed-to-checkout {
 		display: flex;
 		justify-content: flex-end;
-		--primaryBtnPadding: 15px 40px;
+		--primarybtnpadding: 15px 40px;
 	}
 }
 

--- a/assets/scss/components/compat/woocommerce/_cart.scss
+++ b/assets/scss/components/compat/woocommerce/_cart.scss
@@ -186,7 +186,7 @@
 	border: 0;
 
 	> h2 {
-		font-size: var(--h4FontSize);
+		font-size: var(--h4fontsize);
 	}
 
 	td,
@@ -250,6 +250,6 @@
 .cross-sells {
 
 	> h2 {
-		font-size: var(--h4FontSize);
+		font-size: var(--h4fontsize);
 	}
 }

--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -86,7 +86,7 @@
 			th,
 			td {
 				border: 0;
-				font-weight: var(--bodyFontWeight);
+				font-weight: var(--bodyfontweight);
 				font-size: $text-sm;
 			}
 		}
@@ -101,7 +101,7 @@
 
 			th,
 			bdi {
-				font-size: var(--bodyFontSize);
+				font-size: var(--bodyfontsize);
 				font-weight: 700;
 			}
 		}
@@ -166,7 +166,7 @@
 		&.select2-container--open {
 			outline: 0;
 			box-shadow: 0 0 3px 0 var(--nv-secondary-accent);
-			--formFieldBorderColor: var(--nv-secondary-accent);
+			--formfieldbordercolor: var(--nv-secondary-accent);
 		}
 
 		[data-selected="true"] {
@@ -183,13 +183,13 @@
 	.select2-results__options,
 	.select2-search,
 	.select2-search__field {
-		color: var(--formFieldColor);
-		background-color: var(--formFieldBgColor);
+		color: var(--formfieldcolor);
+		background-color: var(--formfieldbgcolor);
 	}
 
 	.select2-selection__rendered {
 		padding: 0 !important;
-		color: var(--formFieldColor) !important;
+		color: var(--formfieldcolor) !important;
 	}
 
 	.select2-selection__arrow {

--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -23,7 +23,7 @@
 		}
 
 		h2 {
-			font-size: var(--h4FontSize);
+			font-size: var(--h4fontsize);
 		}
 	}
 
@@ -71,8 +71,8 @@
 		}
 
 		th {
-			font-size: var(--h5FontSize);
-			font-weight: var(--h5FontWeight);
+			font-size: var(--h5fontsize);
+			font-weight: var(--h5fontweight);
 			padding: $spacing-sm;
 		}
 

--- a/assets/scss/components/compat/woocommerce/_nav-cart.scss
+++ b/assets/scss/components/compat/woocommerce/_nav-cart.scss
@@ -8,21 +8,21 @@ $cart-width: 360px;
 	align-items: center;
 
 	&:hover {
-		color: var(--hoverColor, var(--color));
+		color: var(--hovercolor, var(--color));
 	}
 
 	.nv-cart {
 		display: flex;
 
 		svg {
-			width: var(--iconSize);
-			height: var(--iconSize);
+			width: var(--iconsize);
+			height: var(--iconsize);
 		}
 	}
 
 	.cart-icon-label {
 		margin-right: $spacing-xxs;
-		font-size: var(--labelSize);
+		font-size: var(--labelsize);
 	}
 
 	.cart-count {
@@ -52,8 +52,8 @@ $cart-width: 360px;
 	z-index: 100;
 	width: $cart-width;
 	text-align: left;
-	--primaryBtnPadding: 13px 15px;
-	--secondaryBtnPadding: 13px 15px;
+	--primarybtnpadding: 13px 15px;
+	--secondarybtnpadding: 13px 15px;
 
 	.widget {
 		// Overflow needed to hide scrollbar.
@@ -140,7 +140,7 @@ $cart-width: 360px;
 			}
 
 			.button {
-				--btnFs: var(--bodyFontSize);
+				--btnfs: var(--bodyfontsize);
 				margin: 0;
 				display: flex;
 				align-items: center;

--- a/assets/scss/components/compat/woocommerce/_notices.scss
+++ b/assets/scss/components/compat/woocommerce/_notices.scss
@@ -13,13 +13,13 @@
 	flex-direction: column-reverse;
 	text-align: center;
 	padding: 15px;
-	--btnFs: $text-sm;
-	--primaryBtnPadding: 10px 15px;
-	--primaryBtnBorderWidth: 3px;
-	--primaryBtnColor: #fff;
-	--primaryBtnHoverColor: #fff;
-	--primaryBtnHoverBg: transparent;
-	--primaryBtnBg: transparent;
+	--btnfs: $text-sm;
+	--primarybtnpadding: 10px 15px;
+	--primarybtnborderwidth: 3px;
+	--primarybtncolor: #fff;
+	--primarybtnhovercolor: #fff;
+	--primarybtnhoverbg: transparent;
+	--primarybtnbg: transparent;
 
 	&::before {
 		display: none;

--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -136,7 +136,7 @@
 	}
 
 	ul.products li.product .price {
-		font-size: var(--bodyFontSize);
+		font-size: var(--bodyfontsize);
 	}
 }
 

--- a/assets/scss/components/compat/woocommerce/_shop-loop.scss
+++ b/assets/scss/components/compat/woocommerce/_shop-loop.scss
@@ -40,7 +40,7 @@
 
 	.out-of-stock-badge {
 		color: var(--nv-text-color);
-		font-weight: var(--h4FontWeight);
+		font-weight: var(--h4fontweight);
 		text-transform: uppercase;
 		position: absolute;
 		top: 50%;

--- a/assets/scss/components/compat/woocommerce/single/_exclusive-products.scss
+++ b/assets/scss/components/compat/woocommerce/single/_exclusive-products.scss
@@ -50,7 +50,7 @@ section.exclusive {
 	}
 
 	ul.products.exclusive-products {
-		--shopColTemplate: 4;
+		--shopcoltemplate: 4;
 		margin: 0;
 	}
 

--- a/assets/scss/components/compat/woocommerce/single/_reviews.scss
+++ b/assets/scss/components/compat/woocommerce/single/_reviews.scss
@@ -6,7 +6,7 @@
 }
 
 .woocommerce-Tabs-panel h2 {
-	font-size: var(--h4FontSize);
+	font-size: var(--h4fontsize);
 }
 
 .woocommerce {
@@ -49,11 +49,11 @@
 	}
 
 	#reply-title {
-		font-size: var(--h4FontSize);
-		font-weight: var(--h2FontWeight);
-		line-height: var(--h2LineHeight);
-		letter-spacing: var(--h2LetterSpacing);
-		text-transform: var(--h2TextTransform);
+		font-size: var(--h4fontsize);
+		font-weight: var(--h2fontweight);
+		line-height: var(--h2lineheight);
+		letter-spacing: var(--h2letterspacing);
+		text-transform: var(--h2texttransform);
 		margin-bottom: $spacing-lg;
 		display: block;
 	}

--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -64,11 +64,11 @@ $headings: [h1,h2,h3,h4,h5,h6];
 
 		&.wp-block,
 		& {
-			font-size: var(--#{$heading}FontSize);
-			font-weight: var(--#{$heading}FontWeight);
-			line-height: var(--#{$heading}LineHeight);
-			letter-spacing: var(--#{$heading}LetterSpacing);
-			text-transform: var(--#{$heading}TextTransform);
+			font-size: var(--#{$heading}fontsize);
+			font-weight: var(--#{$heading}fontweight);
+			line-height: var(--#{$heading}lineheight);
+			letter-spacing: var(--#{$heading}letterspacing);
+			text-transform: var(--#{$heading}texttransform);
 		}
 	}
 }

--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -4,12 +4,12 @@
 body &,
 body & p {
 	color: var(--nv-text-color);
-	font-size: var(--bodyFontSize);
-	line-height: var(--bodyLineHeight);
-	letter-spacing: var(--bodyLetterSpacing);
-	font-family: var(--bodyFontFamily);
-	text-transform: var(--bodyTextTransform);
-	font-weight: var(--bodyFontWeight);
+	font-size: var(--bodyfontsize);
+	line-height: var(--bodylineheight);
+	letter-spacing: var(--bodyletterspacing);
+	font-family: var(--bodyfontfamily);
+	text-transform: var(--bodytexttransform);
+	font-weight: var(--bodyfontweight);
 }
 
 .wp-block {
@@ -53,7 +53,7 @@ h6 {
 
 	&.wp-block,
 	& {
-		font-family: var(--headingsFontFamily, var(--bodyFontFamily));
+		font-family: var(--headingsfontfamily, var(--bodyfontfamily));
 	}
 }
 

--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -75,11 +75,11 @@ $headings: [h1,h2,h3,h4,h5,h6];
 
 .editor-post-title__block .editor-post-title__input {
 	color: var(--nv-text-color);
-	font-size: var(--h1FontSize);
-	font-weight: var(--h1FontWeight);
-	line-height: var(--h1LineHeight);
-	letter-spacing: var(--h1LetterSpacing);
-	text-transform: var(--h1TextTransform);
+	font-size: var(--h1fontsize);
+	font-weight: var(--h1fontweight);
+	line-height: var(--h1lineheight);
+	letter-spacing: var(--h1letterspacing);
+	text-transform: var(--h1texttransform);
 }
 
 // Lists

--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -56,8 +56,8 @@ pre {
 
 .nv-content-wrap,
 .excerpt-wrap {
-	--listPad: 20px;
-	--listStyle: disc;
+	--listpad: 20px;
+	--liststyle: disc;
 
 	ul,
 	ol {

--- a/assets/scss/components/elements/_form-elements.scss
+++ b/assets/scss/components/elements/_form-elements.scss
@@ -11,14 +11,14 @@
 	display: flex;
 	max-width: 100%;
 	line-height: 1;
-	--primaryBtnBg: var(--formFieldBgColor);
-	--primaryBtnHoverBg: var(--formFieldBgColor);
-	--primaryBtnColor: var(--formFieldBorderColor);
-	--primaryBtnHoverColor: var(--formFieldBorderColor);
+	--primarybtnbg: var(--formfieldbgcolor);
+	--primarybtnhoverbg: var(--formfieldbgcolor);
+	--primarybtncolor: var(--formfieldbordercolor);
+	--primarybtnhovercolor: var(--formfieldbordercolor);
 
 	svg {
-		fill: var(--formFieldColor);
-		width: var(--formFieldFontSize);
+		fill: var(--formfieldcolor);
+		width: var(--formfieldfontsize);
 		opacity: 0.5;
 		height: auto;
 	}
@@ -29,10 +29,10 @@
 		align-items: center;
 		min-width: 45px;
 		z-index: 1;
-		--primaryBtnBorderWidth: var(--formFieldBorderWidth);
-		--primaryBtnBorderColor: var(--formFieldBorderColor);
-		--primaryBtnBorderRadius: var(--formFieldBorderRadius);
-		--primaryBtnPadding: var(--formFieldPadding);
+		--primarybtnborderwidth: var(--formfieldborderwidth);
+		--primarybtnbordercolor: var(--formfieldbordercolor);
+		--primarybtnborderradius: var(--formfieldborderradius);
+		--primarybtnpadding: var(--formfieldpadding);
 		height: var(--height);
 		border-bottom-left-radius: 0;
 		border-top-left-radius: 0;
@@ -44,7 +44,7 @@
 			display: block;
 			width: 3px;
 			height: 100%;
-			background-color: var(--formFieldBgColor);
+			background-color: var(--formfieldbgcolor);
 			left: -3px;
 			top: 0;
 			bottom: 0;

--- a/assets/scss/components/elements/_hfg-alignments.scss
+++ b/assets/scss/components/elements/_hfg-alignments.scss
@@ -12,5 +12,5 @@
 footer .nav-ul,
 .item--inner {
 	justify-content: var(--justify, flex-start);
-	text-align: var(--textAlign, left);
+	text-align: var(--textalign, left);
 }

--- a/assets/scss/components/elements/_page.scss
+++ b/assets/scss/components/elements/_page.scss
@@ -15,5 +15,5 @@ body > .wrapper:not(.et-fb-iframe-ancestor) {
 }
 
 .nv-page-title-wrap .nv-page-title {
-	text-align: var(--textAlign, left);
+	text-align: var(--textalign, left);
 }

--- a/assets/scss/components/elements/_sidebar.scss
+++ b/assets/scss/components/elements/_sidebar.scss
@@ -31,7 +31,7 @@
 	.widget-title {
 		margin-bottom: $spacing-xs;
 		font-weight: 700;
-		font-size: var(--h4FontSize);
+		font-size: var(--h4fontsize);
 	}
 
 	ul {

--- a/assets/scss/components/elements/blog/_blogpost-covers.scss
+++ b/assets/scss/components/elements/blog/_blogpost-covers.scss
@@ -16,7 +16,7 @@ $overlay: rgba(0, 0, 0, 0.75);
 }
 
 .cover-post {
-	box-shadow: var(--boxShadow, none);
+	box-shadow: var(--boxshadow, none);
 	position: relative;
 	background-size: cover;
 	display: flex;
@@ -35,7 +35,7 @@ $overlay: rgba(0, 0, 0, 0.75);
 
 	amp-img,
 	img {
-		--boxShadow: none;
+		--boxshadow: none;
 	}
 
 	.inner {

--- a/assets/scss/components/elements/blog/_blogpost-default-alt.scss
+++ b/assets/scss/components/elements/blog/_blogpost-default-alt.scss
@@ -15,7 +15,7 @@
 
 		.nv-post-thumbnail-wrap {
 			margin-bottom: 0;
-			grid-column: var(--thumbGridColumn, 1);
+			grid-column: var(--thumbgridcolumn, 1);
 		}
 
 		.content {
@@ -29,14 +29,14 @@
 	.posts-wrapper > article {
 
 		&.has-post-thumbnail .content {
-			grid-template-columns: var(--postColTemplate, 35fr 65fr);
+			grid-template-columns: var(--postcoltemplate, 35fr 65fr);
 		}
 
 		&.has-post-thumbnail.layout-alternative:nth-child(even) {
-			--thumbGridColumn: 2;
+			--thumbgridcolumn: 2;
 
 			.content {
-				grid-template-columns: var(--postColTemplate, 65fr 35fr);
+				grid-template-columns: var(--postcoltemplate, 65fr 35fr);
 			}
 		}
 	}

--- a/assets/scss/components/elements/blog/_blogpost-index.scss
+++ b/assets/scss/components/elements/blog/_blogpost-index.scss
@@ -25,12 +25,12 @@
 
 	amp-img,
 	img {
-		box-shadow: var(--boxShadow, none);
+		box-shadow: var(--boxshadow, none);
 	}
 }
 
 .posts-wrapper > article {
-	width: var(--postWidth);
+	width: var(--postwidth);
 }
 
 .blog-entry-title {
@@ -116,12 +116,12 @@ article {
 body:not(.nv-blog-default) {
 
 	.posts-wrapper {
-		margin-left: calc(-1 * var(--gridSpacing, 30px) / 2);
-		margin-right: calc(-1 * var(--gridSpacing, 30px) / 2);
+		margin-left: calc(-1 * var(--gridspacing, 30px) / 2);
+		margin-right: calc(-1 * var(--gridspacing, 30px) / 2);
 
 		article {
-			margin-bottom: calc(var(--gridSpacing, 30px));
-			padding: 0 calc(var(--gridSpacing, 30px) / 2);
+			margin-bottom: calc(var(--gridspacing, 30px));
+			padding: 0 calc(var(--gridspacing, 30px) / 2);
 		}
 	}
 }

--- a/assets/scss/components/elements/blog/_blogpost-meta.scss
+++ b/assets/scss/components/elements/blog/_blogpost-meta.scss
@@ -19,8 +19,8 @@
 	}
 
 	.photo {
-		width: var(--avatarSize);
-		height: var(--avatarSize);
+		width: var(--avatarsize);
+		height: var(--avatarsize);
 		border-radius: 50%;
 		transform: translateY(30%);
 		margin-right: 3px;

--- a/assets/scss/components/elements/blog/_pagination.scss
+++ b/assets/scss/components/elements/blog/_pagination.scss
@@ -19,7 +19,7 @@ ul.page-numbers {
 		line-height: 1;
 		margin-right: $spacing-xs;
 		padding: 8px 15px;
-		font-size: var(--bodyFontSize);
+		font-size: var(--bodyfontsize);
 	}
 
 	a,

--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -23,7 +23,7 @@
 }
 
 .entry-header {
-	text-align: var(--textAlign, center);
+	text-align: var(--textalign, center);
 
 	.title {
 		margin-bottom: $spacing-xs;
@@ -119,7 +119,7 @@
 		display: flex;
 		flex-direction: column;
 		z-index: 1;
-		align-self: var(--vAlign, flex-end);
+		align-self: var(--valign, flex-end);
 
 		> *:last-child {
 			margin-bottom: 0;
@@ -133,13 +133,13 @@
 	.container {
 		display: flex;
 		justify-content: var(--justify, center);
-		text-align: var(--textAlign, center);
+		text-align: var(--textalign, center);
 	}
 }
 
 .nv-is-boxed {
 	padding: var(--padding);
-	background: var(--bgColor, var(--nv-light-bg));
+	background: var(--bgcolor, var(--nv-light-bg));
 	color: var(--color, var(--nv-text-color));
 
 	a {
@@ -148,8 +148,8 @@
 }
 
 .nv-overlay {
-	background: var(--bgColor, var(--nv-dark-bg));
-	mix-blend-mode: var(--blendMode, normal);
+	background: var(--bgcolor, var(--nv-dark-bg));
+	mix-blend-mode: var(--blendmode, normal);
 	opacity: calc(var(--opacity) / 100);
 	position: absolute;
 	left: 0;

--- a/assets/scss/components/elements/form-elements/_inputs.scss
+++ b/assets/scss/components/elements/form-elements/_inputs.scss
@@ -32,7 +32,7 @@ textarea,
 	&:focus {
 		outline: 0;
 		box-shadow: 0 0 3px 0 var(--nv-secondary-accent);
-		--formFieldBorderColor: var(--nv-secondary-accent);
+		--formfieldbordercolor: var(--nv-secondary-accent);
 	}
 }
 

--- a/assets/scss/components/elements/navigation/_nav-brand.scss
+++ b/assets/scss/components/elements/navigation/_nav-brand.scss
@@ -31,7 +31,7 @@
 	h1,
 	p {
 		font-size: 24px;
-		font-weight: var(--h1FontWeight);
+		font-weight: var(--h1fontweight);
 		line-height: var(--bodylineheight);
 		letter-spacing: var(--bodyletterspacing);
 		text-transform: var(--texttransform, var(--bodytexttransform));

--- a/assets/scss/components/elements/navigation/_nav-brand.scss
+++ b/assets/scss/components/elements/navigation/_nav-brand.scss
@@ -9,12 +9,12 @@
 	}
 
 	img {
-		max-width: var(--maxWidth);
+		max-width: var(--maxwidth);
 		display: block;
 		margin: 0 auto;
 
 		&[src$=".svg"] {
-			width: var(--maxWidth);
+			width: var(--maxwidth);
 		}
 	}
 
@@ -32,9 +32,9 @@
 	p {
 		font-size: 24px;
 		font-weight: var(--h1FontWeight);
-		line-height: var(--bodyLineHeight);
-		letter-spacing: var(--bodyLetterSpacing);
-		text-transform: var(--textTransform, var(--bodyTextTransform));
+		line-height: var(--bodylineheight);
+		letter-spacing: var(--bodyletterspacing);
+		text-transform: var(--texttransform, var(--bodytexttransform));
 		margin: 0;
 	}
 

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -10,7 +10,7 @@
 }
 
 .dd-title {
-	flex-grow: var(--flexG);
+	flex-grow: var(--flexg);
 	display: flex;
 	align-items: center;
 }
@@ -32,7 +32,7 @@
 	}
 
 	li > a:hover {
-		color: var(--hoverColor);
+		color: var(--hovercolor);
 	}
 
 	> li {
@@ -44,7 +44,7 @@
 		position: relative;
 
 		&.current-menu-item > a:not([href*="#"]) {
-			color: var(--activeColor);
+			color: var(--activecolor);
 		}
 
 		&:hover > .sub-menu,
@@ -67,7 +67,7 @@
 	}
 
 	.sub-menu {
-		background: var(--bgColor, var(--overlayColor));
+		background: var(--bgcolor, var(--overlaycolor));
 		z-index: 100;
 		position: absolute;
 		top: 100%;

--- a/assets/scss/components/elements/navigation/_nav-search.scss
+++ b/assets/scss/components/elements/navigation/_nav-search.scss
@@ -30,12 +30,12 @@
 	outline: 0;
 
 	.nv-icon:hover {
-		color: var(--hoverColor);
+		color: var(--hovercolor);
 	}
 
 	svg {
-		width: var(--iconSize);
-		height: var(--iconSize);
+		width: var(--iconsize);
+		height: var(--iconsize);
 	}
 
 	&.minimal {
@@ -82,7 +82,7 @@
 		.close-responsive-search {
 			display: flex;
 			align-items: center;
-			--primaryBtnPadding: 0 20px;
+			--primarybtnpadding: 0 20px;
 		}
 	}
 
@@ -121,11 +121,11 @@
 .close-responsive-search {
 	background: 0;
 	border: 0;
-	--primaryBtnHoverBg: 0;
+	--primarybtnhoverbg: 0;
 
 	> svg {
 		fill: var(--nv-text-color);
-		width: var(--formFieldFontSize);
+		width: var(--formfieldfontsize);
 		min-width: 25px;
 		min-height: 25px;
 	}

--- a/assets/scss/components/elements/navigation/_nav-styles.scss
+++ b/assets/scss/components/elements/navigation/_nav-styles.scss
@@ -34,7 +34,7 @@
 		right: 0;
 		left: 0;
 		pointer-events: none;
-		background-color: var(--hoverColor, currentColor);
+		background-color: var(--hovercolor, currentColor);
 	}
 }
 

--- a/assets/scss/components/elements/navigation/_nav-toggle.scss
+++ b/assets/scss/components/elements/navigation/_nav-toggle.scss
@@ -8,12 +8,12 @@
 }
 
 .navbar-toggle {
-	--primaryBtnColor: var(--color);
-	--primaryBtnHoverColor: var(--color);
-	--primaryBtnBg: var(--bgColor, transparent);
-	--primaryBtnHoverBg: var(--bgColor, transparent);
-	--primaryBtnBorderWidth: var(--borderWidth, 1px);
-	--primaryBtnBorderRadius: var(--borderRadius, 0);
+	--primarybtncolor: var(--color);
+	--primarybtnhovercolor: var(--color);
+	--primarybtnbg: var(--bgcolor, transparent);
+	--primarybtnhoverbg: var(--bgcolor, transparent);
+	--primarybtnborderwidth: var(--borderwidth, 1px);
+	--primarybtnborderradius: var(--borderradius, 0);
 	padding: var(--padding, 10px 15px);
 	box-shadow: none;
 	display: flex;

--- a/assets/scss/components/hfg/frontend/components/_button.scss
+++ b/assets/scss/components/hfg/frontend/components/_button.scss
@@ -20,7 +20,7 @@
 	}
 
 	.builder-item [class*="button_base"] .button {
-		--primaryBtnPadding: var(--padding);
+		--primarybtnpadding: var(--padding);
 	}
 }
 

--- a/assets/scss/components/hfg/frontend/layout/_footer.scss
+++ b/assets/scss/components/hfg/frontend/layout/_footer.scss
@@ -27,7 +27,7 @@
 
 	.row {
 		display: grid;
-		align-items: var(--vAlign);
+		align-items: var(--valign);
 	}
 
 	.builder-item {

--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -15,12 +15,12 @@
 
 	&.global-styled:not(.neve-transparent-header) {
 
-		background: var(--bgColor);
-		background-image: var(--bgImage, var(--bgColor, none));
-		background-position: var(--bgPosition, center);
+		background: var(--bgcolor);
+		background-image: var(--bgimage, var(--bgcolor, none));
+		background-position: var(--bgposition, center);
 		background-repeat: no-repeat;
 		background-size: cover;
-		background-attachment: var(--bgAttachment);
+		background-attachment: var(--bgattachment);
 
 		&::before {
 			display: block;
@@ -29,8 +29,8 @@
 			bottom: 0;
 			position: absolute;
 			content: "";
-			background-color: var(--overlayColor);
-			opacity: var(--bgOverlayOpacity);
+			background-color: var(--overlaycolor);
+			opacity: var(--bgoverlayopacity);
 		}
 
 		.header--row,
@@ -95,11 +95,11 @@ $desktop: map-get($gl-devices-list, desktop);
 [class*="row-inner"],
 .header-menu-sidebar-bg {
 	position: relative;
-	background-image: var(--bgImage, none);
-	background-position: var(--bgPosition, center);
+	background-image: var(--bgimage, none);
+	background-position: var(--bgposition, center);
 	background-repeat: no-repeat;
 	background-size: cover;
-	background-attachment: var(--bgAttachment);
+	background-attachment: var(--bgattachment);
 
 	&::before {
 		display: block;
@@ -108,22 +108,22 @@ $desktop: map-get($gl-devices-list, desktop);
 		bottom: 0;
 		position: absolute;
 		content: "";
-		background-color: var(--overlayColor);
-		opacity: var(--bgOverlayOpacity);
+		background-color: var(--overlaycolor);
+		opacity: var(--bgoverlayopacity);
 	}
 }
 
 [class*="row-inner"]:not(.footer--row-inner) {
-	border-bottom: var(--rowBWidth, 0) solid var(--rowBColor);
+	border-bottom: var(--rowbwidth, 0) solid var(--rowbcolor);
 }
 
 .footer--row-inner {
-	border-top: var(--rowBWidth, 0) solid var(--rowBColor);
+	border-top: var(--rowbwidth, 0) solid var(--rowbcolor);
 }
 
 [data-row-id] {
 	color: var(--color);
-	background: var(--bgColor);
+	background: var(--bgcolor);
 
 	a {
 		color: var(--color);

--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -24,7 +24,7 @@
 }
 
 .header-menu-sidebar-bg {
-	background-color: var(--bgColor);
+	background-color: var(--bgcolor);
 	color: var(--color);
 	position: relative;
 	display: flex;

--- a/assets/scss/components/hfg/style.scss
+++ b/assets/scss/components/hfg/style.scss
@@ -29,12 +29,12 @@
 
 .builder-item .item--inner {
 	color: var(--color);
-	font-family: var(--fontFamily, var(--bodyFontFamily));
-	font-size: var(--fontSize, var(--bodyFontSize));
-	line-height: var(--lineHeight, var(--bodyLineHeight));
-	letter-spacing: var(--letterSpacing, var(--bodyLetterSpacing));
-	font-weight: var(--fontWeight, var(--bodyFontWeight));
-	text-transform: var(--textTransform, var(--bodyTextTransform));
+	font-family: var(--fontfamily, var(--bodyfontfamily));
+	font-size: var(--fontsize, var(--bodyfontsize));
+	line-height: var(--lineheight, var(--bodylineheight));
+	letter-spacing: var(--letterspacing, var(--bodyletterspacing));
+	font-weight: var(--fontweight, var(--bodyfontweight));
+	text-transform: var(--texttransform, var(--bodytexttransform));
 	padding: var(--padding, 0);
 	margin: var(--margin, 0);
 	position: relative;
@@ -45,6 +45,6 @@
 }
 
 .inherit-ff {
-	font-family: var(--inheritedFF);
-	font-weight: var(--inheritedFW);
+	font-family: var(--inheritedff);
+	font-weight: var(--inheritedfw);
 }

--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -4,45 +4,45 @@
 	box-sizing: border-box;
 	border-color: currentColor;
 	text-align: center;
-	font-family: var(--bodyFontFamily), var(--nv-fallback-ff);
+	font-family: var(--bodyfontfamily), var(--nv-fallback-ff);
 }
 
 %nv-button-primary {
 	cursor: pointer;
 	box-sizing: border-box;
 
-	background: var(--primaryBtnBg);
-	color: var(--primaryBtnColor);
+	background: var(--primarybtnbg);
+	color: var(--primarybtncolor);
 	border-style: solid;
 	border-color: currentColor;
 	fill: currentColor;
-	border-width: var(--primaryBtnBorderWidth, 0);
-	border-radius: var(--primaryBtnBorderRadius, 3px);
-	padding: var(--primaryBtnPadding, 13px 15px);
+	border-width: var(--primarybtnborderwidth, 0);
+	border-radius: var(--primarybtnborderradius, 3px);
+	padding: var(--primarybtnpadding, 13px 15px);
 
-	font-weight: var(--btnFontWeight, 700);
-	font-size: var(--btnFs, var(--bodyFontSize));
-	line-height: var(--btnLineHeight, 1.6);
-	letter-spacing: var(--btnLetterSpacing, var(--bodyLetterSpacing));
-	text-transform: var(--btnTextTransform, none);
+	font-weight: var(--btnfontweight, 700);
+	font-size: var(--btnfs, var(--bodyfontsize));
+	line-height: var(--btnlineheight, 1.6);
+	letter-spacing: var(--btnletterspacing, var(--bodyletterspacing));
+	text-transform: var(--btntexttransform, none);
 }
 
 %nv-button-primary-hover {
-	background: var(--primaryBtnHoverBg);
-	color: var(--primaryBtnHoverColor);
-	border-color: var(--primaryBtnHoverColor);
+	background: var(--primarybtnhoverbg);
+	color: var(--primarybtnhovercolor);
+	border-color: var(--primarybtnhovercolor);
 }
 
 %nv-button-primary-no-border {
 	cursor: pointer;
 	box-sizing: border-box;
-	padding: var(--btnPadding, 13px 15px);
-	border-radius: var(--primaryBtnBorderRadius, 3px);
-	font-weight: var(--btnFontWeight, 700);
-	font-size: var(--btnFs, var(--bodyFontSize));
-	line-height: var(--btnLineHeight, 1.6);
-	letter-spacing: var(--btnLetterSpacing, var(--bodyLetterSpacing));
-	text-transform: var(--btnTextTransform, none);
+	padding: var(--btnpadding, 13px 15px);
+	border-radius: var(--primarybtnborderradius, 3px);
+	font-weight: var(--btnfontweight, 700);
+	font-size: var(--btnfs, var(--bodyfontsize));
+	line-height: var(--btnlineheight, 1.6);
+	letter-spacing: var(--btnletterspacing, var(--bodyletterspacing));
+	text-transform: var(--btntexttransform, none);
 }
 
 %nv-button-primary-no-colors {
@@ -51,120 +51,120 @@
 
 	border-style: solid;
 	border-color: currentColor;
-	border-width: var(--primaryBtnBorderWidth, 0);
-	border-radius: var(--primaryBtnBorderRadius, 3px);
-	padding: var(--primaryBtnPadding, 13px 15px);
+	border-width: var(--primarybtnborderwidth, 0);
+	border-radius: var(--primarybtnborderradius, 3px);
+	padding: var(--primarybtnpadding, 13px 15px);
 
-	font-weight: var(--btnFontWeight, 700);
-	font-size: var(--btnFs, var(--bodyFontSize));
-	line-height: var(--btnLineHeight, 1.6);
-	letter-spacing: var(--btnLetterSpacing, var(--bodyLetterSpacing));
-	text-transform: var(--btnTextTransform, none);
+	font-weight: var(--btnfontweight, 700);
+	font-size: var(--btnfs, var(--bodyfontsize));
+	line-height: var(--btnlineheight, 1.6);
+	letter-spacing: var(--btnletterspacing, var(--bodyletterspacing));
+	text-transform: var(--btntexttransform, none);
 }
 
 %nv-button-secondary {
 	cursor: pointer;
 	box-sizing: border-box;
 
-	background-color: var(--secondaryBtnBg);
-	color: var(--secondaryBtnColor);
+	background-color: var(--secondarybtnbg);
+	color: var(--secondarybtncolor);
 	border-style: solid;
 	border-color: currentColor;
 	fill: currentColor;
-	border-width: var(--secondaryBtnBorderWidth, 0);
-	border-radius: var(--secondaryBtnBorderRadius, 3px);
-	padding: var(--secondaryBtnPadding, 7px 12px);
+	border-width: var(--secondarybtnborderwidth, 0);
+	border-radius: var(--secondarybtnborderradius, 3px);
+	padding: var(--secondarybtnpadding, 7px 12px);
 
-	font-weight: var(--btnFontWeight, 700);
-	font-size: var(--btnFs, var(--bodyFontSize));
-	line-height: var(--btnLineHeight, 1.6);
-	letter-spacing: var(--btnLetterSpacing);
-	text-transform: var(--btnTextTransform, none);
+	font-weight: var(--btnfontweight, 700);
+	font-size: var(--btnfs, var(--bodyfontsize));
+	line-height: var(--btnlineheight, 1.6);
+	letter-spacing: var(--btnletterspacing);
+	text-transform: var(--btntexttransform, none);
 }
 
 %nv-button-secondary-hover {
-	background-color: var(--secondaryBtnHoverBg);
-	color: var(--secondaryBtnHoverColor);
-	border-color: var(--secondaryBtnHoverColor);
+	background-color: var(--secondarybtnhoverbg);
+	color: var(--secondarybtnhovercolor);
+	border-color: var(--secondarybtnhovercolor);
 }
 
 %nv-button-secondary-no-colors {
 	cursor: pointer;
-	border-radius: var(--secondaryBtnBorderRadius, 3px);
+	border-radius: var(--secondarybtnborderradius, 3px);
 	border-style: solid;
 	border-color: currentColor;
-	border-width: var(--secondaryBtnBorderWidth, 0);
-	padding: var(--secondaryBtnPadding, 7px 12px);
+	border-width: var(--secondarybtnborderwidth, 0);
+	padding: var(--secondarybtnpadding, 7px 12px);
 
-	font-weight: var(--btnFontWeight, 700);
-	font-size: var(--btnFs, var(--bodyFontSize));
-	line-height: var(--btnLineHeight, 1.6);
-	letter-spacing: var(--btnLetterSpacing, var(--bodyLetterSpacing));
-	text-transform: var(--btnTextTransform, none);
+	font-weight: var(--btnfontweight, 700);
+	font-size: var(--btnfs, var(--bodyfontsize));
+	line-height: var(--btnlineheight, 1.6);
+	letter-spacing: var(--btnletterspacing, var(--bodyletterspacing));
+	text-transform: var(--btntexttransform, none);
 }
 
 // Form Fields
 %nv-form-fields {
 	border-style: solid;
-	border-color: var(--formFieldBorderColor);
-	border-width: var(--formFieldBorderWidth);
-	border-radius: var(--formFieldBorderRadius, 3px);
-	background: var(--formFieldBgColor);
-	color: var(--formFieldColor);
-	padding: var(--formFieldPadding);
+	border-color: var(--formfieldbordercolor);
+	border-width: var(--formfieldborderwidth);
+	border-radius: var(--formfieldborderradius, 3px);
+	background: var(--formfieldbgcolor);
+	color: var(--formfieldcolor);
+	padding: var(--formfieldpadding);
 
-	text-transform: var(--formFieldTextTransform);
-	font-weight: var(--formFieldFontWeight);
-	font-family: var(--bodyFontFamily);
-	font-size: var(--formFieldFontSize);
-	letter-spacing: var(--formFieldLetterSpacing);
-	line-height: var(--formFieldLineHeight);
+	text-transform: var(--formfieldtexttransform);
+	font-weight: var(--formfieldfontweight);
+	font-family: var(--bodyfontfamily);
+	font-size: var(--formfieldfontsize);
+	letter-spacing: var(--formfieldletterspacing);
+	line-height: var(--formfieldlineheight);
 }
 
 %nv-form-labels {
-	font-weight: var(--formLabelFontWeight, var(--bodyFontWeight));
-	text-transform: var(--formLabelTextTransform);
-	letter-spacing: var(--formLabelLetterSpacing);
-	line-height: var(--formLabelLineHeight);
-	font-size: var(--formLabelFontSize, var(--bodyFontSize));
+	font-weight: var(--formlabelfontweight, var(--bodyfontweight));
+	text-transform: var(--formlabeltexttransform);
+	letter-spacing: var(--formlabelletterspacing);
+	line-height: var(--formlabellineheight);
+	font-size: var(--formlabelfontsize, var(--bodyfontsize));
 }
 
 %nv-has-typography {
-	font-weight: var(--fontWeight);
-	text-transform: var(--textTransform);
-	letter-spacing: var(--letterSpacing);
-	line-height: var(--lineHeight);
-	font-size: var(--fontSize);
+	font-weight: var(--fontweight);
+	text-transform: var(--texttransform);
+	letter-spacing: var(--letterspacing);
+	line-height: var(--lineheight);
+	font-size: var(--fontsize);
 }
 
 %nv-has-h1-typography {
-	font-size: var(--fontSize, var(--h1FontSize));
-	font-weight: var(--fontWeight, var(--h1FontWeight));
-	line-height: var(--lineHeight, var(--h1LineHeight));
-	letter-spacing: var(--letterSpacing, var(--h1LetterSpacing));
-	text-transform: var(--textTransform, var(--h1TextTransform));
+	font-size: var(--fontsize, var(--h1FontSize));
+	font-weight: var(--fontweight, var(--h1FontWeight));
+	line-height: var(--lineheight, var(--h1LineHeight));
+	letter-spacing: var(--letterspacing, var(--h1LetterSpacing));
+	text-transform: var(--texttransform, var(--h1TextTransform));
 }
 
 %nv-has-h2-typography {
-	font-size: var(--fontSize, var(--h2FontSize));
-	font-weight: var(--fontWeight, var(--h2FontWeight));
-	line-height: var(--lineHeight, var(--h2LineHeight));
-	letter-spacing: var(--letterSpacing, var(--h2LetterSpacing));
-	text-transform: var(--textTransform, var(--h2TextTransform));
+	font-size: var(--fontsize, var(--h2FontSize));
+	font-weight: var(--fontweight, var(--h2FontWeight));
+	line-height: var(--lineheight, var(--h2LineHeight));
+	letter-spacing: var(--letterspacing, var(--h2LetterSpacing));
+	text-transform: var(--texttransform, var(--h2TextTransform));
 }
 
 %nv-has-h3-typography {
-	font-size: var(--fontSize, var(--h3FontSize));
-	font-weight: var(--fontWeight, var(--h3FontWeight));
-	line-height: var(--lineHeight, var(--h3LineHeight));
-	letter-spacing: var(--letterSpacing, var(--h3LetterSpacing));
-	text-transform: var(--textTransform, var(--h3TextTransform));
+	font-size: var(--fontsize, var(--h3FontSize));
+	font-weight: var(--fontweight, var(--h3FontWeight));
+	line-height: var(--lineheight, var(--h3LineHeight));
+	letter-spacing: var(--letterspacing, var(--h3LetterSpacing));
+	text-transform: var(--texttransform, var(--h3TextTransform));
 }
 
 %nv-has-h4-typography {
-	font-size: var(--fontSize, var(--h4FontSize));
-	font-weight: var(--fontWeight, var(--h4FontWeight));
-	line-height: var(--lineHeight, var(--h4LineHeight));
-	letter-spacing: var(--letterSpacing, var(--h4LetterSpacing));
-	text-transform: var(--textTransform, var(--h4TextTransform));
+	font-size: var(--fontsize, var(--h4FontSize));
+	font-weight: var(--fontweight, var(--h4FontWeight));
+	line-height: var(--lineheight, var(--h4LineHeight));
+	letter-spacing: var(--letterspacing, var(--h4LetterSpacing));
+	text-transform: var(--texttransform, var(--h4TextTransform));
 }

--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -138,33 +138,33 @@
 }
 
 %nv-has-h1-typography {
-	font-size: var(--fontsize, var(--h1FontSize));
-	font-weight: var(--fontweight, var(--h1FontWeight));
-	line-height: var(--lineheight, var(--h1LineHeight));
-	letter-spacing: var(--letterspacing, var(--h1LetterSpacing));
-	text-transform: var(--texttransform, var(--h1TextTransform));
+	font-size: var(--fontsize, var(--h1fontsize));
+	font-weight: var(--fontweight, var(--h1fontweight));
+	line-height: var(--lineheight, var(--h1lineheight));
+	letter-spacing: var(--letterspacing, var(--h1letterspacing));
+	text-transform: var(--texttransform, var(--h1texttransform));
 }
 
 %nv-has-h2-typography {
-	font-size: var(--fontsize, var(--h2FontSize));
-	font-weight: var(--fontweight, var(--h2FontWeight));
-	line-height: var(--lineheight, var(--h2LineHeight));
-	letter-spacing: var(--letterspacing, var(--h2LetterSpacing));
-	text-transform: var(--texttransform, var(--h2TextTransform));
+	font-size: var(--fontsize, var(--h2fontsize));
+	font-weight: var(--fontweight, var(--h2fontweight));
+	line-height: var(--lineheight, var(--h2lineheight));
+	letter-spacing: var(--letterspacing, var(--h2letterspacing));
+	text-transform: var(--texttransform, var(--h2texttransform));
 }
 
 %nv-has-h3-typography {
-	font-size: var(--fontsize, var(--h3FontSize));
-	font-weight: var(--fontweight, var(--h3FontWeight));
-	line-height: var(--lineheight, var(--h3LineHeight));
-	letter-spacing: var(--letterspacing, var(--h3LetterSpacing));
-	text-transform: var(--texttransform, var(--h3TextTransform));
+	font-size: var(--fontsize, var(--h3fontsize));
+	font-weight: var(--fontweight, var(--h3fontweight));
+	line-height: var(--lineheight, var(--h3lineheight));
+	letter-spacing: var(--letterspacing, var(--h3letterspacing));
+	text-transform: var(--texttransform, var(--h3texttransform));
 }
 
 %nv-has-h4-typography {
-	font-size: var(--fontsize, var(--h4FontSize));
-	font-weight: var(--fontweight, var(--h4FontWeight));
-	line-height: var(--lineheight, var(--h4LineHeight));
-	letter-spacing: var(--letterspacing, var(--h4LetterSpacing));
-	text-transform: var(--texttransform, var(--h4TextTransform));
+	font-size: var(--fontsize, var(--h4fontsize));
+	font-weight: var(--fontweight, var(--h4fontweight));
+	line-height: var(--lineheight, var(--h4lineheight));
+	letter-spacing: var(--letterspacing, var(--h4letterspacing));
+	text-transform: var(--texttransform, var(--h4texttransform));
 }

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -7,12 +7,12 @@ html {
 body {
 	background-color: var(--nv-site-bg);
 	color: var(--nv-text-color);
-	font-size: var(--bodyFontSize);
-	line-height: var(--bodyLineHeight);
-	letter-spacing: var(--bodyLetterSpacing);
-	font-family: var(--bodyFontFamily), var(--nv-fallback-ff);
-	text-transform: var(--bodyTextTransform);
-	font-weight: var(--bodyFontWeight);
+	font-size: var(--bodyfontsize);
+	line-height: var(--bodylineheight);
+	letter-spacing: var(--bodyletterspacing);
+	font-family: var(--bodyfontfamily), var(--nv-fallback-ff);
+	text-transform: var(--bodytexttransform);
+	font-weight: var(--bodyfontweight);
 	overflow-x: hidden;
 	direction: ltr;
 	-webkit-font-smoothing: antialiased;
@@ -26,7 +26,7 @@ h4,
 h5,
 h6 {
 	margin-bottom: $spacing-lg;
-	font-family: var(--headingsFontFamily), var(--nv-fallback-ff);
+	font-family: var(--headingsfontfamily), var(--nv-fallback-ff);
 }
 
 p {
@@ -34,11 +34,11 @@ p {
 }
 
 a {
-	--linkDeco: none;
+	--linkdeco: none;
 
 	color: var(--nv-primary-accent);
 	cursor: pointer;
-	text-decoration: var(--linkDeco);
+	text-decoration: var(--linkdeco);
 
 	&:hover,
 	&:focus {
@@ -53,7 +53,7 @@ a {
 .nv-comment-content {
 
 	a:not([class]) {
-		--linkDeco: underline;
+		--linkdeco: underline;
 	}
 }
 
@@ -111,9 +111,9 @@ h6 {
 
 ul,
 ol {
-	padding-left: var(--listPad, 0);
+	padding-left: var(--listpad, 0);
 }
 
 ul {
-	list-style: var(--listStyle, none);
+	list-style: var(--liststyle, none);
 }

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -62,51 +62,51 @@ ins {
 }
 
 h1 {
-	font-size: var(--h1FontSize);
-	font-weight: var(--h1FontWeight);
-	line-height: var(--h1LineHeight);
-	letter-spacing: var(--h1LetterSpacing);
-	text-transform: var(--h1TextTransform);
+	font-size: var(--h1fontsize);
+	font-weight: var(--h1fontweight);
+	line-height: var(--h1lineheight);
+	letter-spacing: var(--h1letterspacing);
+	text-transform: var(--h1texttransform);
 }
 
 h2 {
-	font-size: var(--h2FontSize);
-	font-weight: var(--h2FontWeight);
-	line-height: var(--h2LineHeight);
-	letter-spacing: var(--h2LetterSpacing);
-	text-transform: var(--h2TextTransform);
+	font-size: var(--h2fontsize);
+	font-weight: var(--h2fontweight);
+	line-height: var(--h2lineheight);
+	letter-spacing: var(--h2letterspacing);
+	text-transform: var(--h2texttransform);
 }
 
 h3 {
-	font-size: var(--h3FontSize);
-	font-weight: var(--h3FontWeight);
-	line-height: var(--h3LineHeight);
-	letter-spacing: var(--h3LetterSpacing);
-	text-transform: var(--h3TextTransform);
+	font-size: var(--h3fontsize);
+	font-weight: var(--h3fontweight);
+	line-height: var(--h3lineheight);
+	letter-spacing: var(--h3letterspacing);
+	text-transform: var(--h3texttransform);
 }
 
 h4 {
-	font-size: var(--h4FontSize);
-	font-weight: var(--h4FontWeight);
-	line-height: var(--h4LineHeight);
-	letter-spacing: var(--h4LetterSpacing);
-	text-transform: var(--h4TextTransform);
+	font-size: var(--h4fontsize);
+	font-weight: var(--h4fontweight);
+	line-height: var(--h4lineheight);
+	letter-spacing: var(--h4letterspacing);
+	text-transform: var(--h4texttransform);
 }
 
 h5 {
-	font-size: var(--h5FontSize);
-	font-weight: var(--h5FontWeight);
-	line-height: var(--h5LineHeight);
-	letter-spacing: var(--h5LetterSpacing);
-	text-transform: var(--h5TextTransform);
+	font-size: var(--h5fontsize);
+	font-weight: var(--h5fontweight);
+	line-height: var(--h5lineheight);
+	letter-spacing: var(--h5letterspacing);
+	text-transform: var(--h5texttransform);
 }
 
 h6 {
-	font-size: var(--h6FontSize);
-	font-weight: var(--h6FontWeight);
-	line-height: var(--h6LineHeight);
-	letter-spacing: var(--h6LetterSpacing);
-	text-transform: var(--h6TextTransform);
+	font-size: var(--h6fontsize);
+	font-weight: var(--h6fontweight);
+	line-height: var(--h6lineheight);
+	letter-spacing: var(--h6letterspacing);
+	text-transform: var(--h6texttransform);
 }
 
 ul,

--- a/assets/scss/lifter.scss
+++ b/assets/scss/lifter.scss
@@ -117,10 +117,10 @@
 }
 
 .llms-form-field .select2-container .select2-selection--single{
-  background: var(--formFieldBgColor);
+  background: var(--formfieldbgcolor);
   border-style: solid;
-  border-color: var(--formFieldBorderColor);
-  border-width: var(--formFieldBorderWidth);
+  border-color: var(--formfieldbordercolor);
+  border-width: var(--formfieldborderwidth);
 }
 
 .lifterlms .select2-container--default .select2-selection--single .select2-selection__rendered,
@@ -151,13 +151,13 @@ td .llms-progress .llms-progress-bar{
 }
 
 .llms-progress .progress-bar-complete{
-	background-color: var(--lLmsPrimaryColor,var(--nv-primary-accent));
+	background-color: var(--llmsprimarycolor,var(--nv-primary-accent));
 }
 
 .llms-donut{
-  color: var(--lLmsPrimaryColor,var(--nv-primary-accent));
+  color: var(--llmsprimarycolor,var(--nv-primary-accent));
   svg path{
-	stroke: var(--lLmsPrimaryColor,var(--nv-primary-accent));
+	stroke: var(--llmsprimarycolor,var(--nv-primary-accent));
   }
 }
 

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -407,7 +407,7 @@ abstract class Abstract_Builder implements Builder {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'responsive'           => true,
-							'vars'                 => '--rowBWidth',
+							'vars'                 => '--rowbwidth',
 							'suffix'               => 'px',
 							'fallback'             => '0',
 							'selector'             => '.' . $this->get_id() . '-' . $row_id,
@@ -447,7 +447,7 @@ abstract class Abstract_Builder implements Builder {
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'     => '--rowBColor',
+							'vars'     => '--rowbcolor',
 							'selector' => '.' . $this->get_id() . '-' . $row_id,
 						],
 					],
@@ -1151,7 +1151,7 @@ abstract class Abstract_Builder implements Builder {
 				Dynamic_Selector::META_DEFAULT       => '{ desktop: 0, tablet: 0, mobile: 0 }',
 			];
 
-			$rules['--rowBWidth'] = [
+			$rules['--rowbwidth'] = [
 				Dynamic_Selector::META_KEY           => $this->control_id . '_' . $row_index . '_' . self::BOTTOM_BORDER,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_FILTER        => function ( $css_prop, $value, $meta, $device ) {
@@ -1164,7 +1164,7 @@ abstract class Abstract_Builder implements Builder {
 				},
 			];
 
-			$rules['--rowBColor'] = [
+			$rules['--rowbcolor'] = [
 				Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_' . self::BORDER_COLOR,
 				Dynamic_Selector::META_DEFAULT => 'var(--nv-light-bg)',
 			];
@@ -1192,7 +1192,7 @@ abstract class Abstract_Builder implements Builder {
 				$rules = array_merge(
 					$rules,
 					[
-						'--bgColor' => [
+						'--bgcolor' => [
 							Dynamic_Selector::META_KEY     => $this->control_id . '_' . $row_index . '_background.colorValue',
 							Dynamic_Selector::META_DEFAULT => $default_color,
 						],
@@ -1204,17 +1204,17 @@ abstract class Abstract_Builder implements Builder {
 				$rules = array_merge(
 					$rules,
 					[
-						'--overlayColor'     => [
+						'--overlaycolor'     => [
 							Dynamic_Selector::META_KEY => $this->control_id . '_' . $row_index . '_background.overlayColorValue',
 						],
-						'--bgImage'          => [
+						'--bgimage'          => [
 							Dynamic_Selector::META_KEY    => $this->control_id . '_' . $row_index . '_background',
 							Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 								$image = $this->get_row_featured_image( $value['imageUrl'], $value['useFeatured'], $meta );
 								return sprintf( '%s:%s;', $css_prop, $image );
 							},
 						],
-						'--bgPosition'       => [
+						'--bgposition'       => [
 							Dynamic_Selector::META_KEY    => $this->control_id . '_' . $row_index . '_background',
 							Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 								if ( ! $this->is_valid_focus_point( $value['focusPoint'] ) ) {
@@ -1226,7 +1226,7 @@ abstract class Abstract_Builder implements Builder {
 								return sprintf( '%s:%s;', $css_prop, $parsed_position );
 							},
 						],
-						'--bgAttachment'     => [
+						'--bgattachment'     => [
 							Dynamic_Selector::META_KEY    => $this->control_id . '_' . $row_index . '_background',
 							Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 								if ( ! isset( $value['fixed'] ) || $value['fixed'] !== true ) {
@@ -1236,7 +1236,7 @@ abstract class Abstract_Builder implements Builder {
 								return sprintf( '%s:fixed;', $css_prop );
 							},
 						],
-						'--bgOverlayOpacity' => [
+						'--bgoverlayopacity' => [
 							Dynamic_Selector::META_KEY    => $this->control_id . '_' . $row_index . '_background',
 							Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 								if ( ! isset( $value['overlayOpacity'] ) ) {
@@ -2002,8 +2002,8 @@ abstract class Abstract_Builder implements Builder {
 					'cssVar' => [
 						'vars'       => [
 							'--justify',
-							'--textAlign',
-							'--flexG',
+							'--textalign',
+							'--flexg',
 						],
 						'valueRemap' => [
 							'--justify' => [
@@ -2011,7 +2011,7 @@ abstract class Abstract_Builder implements Builder {
 								'center' => 'center',
 								'right'  => 'flex-end',
 							],
-							'--flexG'   => [
+							'--flexg'   => [
 								'left'   => '1',
 								'center' => '0',
 								'right'  => '0',
@@ -2177,7 +2177,7 @@ abstract class Abstract_Builder implements Builder {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [
-						'vars'     => '--vAlign',
+						'vars'     => '--valign',
 						'selector' => '.' . $this->get_id() . '-' . $row_id . ' .row',
 					],
 					'is_for' => 'vertical',
@@ -2298,12 +2298,12 @@ abstract class Abstract_Builder implements Builder {
 						},
 						Dynamic_Selector::META_DEFAULT => $align_default,
 					],
-					'--textAlign' => [
+					'--textalign' => [
 						Dynamic_Selector::META_KEY     => $align_id,
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_DEFAULT => $align_default,
 					],
-					'--flexG'     => [
+					'--flexg'     => [
 						Dynamic_Selector::META_KEY     => $align_id,
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_FILTER  => function ( $css_prop, $value, $meta, $device ) {
@@ -2371,7 +2371,7 @@ abstract class Abstract_Builder implements Builder {
 						return sprintf( '%s:%s;', $css_prop, $proportions );
 					},
 				],
-				'--vAlign'                          => [
+				'--valign'                          => [
 					Dynamic_Selector::META_KEY     => $mods_prefix . self::VERTICAL_ALIGN,
 					Dynamic_Selector::META_DEFAULT => 'flex-start',
 				],

--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -395,7 +395,7 @@ class Header extends Abstract_Builder {
 			$rules = array_merge(
 				$rules,
 				[
-					'--bgColor' => [
+					'--bgcolor' => [
 						Dynamic_Selector::META_KEY     => $control_id . '.colorValue',
 						Dynamic_Selector::META_DEFAULT => $default_color,
 					],
@@ -407,17 +407,17 @@ class Header extends Abstract_Builder {
 			$rules = array_merge(
 				$rules,
 				[
-					'--overlayColor'     => [
+					'--overlaycolor'     => [
 						Dynamic_Selector::META_KEY => $control_id . '.overlayColorValue',
 					],
-					'--bgImage'          => [
+					'--bgimage'          => [
 						Dynamic_Selector::META_KEY    => $control_id,
 						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 							$image = $this->get_row_featured_image( $value['imageUrl'], $value['useFeatured'], $meta );
 							return sprintf( '%s:%s;', $css_prop, $image );
 						},
 					],
-					'--bgPosition'       => [
+					'--bgposition'       => [
 						Dynamic_Selector::META_KEY    => $control_id,
 						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 							if ( ! $this->is_valid_focus_point( $value['focusPoint'] ) ) {
@@ -429,7 +429,7 @@ class Header extends Abstract_Builder {
 							return sprintf( '%s:%s;', $css_prop, $parsed_position );
 						},
 					],
-					'--bgAttachment'     => [
+					'--bgattachment'     => [
 						Dynamic_Selector::META_KEY    => $control_id,
 						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 							if ( ! isset( $value['fixed'] ) || $value['fixed'] !== true ) {
@@ -439,7 +439,7 @@ class Header extends Abstract_Builder {
 							return sprintf( '%s:fixed;', $css_prop );
 						},
 					],
-					'--bgOverlayOpacity' => [
+					'--bgoverlayopacity' => [
 						Dynamic_Selector::META_KEY    => $control_id,
 						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 							if ( ! isset( $value['overlayOpacity'] ) ) {

--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -752,37 +752,37 @@ abstract class Abstract_Component implements Component {
 			$rules = array_merge(
 				$rules,
 				[
-					'--fontFamily'    => [
+					'--fontfamily'    => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FONT_FAMILY_ID,
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FONT_FAMILY_ID ),
 					],
-					'--fontSize'      => [
+					'--fontsize'      => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.fontSize',
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_SUFFIX  => 'em',
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'fontSize' ),
 					],
-					'--lineHeight'    => [
+					'--lineheight'    => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.lineHeight',
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'lineHeight' ),
 					],
-					'--letterSpacing' => [
+					'--letterspacing' => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.letterSpacing',
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_SUFFIX  => 'px',
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'letterSpacing' ),
 					],
-					'--fontWeight'    => [
+					'--fontweight'    => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.fontWeight',
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'fontWeight' ),
 						'font'                         => 'mods_' . $this->get_id() . '_' . self::FONT_FAMILY_ID,
 					],
-					'--textTransform' => [
+					'--texttransform' => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.textTransform',
 						Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'textTransform' ),
 					],
-					'--iconSize'      => [
+					'--iconsize'      => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.fontSize',
 						Dynamic_Selector::META_IS_RESPONSIVE => true,
 						Dynamic_Selector::META_SUFFIX  => 'responsive_suffix',
@@ -795,11 +795,11 @@ abstract class Abstract_Component implements Component {
 				$css_array[] = [
 					Dynamic_Selector::KEY_SELECTOR => '.hfg-is-group.has-' . $this->get_id() . ' .inherit-ff',
 					Dynamic_Selector::KEY_RULES    => [
-						'--inheritedFF' => [
+						'--inheritedff' => [
 							Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FONT_FAMILY_ID,
 							Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FONT_FAMILY_ID ),
 						],
-						'--inheritedFW' => [
+						'--inheritedfw' => [
 							Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::TYPEFACE_ID . '.fontWeight',
 							Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::TYPEFACE_ID, 'fontWeight' ),
 						],
@@ -809,7 +809,7 @@ abstract class Abstract_Component implements Component {
 		}
 
 		if ( $this->has_horizontal_alignment ) {
-			$rules['--textAlign'] = [
+			$rules['--textalign'] = [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::ALIGNMENT_ID,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::ALIGNMENT_ID ),
@@ -900,7 +900,7 @@ abstract class Abstract_Component implements Component {
 					'live_refresh_selector' => $this->default_typography_selector,
 					'live_refresh_css_prop' => array(
 						'cssVar' => [
-							'vars'     => '--fontFamily',
+							'vars'     => '--fontfamily',
 							'selector' => '.builder-item--' . $this->get_id(),
 						],
 					),
@@ -926,17 +926,17 @@ abstract class Abstract_Component implements Component {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'     => [
-								'--textTransform' => 'textTransform',
-								'--fontWeight'    => 'fontWeight',
-								'--fontSize'      => [
+								'--texttransform' => 'textTransform',
+								'--fontweight'    => 'fontWeight',
+								'--fontsize'      => [
 									'key'        => 'fontSize',
 									'responsive' => true,
 								],
-								'--lineHeight'    => [
+								'--lineheight'    => [
 									'key'        => 'lineHeight',
 									'responsive' => true,
 								],
-								'--letterSpacing' => [
+								'--letterspacing' => [
 									'key'        => 'letterSpacing',
 									'suffix'     => 'px',
 									'responsive' => true,
@@ -1053,7 +1053,7 @@ abstract class Abstract_Component implements Component {
 				'live_refresh_css_prop' => [
 					'cssVar'         => [
 						'vars'       => [
-							'--textAlign',
+							'--textalign',
 							'--justify',
 						],
 						'valueRemap' => [

--- a/header-footer-grid/Core/Components/Button.php
+++ b/header-footer-grid/Core/Components/Button.php
@@ -142,15 +142,15 @@ class Button extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar' => [
 						'vars'     => [
-							'--primaryBtnBg'           => 'background',
-							'--primaryBtnColor'        => 'text',
-							'--primaryBtnHoverBg'      => 'backgroundHover',
-							'--primaryBtnHoverColor'   => 'textHover',
-							'--primaryBtnBorderRadius' => [
+							'--primarybtnbg'           => 'background',
+							'--primarybtncolor'        => 'text',
+							'--primarybtnhoverbg'      => 'backgroundHover',
+							'--primarybtnhovercolor'   => 'textHover',
+							'--primarybtnborderradius' => [
 								'key'    => 'borderRadius',
 								'suffix' => 'px',
 							],
-							'--primaryBtnBorderWidth'  => [
+							'--primarybtnborderwidth'  => [
 								'key'    => 'borderWidth',
 								'suffix' => 'px',
 							],
@@ -218,18 +218,18 @@ class Button extends Abstract_Component {
 		$value = get_theme_mod( $id );
 
 		$rules = [
-			'--primaryBtnBg'           => [ Dynamic_Selector::META_KEY => $id . '.background' ],
-			'--primaryBtnColor'        => [ Dynamic_Selector::META_KEY => $id . '.text' ],
-			'--primaryBtnHoverBg'      => [ Dynamic_Selector::META_KEY => $id . '.backgroundHover' ],
-			'--primaryBtnHoverColor'   => [ Dynamic_Selector::META_KEY => $id . '.textHover' ],
-			'--primaryBtnBorderRadius' => [
+			'--primarybtnbg'           => [ Dynamic_Selector::META_KEY => $id . '.background' ],
+			'--primarybtncolor'        => [ Dynamic_Selector::META_KEY => $id . '.text' ],
+			'--primarybtnhoverbg'      => [ Dynamic_Selector::META_KEY => $id . '.backgroundHover' ],
+			'--primarybtnhovercolor'   => [ Dynamic_Selector::META_KEY => $id . '.textHover' ],
+			'--primarybtnborderradius' => [
 				Dynamic_Selector::META_KEY => $id . '.borderRadius',
 				'directional-prop'         => Config::CSS_PROP_BORDER_RADIUS,
 			],
 		];
 
 		if ( isset( $value['type'] ) && $value['type'] === 'outline' ) {
-			$rules['--primaryBtnBorderWidth'] = [
+			$rules['--primarybtnborderwidth'] = [
 				Dynamic_Selector::META_KEY => $id . '.borderWidth',
 				'directional-prop'         => Config::CSS_PROP_BORDER_WIDTH,
 			];

--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -155,7 +155,7 @@ class CartIcon extends Abstract_Component {
 				'live_refresh_selector' => $this->default_selector . ' span.nv-icon.nv-cart svg',
 				'live_refresh_css_prop' => [
 					'cssVar'  => [
-						'vars'     => '--iconSize',
+						'vars'     => '--iconsize',
 						'selector' => '.builder-item--' . $this->get_id(),
 						'suffix'   => 'px',
 					],
@@ -210,7 +210,7 @@ class CartIcon extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					[
@@ -314,12 +314,12 @@ class CartIcon extends Abstract_Component {
 		}
 
 		$rules = [
-			'--iconSize'   => [
+			'--iconsize'   => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::SIZE_ID,
 				Dynamic_Selector::META_SUFFIX  => 'px',
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::SIZE_ID ),
 			],
-			'--labelSize'  => [
+			'--labelsize'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::LABEL_SIZE_ID,
 				Dynamic_Selector::META_SUFFIX  => 'px',
 				Dynamic_Selector::META_DEFAULT => 15,
@@ -328,7 +328,7 @@ class CartIcon extends Abstract_Component {
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::COLOR_ID ),
 			],
-			'--hoverColor' => [
+			'--hovercolor' => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],

--- a/header-footer-grid/Core/Components/EddCartIcon.php
+++ b/header-footer-grid/Core/Components/EddCartIcon.php
@@ -72,7 +72,7 @@ class EddCartIcon extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'  => [
-						'vars'     => '--iconSize',
+						'vars'     => '--iconsize',
 						'selector' => '.builder-item--' . $this->get_id(),
 						'suffix'   => 'px',
 					],
@@ -117,7 +117,7 @@ class EddCartIcon extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 				],
@@ -147,12 +147,12 @@ class EddCartIcon extends Abstract_Component {
 	 */
 	public function add_style( array $css_array = array() ) {
 		$rules = [
-			'--iconSize'   => [
+			'--iconsize'   => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::SIZE_ID,
 				Dynamic_Selector::META_SUFFIX  => 'px',
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::SIZE_ID ),
 			],
-			'--labelSize'  => [
+			'--labelsize'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::LABEL_SIZE_ID,
 				Dynamic_Selector::META_SUFFIX  => 'px',
 				Dynamic_Selector::META_DEFAULT => 15,
@@ -161,7 +161,7 @@ class EddCartIcon extends Abstract_Component {
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::COLOR_ID ),
 			],
-			'--hoverColor' => [
+			'--hovercolor' => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],

--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -261,7 +261,7 @@ class Logo extends Abstract_Component {
 			if ( fileExt === 'svg' ) {
 				picture.removeAttribute('width');
 				picture.removeAttribute('height');
-				picture.style = 'width: var(--maxWidth)';
+				picture.style = 'width: var(--maxwidth)';
 			}
 			var compId = picture.getAttribute('data-variant');
 			if ( compId && variants[compId] ) {
@@ -515,7 +515,7 @@ JS;
 		$css_array[] = [
 			Dynamic_Selector::KEY_SELECTOR => '.builder-item--' . $this->get_id(),
 			Dynamic_Selector::KEY_RULES    => [
-				'--maxWidth' => [
+				'--maxwidth' => [
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::MAX_WIDTH,
 					Dynamic_Selector::META_SUFFIX        => 'px',

--- a/header-footer-grid/Core/Components/MenuIcon.php
+++ b/header-footer-grid/Core/Components/MenuIcon.php
@@ -492,13 +492,13 @@ CSS;
 				'live_refresh_css_prop' => [
 					'cssVar'             => [
 						'vars'     => [
-							'--bgColor'      => 'background',
+							'--bgcolor'      => 'background',
 							'--color'        => 'text',
-							'--borderRadius' => [
+							'--borderradius' => [
 								'key'    => 'borderRadius',
 								'suffix' => 'px',
 							],
-							'--borderWidth'  => [
+							'--borderwidth'  => [
 								'key'    => 'borderWidth',
 								'suffix' => 'px',
 							],
@@ -563,13 +563,13 @@ CSS;
 		$id = $this->get_id() . '_' . self::BUTTON_APPEARANCE;
 
 		$rules = [
-			'--bgColor'      => $id . '.background',
+			'--bgcolor'      => $id . '.background',
 			'--color'        => $id . '.text',
-			'--borderRadius' => [
+			'--borderradius' => [
 				Dynamic_Selector::META_KEY => $id . '.borderRadius',
 				'directional-prop'         => Config::CSS_PROP_BORDER_RADIUS,
 			],
-			'--borderWidth'  => [
+			'--borderwidth'  => [
 				Dynamic_Selector::META_KEY => $id . '.borderWidth',
 				'directional-prop'         => Config::CSS_PROP_BORDER_WIDTH,
 			],
@@ -579,7 +579,7 @@ CSS;
 
 
 		if ( isset( $value['type'] ) && $value['type'] !== 'outline' ) {
-			$rules ['--borderWidth']['override'] = 0;
+			$rules ['--borderwidth']['override'] = 0;
 		}
 
 		$css_array[] = [

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -143,7 +143,7 @@ class Nav extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--activeColor',
+						'vars'     => '--activecolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					'template' =>
@@ -168,7 +168,7 @@ class Nav extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					'template' =>
@@ -366,11 +366,11 @@ class Nav extends Abstract_Component {
 			'--color'       => [
 				Dynamic_Selector::META_KEY => $this->get_id() . '_' . self::COLOR_ID,
 			],
-			'--hoverColor'  => [
+			'--hovercolor'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],
-			'--activeColor' => [
+			'--activecolor' => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::ACTIVE_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::ACTIVE_COLOR_ID ),
 			],

--- a/header-footer-grid/Core/Components/NavFooter.php
+++ b/header-footer-grid/Core/Components/NavFooter.php
@@ -115,7 +115,7 @@ class NavFooter extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					[
@@ -333,7 +333,7 @@ class NavFooter extends Abstract_Component {
 			'--color'      => [
 				Dynamic_Selector::META_KEY => $this->get_id() . '_' . self::COLOR_ID,
 			],
-			'--hoverColor' => [
+			'--hovercolor' => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],

--- a/header-footer-grid/Core/Components/PaletteSwitch.php
+++ b/header-footer-grid/Core/Components/PaletteSwitch.php
@@ -154,8 +154,8 @@ class PaletteSwitch extends Abstract_Component {
 		}
 		.toggle-palette .icon {
 			display: flex;
-			width: var(--iconSize);
-			height: var(--iconSize);
+			width: var(--iconsize);
+			height: var(--iconsize);
 			fill: currentColor;
 		}
 		.toggle-palette .label {
@@ -397,7 +397,7 @@ class PaletteSwitch extends Abstract_Component {
 					],
 					'section'           => $this->section,
 				],
-				$custom_icon_args 
+				$custom_icon_args
 			)
 		);
 
@@ -429,7 +429,7 @@ class PaletteSwitch extends Abstract_Component {
 				'live_refresh_selector' => $this->default_selector . ' div.component-wrap .palette-icon-wrapper svg',
 				'live_refresh_css_prop' => array(
 					'cssVar'  => [
-						'vars'       => '--iconSize',
+						'vars'       => '--iconsize',
 						'responsive' => true,
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
@@ -494,7 +494,7 @@ class PaletteSwitch extends Abstract_Component {
 			$css_array[] = [
 				Dynamic_Selector::KEY_SELECTOR => '.builder-item--' . $this->get_id(),
 				Dynamic_Selector::KEY_RULES    => [
-					'--iconSize' => [
+					'--iconsize' => [
 						Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::SIZE_ID,
 						Dynamic_Selector::META_DEFAULT => '{ "mobile": "' . self::DEFAULT_ICON_SIZE . '", "tablet": "' . self::DEFAULT_ICON_SIZE . '", "desktop": "' . self::DEFAULT_ICON_SIZE . '" }',
 						Dynamic_Selector::META_SUFFIX  => 'px',

--- a/header-footer-grid/Core/Components/Search.php
+++ b/header-footer-grid/Core/Components/Search.php
@@ -129,7 +129,7 @@ class Search extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'     => [
 						'responsive' => true,
-						'vars'       => '--formFieldFontSize',
+						'vars'       => '--formfieldfontsize',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -215,7 +215,7 @@ class Search extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'      => [
 						'responsive' => true,
-						'vars'       => '--formFieldBorderWidth',
+						'vars'       => '--formfieldborderwidth',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -278,7 +278,7 @@ class Search extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'      => [
 						'responsive' => true,
-						'vars'       => '--formFieldBorderRadius',
+						'vars'       => '--formfieldborderradius',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -314,7 +314,7 @@ class Search extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--formFieldBgColor',
+						'vars'     => '--formfieldbgcolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					'template' =>
@@ -341,8 +341,8 @@ class Search extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
 						'vars'     => [
-							'--formFieldColor',
-							'--formFieldBorderColor',
+							'--formfieldcolor',
+							'--formfieldbordercolor',
 						],
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
@@ -490,33 +490,33 @@ class Search extends Abstract_Component {
 				Dynamic_Selector::META_SUFFIX        => 'px',
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_HEIGHT ),
 			],
-			'--formFieldFontSize'     => [
+			'--formfieldfontsize'     => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_FONT_SIZE,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 			],
-			'--formFieldBorderWidth'  => [
+			'--formfieldborderwidth'  => [
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_BORDER_WIDTH,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BORDER_WIDTH ),
 				'directional-prop'                   => Config::CSS_PROP_BORDER_WIDTH,
 			],
-			'--formFieldBorderRadius' => [
+			'--formfieldborderradius' => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_BORDER_RADIUS,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BORDER_RADIUS ),
 				'directional-prop'                   => Config::CSS_PROP_BORDER_RADIUS,
 			],
-			'--formFieldBgColor'      => [
+			'--formfieldbgcolor'      => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_BG,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BG ),
 			],
-			'--formFieldBorderColor'  => [
+			'--formfieldbordercolor'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_TEXT_COLOR,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_TEXT_COLOR ),
 			],
-			'--formFieldColor'        => [
+			'--formfieldcolor'        => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_TEXT_COLOR,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_TEXT_COLOR ),
 			],

--- a/header-footer-grid/Core/Components/SearchResponsive.php
+++ b/header-footer-grid/Core/Components/SearchResponsive.php
@@ -163,7 +163,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--iconSize',
+						'vars'     => '--iconsize',
 						'suffix'   => 'px',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
@@ -217,7 +217,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					'template' =>
@@ -306,7 +306,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'     => [
 						'responsive' => true,
-						'vars'       => '--formFieldFontSize',
+						'vars'       => '--formfieldfontsize',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -392,7 +392,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'      => [
 						'responsive' => true,
-						'vars'       => '--formFieldBorderWidth',
+						'vars'       => '--formfieldborderwidth',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -455,7 +455,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'      => [
 						'responsive' => true,
-						'vars'       => '--formFieldBorderRadius',
+						'vars'       => '--formfieldborderradius',
 						'suffix'     => 'px',
 						'selector'   => '.builder-item--' . $this->get_id(),
 					],
@@ -491,7 +491,7 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
-						'vars'     => '--formFieldBgColor',
+						'vars'     => '--formfieldbgcolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					'template' =>
@@ -518,8 +518,8 @@ class SearchResponsive extends Abstract_Component {
 				'live_refresh_css_prop' => [
 					'cssVar'   => [
 						'vars'     => [
-							'--formFieldColor',
-							'--formFieldBorderColor',
+							'--formfieldcolor',
+							'--formfieldbordercolor',
 						],
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
@@ -713,7 +713,7 @@ class SearchResponsive extends Abstract_Component {
 
 
 		$rules = [
-			'--iconSize'              => [
+			'--iconsize'              => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::SIZE_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::SIZE_ID ),
 				Dynamic_Selector::META_SUFFIX  => 'px',
@@ -722,37 +722,37 @@ class SearchResponsive extends Abstract_Component {
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::COLOR_ID ),
 			],
-			'--hoverColor'            => [
+			'--hovercolor'            => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],
-			'--formFieldFontSize'     => [
+			'--formfieldfontsize'     => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_FONT_SIZE,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_FONT_SIZE ),
 			],
-			'--formFieldBorderWidth'  => [
+			'--formfieldborderwidth'  => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_BORDER_WIDTH,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BORDER_WIDTH ),
 				'directional-prop'                   => Config::CSS_PROP_BORDER_WIDTH,
 			],
-			'--formFieldBorderRadius' => [
+			'--formfieldborderradius' => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::FIELD_BORDER_RADIUS,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BORDER_RADIUS ),
 				'directional-prop'                   => Config::CSS_PROP_BORDER_RADIUS,
 			],
-			'--formFieldBgColor'      => [
+			'--formfieldbgcolor'      => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_BG,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_BG ),
 			],
-			'--formFieldBorderColor'  => [
+			'--formfieldbordercolor'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_TEXT_COLOR,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_TEXT_COLOR ),
 			],
-			'--formFieldColor'        => [
+			'--formfieldcolor'        => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::FIELD_TEXT_COLOR,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::FIELD_TEXT_COLOR ),
 			],

--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -117,7 +117,7 @@ class SecondNav extends Abstract_Component {
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
 					'cssVar' => [
-						'vars'     => '--hoverColor',
+						'vars'     => '--hovercolor',
 						'selector' => '.builder-item--' . $this->get_id(),
 					],
 					[
@@ -234,7 +234,7 @@ class SecondNav extends Abstract_Component {
 			'--color'      => [
 				Dynamic_Selector::META_KEY => $this->get_id() . '_' . self::COLOR_ID,
 			],
-			'--hoverColor' => [
+			'--hovercolor' => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -42,36 +42,36 @@ trait Css_Vars {
 		$default_secondary = neve_get_button_appearance_default( 'secondary' );
 
 		$rules = [
-			'--primaryBtnBg'             => [
+			'--primarybtnbg'             => [
 				Dynamic_Selector::META_KEY => $mod_key_primary . '.background',
 			],
-			'--secondaryBtnBg'           => [
+			'--secondarybtnbg'           => [
 				Dynamic_Selector::META_KEY => $mod_key_secondary . '.background',
 			],
-			'--primaryBtnHoverBg'        => [
+			'--primarybtnhoverbg'        => [
 				Dynamic_Selector::META_KEY => $mod_key_primary . '.backgroundHover',
 			],
-			'--secondaryBtnHoverBg'      => [
+			'--secondarybtnhoverbg'      => [
 				Dynamic_Selector::META_KEY => $mod_key_secondary . '.backgroundHover',
 			],
-			'--primaryBtnColor'          => [
+			'--primarybtncolor'          => [
 				Dynamic_Selector::META_KEY => $mod_key_primary . '.text',
 			],
-			'--secondaryBtnColor'        => [
+			'--secondarybtncolor'        => [
 				Dynamic_Selector::META_KEY => $mod_key_secondary . '.text',
 			],
-			'--primaryBtnHoverColor'     => [
+			'--primarybtnhovercolor'     => [
 				Dynamic_Selector::META_KEY => $mod_key_primary . '.textHover',
 			],
-			'--secondaryBtnHoverColor'   => [
+			'--secondarybtnhovercolor'   => [
 				Dynamic_Selector::META_KEY => $mod_key_secondary . '.textHover',
 			],
-			'--primaryBtnBorderRadius'   => [
+			'--primarybtnborderradius'   => [
 				Dynamic_Selector::META_KEY    => $mod_key_primary . '.borderRadius',
 				Dynamic_Selector::META_SUFFIX => 'px',
 				'directional-prop'            => Config::CSS_PROP_BORDER_RADIUS,
 			],
-			'--secondaryBtnBorderRadius' => [
+			'--secondarybtnborderradius' => [
 				Dynamic_Selector::META_KEY    => $mod_key_secondary . '.borderRadius',
 				Dynamic_Selector::META_SUFFIX => 'px',
 				'directional-prop'            => Config::CSS_PROP_BORDER_RADIUS,
@@ -84,14 +84,14 @@ trait Css_Vars {
 
 		// Border Width
 		if ( isset( $primary_values['type'] ) && $primary_values['type'] === 'outline' ) {
-			$rules['--primaryBtnBorderWidth'] = [
+			$rules['--primarybtnborderwidth'] = [
 				Dynamic_Selector::META_KEY    => $mod_key_primary . '.borderWidth',
 				Dynamic_Selector::META_SUFFIX => 'px',
 				'directional-prop'            => Config::CSS_PROP_BORDER_WIDTH,
 			];
 		}
 		if ( isset( $secondary_values['type'] ) && $secondary_values['type'] === 'outline' ) {
-			$rules['--secondaryBtnBorderWidth'] = [
+			$rules['--secondarybtnborderwidth'] = [
 				Dynamic_Selector::META_KEY    => $mod_key_secondary . '.borderWidth',
 				Dynamic_Selector::META_SUFFIX => 'px',
 				'directional-prop'            => Config::CSS_PROP_BORDER_WIDTH,
@@ -101,7 +101,7 @@ trait Css_Vars {
 		$mod_key_primary       = Config::MODS_BUTTON_PRIMARY_PADDING;
 		$default_primary       = Mods::get_alternative_mod_default( Config::MODS_BUTTON_PRIMARY_PADDING );
 
-		$rules['--btnPadding'] = [
+		$rules['--btnpadding'] = [
 			Dynamic_Selector::META_KEY           => $mod_key_primary,
 			Dynamic_Selector::META_DEFAULT       => $default_primary,
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
@@ -136,9 +136,9 @@ trait Css_Vars {
 						$paddings[ $btn_type ][ $direction ] = $padding_value - $border_width[ $direction ];
 					}
 				}
-				$final_value_default   = Css_Prop::transform_directional_prop( $meta, $device, $value, '--btnPadding', Config::CSS_PROP_PADDING );
-				$final_value_primary   = Css_Prop::transform_directional_prop( $meta, $device, $paddings['primary'], '--primaryBtnPadding', Config::CSS_PROP_PADDING );
-				$final_value_secondary = Css_Prop::transform_directional_prop( $meta, $device, $paddings['secondary'], '--secondaryBtnPadding', Config::CSS_PROP_PADDING );
+				$final_value_default   = Css_Prop::transform_directional_prop( $meta, $device, $value, '--btnpadding', Config::CSS_PROP_PADDING );
+				$final_value_primary   = Css_Prop::transform_directional_prop( $meta, $device, $paddings['primary'], '--primarybtnpadding', Config::CSS_PROP_PADDING );
+				$final_value_secondary = Css_Prop::transform_directional_prop( $meta, $device, $paddings['secondary'], '--secondarybtnpadding', Config::CSS_PROP_PADDING );
 
 				return $final_value_default . $final_value_primary . $final_value_secondary;
 			},
@@ -146,24 +146,24 @@ trait Css_Vars {
 		];
 
 		$mod_key_primary             = Config::MODS_BUTTON_TYPEFACE;
-		$rules['--btnFs']            = [
+		$rules['--btnfs']            = [
 			Dynamic_Selector::META_KEY           => $mod_key_primary . '.fontSize',
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
 		];
-		$rules['--btnLineHeight']    = [
+		$rules['--btnlineheight']    = [
 			Dynamic_Selector::META_KEY           => $mod_key_primary . '.lineHeight',
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
 		];
-		$rules['--btnLetterSpacing'] = [
+		$rules['--btnletterspacing'] = [
 			Dynamic_Selector::META_KEY           => $mod_key_primary . '.letterSpacing',
 			Dynamic_Selector::META_IS_RESPONSIVE => true,
 			Dynamic_Selector::META_SUFFIX        => 'px',
 		];
-		$rules['--btnTextTransform'] = [
+		$rules['--btntexttransform'] = [
 			Dynamic_Selector::META_KEY           => $mod_key_primary . '.textTransform',
 			Dynamic_Selector::META_IS_RESPONSIVE => false,
 		];
-		$rules['--btnFontWeight']    = [
+		$rules['--btnfontweight']    = [
 			Dynamic_Selector::META_KEY => $mod_key_primary . '.fontWeight',
 		];
 
@@ -180,37 +180,37 @@ trait Css_Vars {
 		$mod_key = Config::MODS_TYPEFACE_GENERAL;
 
 		$rules = [
-			'--bodyFontFamily'     => [
+			'--bodyfontfamily'     => [
 				Dynamic_Selector::META_KEY     => Config::MODS_FONT_GENERAL,
 				Dynamic_Selector::META_DEFAULT => Mods::get_alternative_mod_default( Config::MODS_FONT_GENERAL ),
 			],
-			'--bodyFontSize'       => [
+			'--bodyfontsize'       => [
 				Dynamic_Selector::META_KEY           => $mod_key . '.fontSize',
 				Dynamic_Selector::META_DEFAULT       => $default['fontSize'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 			],
-			'--bodyLineHeight'     => [
+			'--bodylineheight'     => [
 				Dynamic_Selector::META_KEY           => $mod_key . '.lineHeight',
 				Dynamic_Selector::META_DEFAULT       => $default['lineHeight'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => '',
 			],
-			'--bodyLetterSpacing'  => [
+			'--bodyletterspacing'  => [
 				Dynamic_Selector::META_KEY           => $mod_key . '.letterSpacing',
 				Dynamic_Selector::META_DEFAULT       => $default['letterSpacing'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 			],
-			'--bodyFontWeight'     => [
+			'--bodyfontweight'     => [
 				Dynamic_Selector::META_KEY     => $mod_key . '.fontWeight',
 				Dynamic_Selector::META_DEFAULT => $default['fontWeight'],
 				'font'                         => 'mods_' . Config::MODS_FONT_HEADINGS,
 			],
-			'--bodyTextTransform'  => [
+			'--bodytexttransform'  => [
 				Dynamic_Selector::META_KEY => $mod_key . '.textTransform',
 			],
-			'--headingsFontFamily' => [
+			'--headingsfontfamily' => [
 				Dynamic_Selector::META_KEY => Config::MODS_FONT_HEADINGS,
 			],
 		];

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -219,34 +219,34 @@ trait Css_Vars {
 			$mod_key      = $composed_key;
 			$default      = Mods::get_alternative_mod_default( $composed_key );
 
-			$rules[ '--' . $id . 'FontSize' ] = [
+			$rules[ '--' . $id . 'fontsize' ] = [
 				Dynamic_Selector::META_KEY           => $mod_key . '.fontSize',
 				Dynamic_Selector::META_DEFAULT       => $default['fontSize'],
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 			];
 
-			$rules[ '--' . $id . 'FontWeight' ] = [
+			$rules[ '--' . $id . 'fontweight' ] = [
 				Dynamic_Selector::META_KEY     => $mod_key . '.fontWeight',
 				Dynamic_Selector::META_DEFAULT => $default['fontWeight'],
 				'font'                         => 'mods_' . Config::MODS_FONT_HEADINGS,
 			];
 
-			$rules[ '--' . $id . 'LineHeight' ] = [
+			$rules[ '--' . $id . 'lineheight' ] = [
 				Dynamic_Selector::META_KEY           => $mod_key . '.lineHeight',
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => $default['lineHeight'],
 				Dynamic_Selector::META_SUFFIX        => '',
 			];
 
-			$rules[ '--' . $id . 'LetterSpacing' ] = [
+			$rules[ '--' . $id . 'letterspacing' ] = [
 				Dynamic_Selector::META_KEY           => $mod_key . '.letterSpacing',
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => $default['letterSpacing'],
 				Dynamic_Selector::META_SUFFIX        => 'px',
 			];
 
-			$rules[ '--' . $id . 'TextTransform' ] = [
+			$rules[ '--' . $id . 'texttransform' ] = [
 				Dynamic_Selector::META_KEY     => $mod_key . '.textTransform',
 				Dynamic_Selector::META_DEFAULT => $default['textTransform'],
 			];

--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -153,7 +153,7 @@ class Frontend extends Generator {
 
 		$thumbnail_box_shadow_meta_name                = apply_filters( 'neve_thumbnail_box_shadow_meta_filter', 'neve_post_thumbnail_box_shadow' );
 		$this->_subscribers['.nv-post-thumbnail-wrap'] = [
-			'--boxShadow' => [
+			'--boxshadow' => [
 				Dynamic_Selector::META_KEY    => $thumbnail_box_shadow_meta_name,
 				Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
 					if ( absint( $value ) === 0 ) {
@@ -208,30 +208,30 @@ class Frontend extends Generator {
 		];
 		foreach ( $archive_typography as $selector => $args ) {
 			$this->_subscribers[ $selector ] = [
-				'--fontSize'      => [
+				'--fontsize'      => [
 					Dynamic_Selector::META_KEY           => $args['mod'] . '.fontSize',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_SUFFIX        => 'px',
 				],
-				'--lineHeight'    => [
+				'--lineheight'    => [
 					Dynamic_Selector::META_KEY           => $args['mod'] . '.lineHeight',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_SUFFIX        => '',
 				],
-				'--letterSpacing' => [
+				'--letterspacing' => [
 					Dynamic_Selector::META_KEY           => $args['mod'] . '.letterSpacing',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_SUFFIX        => 'px',
 				],
-				'--fontWeight'    => [
+				'--fontweight'    => [
 					Dynamic_Selector::META_KEY => $args['mod'] . '.fontWeight',
 					'font'                     => 'mods_' . $args['font'],
 				],
-				'--textTransform' => $args['mod'] . '.textTransform',
+				'--texttransform' => $args['mod'] . '.textTransform',
 			];
 		}
 	}
-	
+
 	/**
 	 * Add css for blog layout.
 	 *
@@ -246,7 +246,7 @@ class Frontend extends Generator {
 		}
 
 		$this->_subscribers[':root'] = [
-			'--postWidth' => [
+			'--postwidth' => [
 				Dynamic_Selector::META_KEY           => 'neve_grid_layout',
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => $this->grid_columns_default(),
@@ -816,78 +816,78 @@ class Frontend extends Generator {
 		$this->_subscribers[] = [
 			Dynamic_Selector::KEY_SELECTOR => ':root',
 			Dynamic_Selector::KEY_RULES    => [
-				'--formFieldBorderWidth'   => [
+				'--formfieldborderwidth'   => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_BORDER_WIDTH,
 					Dynamic_Selector::META_SUFFIX  => 'px',
 					Dynamic_Selector::META_DEFAULT => $border_width_default,
 					'directional-prop'             => Config::CSS_PROP_BORDER_WIDTH,
 				],
-				'--formFieldBorderRadius'  => [
+				'--formfieldborderradius'  => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_BORDER_RADIUS,
 					Dynamic_Selector::META_SUFFIX  => 'px',
 					Dynamic_Selector::META_DEFAULT => $border_radius_default,
 					'directional-prop'             => Config::CSS_PROP_BORDER_RADIUS,
 				],
-				'--formFieldBgColor'       => [
+				'--formfieldbgcolor'       => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_BACKGROUND_COLOR,
 					Dynamic_Selector::META_DEFAULT => 'var(--nv-site-bg)',
 				],
-				'--formFieldBorderColor'   => [
+				'--formfieldbordercolor'   => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_BORDER_COLOR,
 					Dynamic_Selector::META_DEFAULT => '#dddddd',
 				],
-				'--formFieldColor'         => [
+				'--formfieldcolor'         => [
 					Dynamic_Selector::META_KEY     => Config::MODS_FORM_FIELDS_COLOR,
 					Dynamic_Selector::META_DEFAULT => 'var(--nv-text-color)',
 				],
-				'--formFieldPadding'       => [
+				'--formfieldpadding'       => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_PADDING,
 					Dynamic_Selector::META_DEFAULT       => Mods::get_alternative_mod_default( Config::MODS_FORM_FIELDS_PADDING ),
 					Dynamic_Selector::META_SUFFIX        => 'px',
 					Dynamic_Selector::META_IS_RESPONSIVE => false,
 					'directional-prop'                   => Config::CSS_PROP_PADDING,
 				],
-				'--formFieldTextTransform' => [
+				'--formfieldtexttransform' => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_TYPEFACE . '.textTransform',
 					Dynamic_Selector::META_IS_RESPONSIVE => false,
 				],
-				'--formFieldFontSize'      => [
+				'--formfieldfontsize'      => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_TYPEFACE . '.fontSize',
 					Dynamic_Selector::META_SUFFIX        => 'px',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 				],
-				'--formFieldLineHeight'    => [
+				'--formfieldlineheight'    => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_TYPEFACE . '.lineHeight',
 					Dynamic_Selector::META_SUFFIX        => '',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 				],
-				'--formFieldLetterSpacing' => [
+				'--formfieldletterspacing' => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_TYPEFACE . '.letterSpacing',
 					Dynamic_Selector::META_SUFFIX        => 'px',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 				],
-				'--formFieldFontWeight'    => [
+				'--formfieldfontweight'    => [
 					Dynamic_Selector::META_KEY => Config::MODS_FORM_FIELDS_TYPEFACE . '.fontWeight',
 				],
 				// Form Labels
-				'--formLabelFontSize'      => [
+				'--formlabelfontsize'      => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.fontSize',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_SUFFIX        => 'px',
 				],
-				'--formLabelLineHeight'    => [
+				'--formlabellineheight'    => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.lineHeight',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_SUFFIX        => '',
 				],
-				'--formLabelLetterSpacing' => [
+				'--formlabelletterspacing' => [
 					Dynamic_Selector::META_KEY           => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.letterSpacing',
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 				],
-				'--formLabelFontWeight'    => [
+				'--formlabelfontweight'    => [
 					Dynamic_Selector::META_KEY => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.fontWeight',
 				],
-				'--formLabelTextTransform' => [
+				'--formlabeltexttransform' => [
 					Dynamic_Selector::META_KEY => Config::MODS_FORM_FIELDS_LABELS_TYPEFACE . '.textTransform',
 				],
 			],
@@ -902,27 +902,27 @@ class Frontend extends Generator {
 
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['background-color']       = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnBg, transparent)',
+			'override' => 'var(--secondarybtnbg, transparent)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['color']                  = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnColor)',
+			'override' => 'var(--secondarybtncolor)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['padding']                = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnPadding, 7px 12px)',
+			'override' => 'var(--secondarybtnpadding, 7px 12px)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['border-radius']          = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnBorderRadius, 3px)',
+			'override' => 'var(--secondarybtnborderradius, 3px)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON_HOVER ]['background-color'] = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnHoverBg, transparent)',
+			'override' => 'var(--secondarybtnhoverbg, transparent)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON_HOVER ]['color']            = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnHoverColor)',
+			'override' => 'var(--secondarybtnhovercolor)',
 		];
 
 		$mod_key_secondary = Config::MODS_BUTTON_SECONDARY_STYLE;
@@ -935,15 +935,15 @@ class Frontend extends Generator {
 
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['border-width']       = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnBorderWidth, 3px)',
+			'override' => 'var(--secondarybtnborderwidth, 3px)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON ]['border-color']       = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnHoverColor)',
+			'override' => 'var(--secondarybtnhovercolor)',
 		];
 		$this->_subscribers[ Config::CSS_SELECTOR_FORM_BUTTON_HOVER ]['border-color'] = [
 			'key'      => 'neve_form_button_type',
-			'override' => 'var(--secondaryBtnHoverColor)',
+			'override' => 'var(--secondarybtnhovercolor)',
 		];
 	}
 
@@ -987,7 +987,7 @@ class Frontend extends Generator {
 		}
 
 		$rules = [
-			'--avatarSize' => [
+			'--avatarsize' => [
 				Dynamic_Selector::META_KEY           => $archive_avatar_size_meta_key,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
@@ -996,7 +996,7 @@ class Frontend extends Generator {
 		];
 
 		$rules_single = [
-			'--avatarSize' => [
+			'--avatarsize' => [
 				Dynamic_Selector::META_KEY           => $single_avatar_size_meta_key,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
@@ -1158,7 +1158,7 @@ class Frontend extends Generator {
 				Dynamic_Selector::META_DEFAULT       => $this->padding_default(),
 				'directional-prop'                   => Config::CSS_PROP_PADDING,
 			],
-			'--bgColor' => [
+			'--bgcolor' => [
 				Dynamic_Selector::META_KEY => Config::MODS_POST_COMMENTS_BACKGROUND_COLOR,
 			],
 			'--color'   => [
@@ -1178,7 +1178,7 @@ class Frontend extends Generator {
 				Dynamic_Selector::META_DEFAULT       => $this->padding_default(),
 				'directional-prop'                   => Config::CSS_PROP_PADDING,
 			],
-			'--bgColor' => [
+			'--bgcolor' => [
 				Dynamic_Selector::META_KEY => Config::MODS_POST_COMMENTS_FORM_BACKGROUND_COLOR,
 			],
 			'--color'   => [
@@ -1276,12 +1276,12 @@ class Frontend extends Generator {
 						return sprintf( '%s: %s;', $css_prop, $justify_map[ $value ] );
 					},
 				],
-				'--textAlign' => [
+				'--textalign' => [
 					Dynamic_Selector::META_KEY           => $this->get_cover_meta( $context, Config::MODS_COVER_TITLE_ALIGNMENT, $allowed_context ),
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_DEFAULT       => self::post_title_alignment(),
 				],
-				'--vAlign'    => [
+				'--valign'    => [
 					Dynamic_Selector::META_KEY           => $this->get_cover_meta( $context, Config::MODS_COVER_TITLE_POSITION, $allowed_context ),
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_DEFAULT       => [
@@ -1307,7 +1307,7 @@ class Frontend extends Generator {
 				'--color'     => [
 					Dynamic_Selector::META_KEY => $this->get_cover_meta( $context, Config::MODS_COVER_TEXT_COLOR, $allowed_context ),
 				],
-				'--textAlign' => [
+				'--textalign' => [
 					Dynamic_Selector::META_KEY           => $this->get_cover_meta( $context, Config::MODS_COVER_TITLE_ALIGNMENT, $allowed_context ),
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_DEFAULT       => self::post_title_alignment(),
@@ -1332,7 +1332,7 @@ class Frontend extends Generator {
 					Dynamic_Selector::META_DEFAULT       => $this->padding_default( 'cover' ),
 					'directional-prop'                   => Config::CSS_PROP_PADDING,
 				],
-				'--bgColor' => [
+				'--bgcolor' => [
 					Dynamic_Selector::META_KEY     => $this->get_cover_meta( $context, Config::MODS_COVER_BOXED_TITLE_BACKGROUND, $allowed_context ),
 					Dynamic_Selector::META_DEFAULT => 'var(--nv-dark-bg)',
 				],
@@ -1350,14 +1350,14 @@ class Frontend extends Generator {
 		);
 		if ( $can_use_overlay_rules ) {
 			$overlay_rules        = [
-				'--bgColor'   => [
+				'--bgcolor'   => [
 					Dynamic_Selector::META_KEY => $this->get_cover_meta( $context, Config::MODS_COVER_BACKGROUND_COLOR, $allowed_context ),
 				],
 				'--opacity'   => [
 					Dynamic_Selector::META_KEY     => $this->get_cover_meta( $context, Config::MODS_COVER_OVERLAY_OPACITY, $allowed_context ),
 					Dynamic_Selector::META_DEFAULT => 50,
 				],
-				'--blendMode' => [
+				'--blendmode' => [
 					Dynamic_Selector::META_KEY     => $this->get_cover_meta( $context, Config::MODS_COVER_BLEND_MODE, $allowed_context ),
 					Dynamic_Selector::META_DEFAULT => 'normal',
 				],

--- a/inc/customizer/base_customizer.php
+++ b/inc/customizer/base_customizer.php
@@ -395,7 +395,7 @@ abstract class Base_Customizer {
 
 			$background_live_refresh_settings = [
 				'cssVar' => array(
-					'vars'     => '--bgColor',
+					'vars'     => '--bgcolor',
 					'selector' => $settings['boxed_selector'],
 				),
 			];

--- a/inc/customizer/options/base_layout_single.php
+++ b/inc/customizer/options/base_layout_single.php
@@ -270,7 +270,7 @@ abstract class Base_Layout_Single extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'       => [
-								'--textAlign',
+								'--textalign',
 								'--justify',
 							],
 							'valueRemap' => [
@@ -325,7 +325,7 @@ abstract class Base_Layout_Single extends Base_Customizer {
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'       => '--vAlign',
+							'vars'       => '--valign',
 							'responsive' => true,
 							'selector'   => $this->cover_selector,
 						],
@@ -357,7 +357,7 @@ abstract class Base_Layout_Single extends Base_Customizer {
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => array(
-							'vars'     => '--bgColor',
+							'vars'     => '--bgcolor',
 							'selector' => $this->cover_selector . ' .nv-overlay',
 						),
 					],
@@ -474,7 +474,7 @@ abstract class Base_Layout_Single extends Base_Customizer {
 					'live_refresh_selector' => true,
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'     => '--blendMode',
+							'vars'     => '--blendmode',
 							'selector' => $this->cover_selector . ' .nv-overlay',
 						],
 					],

--- a/inc/customizer/options/buttons.php
+++ b/inc/customizer/options/buttons.php
@@ -132,24 +132,24 @@ class Buttons extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'     => [
-								'--btnFs'            => [
+								'--btnfs'            => [
 									'key'        => 'fontSize',
 									'responsive' => true,
 									'suffix'     => 'px',
 								],
-								'--btnLineHeight'    => [
+								'--btnlineheight'    => [
 									'key'        => 'lineHeight',
 									'responsive' => true,
 								],
-								'--btnLetterSpacing' => [
+								'--btnletterspacing' => [
 									'key'        => 'letterSpacing',
 									'responsive' => true,
 									'suffix'     => 'px',
 								],
-								'--btnTextTransform' => [
+								'--btntexttransform' => [
 									'key' => 'textTransform',
 								],
-								'--btnFontWeight'    => [
+								'--btnfontweight'    => [
 									'key' => 'fontWeight',
 								],
 							],

--- a/inc/customizer/options/form_fields.php
+++ b/inc/customizer/options/form_fields.php
@@ -101,7 +101,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'      => [
 							'selector' => 'body',
-							'vars'     => '--formFieldPadding',
+							'vars'     => '--formfieldpadding',
 							'suffix'   => 'px',
 						],
 						'responsive'  => false,
@@ -155,7 +155,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'   => [
 							'selector' => 'body',
-							'vars'     => '--formFieldBgColor',
+							'vars'     => '--formfieldbgcolor',
 						],
 						'template' => '
 							body form input:read-write,
@@ -198,7 +198,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'      => [
 							'selector' => 'body',
-							'vars'     => '--formFieldBorderWidth',
+							'vars'     => '--formfieldborderwidth',
 							'suffix'   => 'px',
 						],
 						'responsive'  => false,
@@ -257,7 +257,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'      => [
 							'selector' => 'body',
-							'vars'     => '--formFieldBorderRadius',
+							'vars'     => '--formfieldborderradius',
 							'suffix'   => 'px',
 						],
 						'responsive'  => false,
@@ -303,7 +303,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'   => [
 							'selector' => 'body',
-							'vars'     => '--formFieldBorderColor',
+							'vars'     => '--formfieldbordercolor',
 						],
 						'template' => '
 							body form input:read-write,
@@ -367,7 +367,7 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar'   => [
 							'selector' => 'body',
-							'vars'     => '--formFieldColor',
+							'vars'     => '--formfieldcolor',
 						],
 						'template' => '
 							body form input:read-write,
@@ -444,17 +444,17 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'     => [
-								'--formFieldTextTransform' => 'textTransform',
-								'--formFieldFontWeight'    => 'fontWeight',
-								'--formFieldFontSize'      => [
+								'--formfieldtexttransform' => 'textTransform',
+								'--formfieldfontweight'    => 'fontWeight',
+								'--formfieldfontsize'      => [
 									'key'        => 'fontSize',
 									'responsive' => true,
 								],
-								'--formFieldLineHeight'    => [
+								'--formfieldlineheight'    => [
 									'key'        => 'lineHeight',
 									'responsive' => true,
 								],
-								'--formFieldLetterSpacing' => [
+								'--formfieldletterspacing' => [
 									'key'        => 'letterSpacing',
 									'suffix'     => 'px',
 									'responsive' => true,
@@ -533,17 +533,17 @@ class Form_Fields extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'     => [
-								'--formLabelTextTransform' => 'textTransform',
-								'--formLabelFontWeight'    => 'fontWeight',
-								'--formLabelFontSize'      => [
+								'--formlabeltexttransform' => 'textTransform',
+								'--formlabelfontweight'    => 'fontWeight',
+								'--formlabelfontsize'      => [
 									'key'        => 'fontSize',
 									'responsive' => true,
 								],
-								'--formLabelLineHeight'    => [
+								'--formlabellineheight'    => [
 									'key'        => 'lineHeight',
 									'responsive' => true,
 								],
-								'--formLabelLetterSpacing' => [
+								'--formlabelletterspacing' => [
 									'key'        => 'letterSpacing',
 									'suffix'     => 'px',
 									'responsive' => true,

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -93,7 +93,7 @@ class Typography extends Base_Customizer {
 					'live_refresh_selector' => apply_filters( 'neve_body_font_family_selectors', 'body, .site-title' ),
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'     => '--bodyFontFamily',
+							'vars'     => '--bodyfontfamily',
 							'selector' => 'body',
 							'fallback' => Mods::get_alternative_mod_default( Config::MODS_FONT_GENERAL ),
 							'suffix'   => ', var(--nv-fallback-ff)',
@@ -140,17 +140,17 @@ class Typography extends Base_Customizer {
 					'live_refresh_css_prop' => [
 						'cssVar' => [
 							'vars'     => [
-								'--bodyTextTransform' => 'textTransform',
-								'--bodyFontWeight'    => 'fontWeight',
-								'--bodyFontSize'      => [
+								'--bodytexttransform' => 'textTransform',
+								'--bodyfontweight'    => 'fontWeight',
+								'--bodyfontsize'      => [
 									'key'        => 'fontSize',
 									'responsive' => true,
 								],
-								'--bodyLineHeight'    => [
+								'--bodylineheight'    => [
 									'key'        => 'lineHeight',
 									'responsive' => true,
 								],
-								'--bodyLetterSpacing' => [
+								'--bodyletterspacing' => [
 									'key'        => 'letterSpacing',
 									'suffix'     => 'px',
 									'responsive' => true,
@@ -223,7 +223,7 @@ class Typography extends Base_Customizer {
 					'live_refresh_selector' => apply_filters( 'neve_headings_font_family_selectors', 'h1:not(.site-title), .single h1.entry-title, h2, h3, .woocommerce-checkout h3, h4, h5, h6' ),
 					'live_refresh_css_prop' => [
 						'cssVar' => [
-							'vars'     => '--headingsFontFamily',
+							'vars'     => '--headingsfontfamily',
 							'selector' => 'body',
 						],
 						'type'   => 'svg-icon-size',
@@ -396,17 +396,17 @@ class Typography extends Base_Customizer {
 						'live_refresh_css_prop' => [
 							'cssVar' => [
 								'vars'     => [
-									'--textTransform' => 'textTransform',
-									'--fontWeight'    => 'fontWeight',
-									'--fontSize'      => [
+									'--texttransform' => 'textTransform',
+									'--fontweight'    => 'fontWeight',
+									'--fontsize'      => [
 										'key'        => 'fontSize',
 										'responsive' => true,
 									],
-									'--lineHeight'    => [
+									'--lineheight'    => [
 										'key'        => 'lineHeight',
 										'responsive' => true,
 									],
-									'--letterSpacing' => [
+									'--letterspacing' => [
 										'key'        => 'letterSpacing',
 										'suffix'     => 'px',
 										'responsive' => true,

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -284,17 +284,17 @@ class Typography extends Base_Customizer {
 						'live_refresh_css_prop' => [
 							'cssVar' => [
 								'vars'     => [
-									'--' . $heading_id . 'TextTransform' => 'textTransform',
-									'--' . $heading_id . 'FontWeight'    => 'fontWeight',
-									'--' . $heading_id . 'FontSize'      => [
+									'--' . $heading_id . 'texttransform' => 'textTransform',
+									'--' . $heading_id . 'fontweight'    => 'fontWeight',
+									'--' . $heading_id . 'fontsize'      => [
 										'key'        => 'fontSize',
 										'responsive' => true,
 									],
-									'--' . $heading_id . 'LineHeight'    => [
+									'--' . $heading_id . 'lineheight'    => [
 										'key'        => 'lineHeight',
 										'responsive' => true,
 									],
-									'--' . $heading_id . 'LetterSpacing' => [
+									'--' . $heading_id . 'letterspacing' => [
 										'key'        => 'letterSpacing',
 										'suffix'     => 'px',
 										'responsive' => true,

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -546,7 +546,7 @@ class Metabox_Settings {
 			return $style;
 		}
 
-		$style .= '--textAlign:' . esc_attr( $title_meta_alignment ) . ';';
+		$style .= '--textalign:' . esc_attr( $title_meta_alignment ) . ';';
 		if ( $context === 'cover' ) {
 			$justify_map = [
 				'left'   => 'flex-start',

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -39,7 +39,7 @@ class Template_Parts extends Base_View {
 
 		wp_add_inline_style(
 			'neve-style',
-			'.nv-ft-post{background:var(--nv-light-bg);margin-top:60px}.nv-ft-post h2{font-size:calc( var(--fontSize, var(--h2FontSize)) * 1.3)}.nv-ft-post .nv-meta-list{display:block}.nv-ft-post .non-grid-content{padding:32px}.nv-ft-post .wp-post-image{position:absolute;object-fit:cover;width:100%;height:100%}.nv-ft-post .nv-post-thumbnail-wrap{margin:0;position:relative;min-height:320px}'
+			'.nv-ft-post{background:var(--nv-light-bg);margin-top:60px}.nv-ft-post h2{font-size:calc( var(--fontsize, var(--h2FontSize)) * 1.3)}.nv-ft-post .nv-meta-list{display:block}.nv-ft-post .non-grid-content{padding:32px}.nv-ft-post .wp-post-image{position:absolute;object-fit:cover;width:100%;height:100%}.nv-ft-post .nv-post-thumbnail-wrap{margin:0;position:relative;min-height:320px}'
 		);
 	}
 

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -39,7 +39,7 @@ class Template_Parts extends Base_View {
 
 		wp_add_inline_style(
 			'neve-style',
-			'.nv-ft-post{background:var(--nv-light-bg);margin-top:60px}.nv-ft-post h2{font-size:calc( var(--fontsize, var(--h2FontSize)) * 1.3)}.nv-ft-post .nv-meta-list{display:block}.nv-ft-post .non-grid-content{padding:32px}.nv-ft-post .wp-post-image{position:absolute;object-fit:cover;width:100%;height:100%}.nv-ft-post .nv-post-thumbnail-wrap{margin:0;position:relative;min-height:320px}'
+			'.nv-ft-post{background:var(--nv-light-bg);margin-top:60px}.nv-ft-post h2{font-size:calc( var(--fontsize, var(--h2fontsize)) * 1.3)}.nv-ft-post .nv-meta-list{display:block}.nv-ft-post .non-grid-content{padding:32px}.nv-ft-post .wp-post-image{position:absolute;object-fit:cover;width:100%;height:100%}.nv-ft-post .nv-post-thumbnail-wrap{margin:0;position:relative;min-height:320px}'
 		);
 	}
 


### PR DESCRIPTION
### Summary
After the discussion on the themes-HQ channel, we decided to go with renaming the CSS variables to better support PageSpeed environments,
This PR changes CSS variables' names from camel case to lowercase.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
1. Test that with the variable renaming things look the same.
2. Test Starter Sites import.
3. Check with sites imported prior to these changes.

<!-- Issues that this pull request closes. -->
Closes #3248.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
