### PR TITLE
chore: add current query title magic tag

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -296,8 +296,10 @@ class Magic_Tags {
 	 * @return string
 	 */
 	public function current_query_title() {
-		$show_homepage_name = apply_filters( 'neve_query_title_magic_tag_on_homepage', false );
-		return ( $show_homepage_name && is_front_page() ) ? get_bloginfo( 'name' ) : wp_title( '' );
+		if ( get_option( 'show_on_front' ) === 'page' && is_front_page() ) {
+			return get_the_title();
+		}
+		return wp_title( '' );
 	}
 
 	/**

--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -299,6 +299,18 @@ class Magic_Tags {
 		if ( get_option( 'show_on_front' ) === 'page' && is_front_page() ) {
 			return get_the_title();
 		}
+
+		if ( class_exists( 'WooCommerce', false ) ) {
+
+			if ( is_product_category() || is_product_tag() ) {
+				return get_the_archive_title();
+			}
+
+			if ( is_shop() ) {
+				return get_the_title( get_option( 'woocommerce_shop_page_id' ) );
+			}       
+		}
+
 		return wp_title( '' );
 	}
 

--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -291,6 +291,16 @@ class Magic_Tags {
 	}
 
 	/**
+	 * Title for the page currently being viewed.
+	 *
+	 * @return string
+	 */
+	public function current_query_title() {
+		$show_homepage_name = apply_filters( 'neve_query_title_magic_tag_on_homepage', false );
+		return ( $show_homepage_name && is_front_page() ) ? get_bloginfo( 'name' ) : wp_title( '' );
+	}
+
+	/**
 	 * Author Bio.
 	 *
 	 * @return string
@@ -636,19 +646,23 @@ class Magic_Tags {
 			[
 				'label'    => __( 'Global', 'neve' ),
 				'controls' => [
-					'site_title'   => [
+					'site_title'          => [
 						'label' => __( 'Site Title', 'neve' ),
 						'type'  => 'string',
 					],
-					'site_tagline' => [
+					'site_tagline'        => [
 						'label' => __( 'Site Tagline', 'neve' ),
 						'type'  => 'string',
 					],
-					'home_url'     => [
+					'current_query_title' => [
+						'label' => __( 'Current Page Title', 'neve' ),
+						'type'  => 'string',
+					],
+					'home_url'            => [
 						'label' => __( 'Home URL', 'neve' ),
 						'type'  => 'url',
 					],
-					'current_year' => [
+					'current_year'        => [
 						'label' => __( 'Current Year', 'neve' ),
 						'type'  => 'string',
 					],


### PR DESCRIPTION
### Summary
Adds `{current_query_title}` magic tag which gets the current title of the page being viewed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add the `{current_query_title}` magic tag to a HTML component anywhere in neve header or footer builder and save changes.
- The magic tag should output the currently viewed page's(or post, or archive) name 

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1586
<!-- Should look like this: `Closes #1, #2, #3.` . -->
