### PR TITLE
fix: changed menu dropdown link to button

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -56,7 +56,7 @@ jobs:
           ${GITHUB_WORKSPACE}/neve-head/bin/pot-diff.sh ./neve-base/languages/neve.pot ./neve-head/languages/neve.pot $PERCENT_TRESHOLD
       - name: Step require review
         if: steps.translation_status.outputs.has_pot_diff != 'success'
-        uses: Automattic/action-required-review@master
+        uses: Automattic/action-required-review@v2
         with:
           requirements: |
             - name: Everything else

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -74,15 +74,11 @@ function handleScrollLinks() {
 function handleMobileDropdowns() {
 	const carets = document.querySelectorAll('.caret-wrap');
 	addEvent(carets, 'click', openCarrets);
-	addEvent(carets, 'keyup', openCarrets);
 }
 
 function openCarrets(e, caret) {
 	e.preventDefault();
 	e.stopPropagation();
-	if (e.keyCode && ![9, 13].includes(e.keyCode)) {
-		return;
-	}
 	const subMenu = caret.parentNode.parentNode.querySelector('.sub-menu');
 	toggleClass(caret, strings[0]);
 	toggleClass(subMenu, strings[0]);

--- a/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
@@ -12,9 +12,7 @@ describe('Menu item alignment', function () {
 		cy.get('.menu-item-title-wrap')
 			.contains('About The Tests')
 			.should('have.css', 'text-align', 'left');
-		cy.get(
-			'#nv-primary-navigation-sidebar > .menu-item-1643 > .wrap > .caret-wrap',
-		).click();
+		cy.get('#nv-primary-navigation-sidebar > .menu-item-1643 > .wrap > .caret-wrap').click();
 		cy.get('.menu-item-title-wrap').contains('Level 2').should('have.css', 'text-align', 'left');
 	});
 });

--- a/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
@@ -13,7 +13,7 @@ describe('Menu item alignment', function () {
 			.contains('About The Tests')
 			.should('have.css', 'text-align', 'left');
 		cy.get(
-			'#nv-primary-navigation-sidebar > .menu-item-1643 > [href="http://localhost:8080/level-1/"] > .caret-wrap',
+			'#nv-primary-navigation-sidebar > .menu-item-1643 > .wrap > [href="http://localhost:8080/level-1/"] > .caret-wrap',
 		).click();
 		cy.get('.menu-item-title-wrap').contains('Level 2').should('have.css', 'text-align', 'left');
 	});

--- a/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
+++ b/e2e-tests/cypress/integration/customizer/hfg/hfg-menu-item-alignment.spec.ts
@@ -13,7 +13,7 @@ describe('Menu item alignment', function () {
 			.contains('About The Tests')
 			.should('have.css', 'text-align', 'left');
 		cy.get(
-			'#nv-primary-navigation-sidebar > .menu-item-1643 > .wrap > [href="http://localhost:8080/level-1/"] > .caret-wrap',
+			'#nv-primary-navigation-sidebar > .menu-item-1643 > .wrap > .caret-wrap',
 		).click();
 		cy.get('.menu-item-title-wrap').contains('Level 2').should('have.css', 'text-align', 'left');
 	});

--- a/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
+++ b/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
@@ -11,7 +11,7 @@ describe('Mega Menu Check', () => {
 		cy.get('@mm').find('.neve-mm-divider').should('be.visible').and('have.length', 4);
 		cy.get('@mm').find('.neve-mm-heading > span').should('be.visible').and('have.length', 4);
 
-		cy.get('@mm').find('.neve-mm-col > .sub-menu > .menu-item-has-children').as('dd');
+		cy.get('@mm').find('.neve-mm-col > .sub-menu > .wrap > .menu-item-has-children').as('dd');
 
 		cy.get('@dd').should('be.visible').and('have.length', 1);
 		cy.get('@dd').realHover();
@@ -32,7 +32,7 @@ describe('Mega Menu Check', () => {
 
 		cy.get('.header-menu-sidebar .neve-mega-menu').as('mm');
 
-		cy.get('@mm').find(' > a > .caret-wrap').click();
+		cy.get('@mm').find(' > .wrap > .caret-wrap').click();
 
 		cy.get('@mm').find('> .sub-menu').should('be.visible');
 		cy.get('@mm').find('.neve-mm-col').should('be.visible').and('have.length', 4);

--- a/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
+++ b/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
@@ -32,7 +32,7 @@ describe('Mega Menu Check', () => {
 
 		cy.get('.header-menu-sidebar .neve-mega-menu').as('mm');
 
-		cy.get('@mm').find(' > a > .caret-wrap').click();
+		cy.get('@mm').find(' > .wrap > .caret-wrap').click();
 
 		cy.get('@mm').find('> .sub-menu').should('be.visible');
 		cy.get('@mm').find('.neve-mm-col').should('be.visible').and('have.length', 4);

--- a/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
+++ b/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
@@ -11,7 +11,7 @@ describe('Mega Menu Check', () => {
 		cy.get('@mm').find('.neve-mm-divider').should('be.visible').and('have.length', 4);
 		cy.get('@mm').find('.neve-mm-heading > span').should('be.visible').and('have.length', 4);
 
-		cy.get('@mm').find('.neve-mm-col > .sub-menu > .wrap > .menu-item-has-children').as('dd');
+		cy.get('@mm').find('.neve-mm-col > .sub-menu > .menu-item-has-children').as('dd');
 
 		cy.get('@dd').should('be.visible').and('have.length', 1);
 		cy.get('@dd').realHover();
@@ -32,7 +32,7 @@ describe('Mega Menu Check', () => {
 
 		cy.get('.header-menu-sidebar .neve-mega-menu').as('mm');
 
-		cy.get('@mm').find(' > .wrap > .caret-wrap').click();
+		cy.get('@mm').find(' > a > .caret-wrap').click();
 
 		cy.get('@mm').find('> .sub-menu').should('be.visible');
 		cy.get('@mm').find('.neve-mm-col').should('be.visible').and('have.length', 4);

--- a/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
+++ b/e2e-tests/cypress/integration/mega-menu/mega-menu-test.spec.ts
@@ -41,7 +41,7 @@ describe('Mega Menu Check', () => {
 
 		cy.get('@mm').find('.neve-mm-col > .sub-menu > .menu-item-has-children').as('dd');
 
-		cy.get('@dd').find('> a > .caret-wrap').click();
+		cy.get('@dd').find('> .wrap > .caret-wrap').click();
 		cy.get('@dd').find('.sub-menu').should('be.visible');
 		cy.get('@dd')
 			.find('.sub-menu a')

--- a/e2e-tests/cypress/support/commands.ts
+++ b/e2e-tests/cypress/support/commands.ts
@@ -28,7 +28,7 @@ Cypress.Commands.add('insertCoverBlock', () => {
 		'<p class="has-text-align-center has-large-font-size">test</p>\n' +
 		'<!-- /wp:paragraph --></div></div>\n' +
 		'<!-- /wp:cover -->';
-	cy.get('.edit-post-more-menu')
+	cy.get('.interface-more-menu-dropdown')
 		.click()
 		.get('.components-dropdown-menu__menu button')
 		.contains('Code editor')

--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -291,6 +291,30 @@ class Magic_Tags {
 	}
 
 	/**
+	 * Title for the page currently being viewed.
+	 *
+	 * @return string
+	 */
+	public function current_query_title() {
+		if ( get_option( 'show_on_front' ) === 'page' && is_front_page() ) {
+			return get_the_title();
+		}
+
+		if ( class_exists( 'WooCommerce', false ) ) {
+
+			if ( is_product_category() || is_product_tag() ) {
+				return get_the_archive_title();
+			}
+
+			if ( is_shop() ) {
+				return get_the_title( get_option( 'woocommerce_shop_page_id' ) );
+			}       
+		}
+
+		return wp_title( '' );
+	}
+
+	/**
 	 * Author Bio.
 	 *
 	 * @return string
@@ -636,19 +660,23 @@ class Magic_Tags {
 			[
 				'label'    => __( 'Global', 'neve' ),
 				'controls' => [
-					'site_title'   => [
+					'site_title'          => [
 						'label' => __( 'Site Title', 'neve' ),
 						'type'  => 'string',
 					],
-					'site_tagline' => [
+					'site_tagline'        => [
 						'label' => __( 'Site Tagline', 'neve' ),
 						'type'  => 'string',
 					],
-					'home_url'     => [
+					'current_query_title' => [
+						'label' => __( 'Current Page Title', 'neve' ),
+						'type'  => 'string',
+					],
+					'home_url'            => [
 						'label' => __( 'Home URL', 'neve' ),
 						'type'  => 'url',
 					],
-					'current_year' => [
+					'current_year'        => [
 						'label' => __( 'Current Year', 'neve' ),
 						'type'  => 'string',
 					],

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -45,6 +45,9 @@ class Nav_Walker extends \Walker_Nav_Menu {
 	 * @return string
 	 */
 	public function add_caret( $title, $item, $args, $depth ) {
+		$args->before = '';
+		$args->after  = '';
+
 		if ( neve_is_amp() ) {
 			return $title;
 		}
@@ -61,15 +64,19 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			return $title;
 		}
 
-		// We add tabindex for sidebar in order for the carret to  be focusable.
-		$expanded = strpos( $args->menu_id, 'sidebar' ) !== false ? 'tabindex="0"' : '';
+		// We add tabindex 0 for sidebar in order for the caret to  be focusable.
+		$expanded = strpos( $args->menu_id, 'sidebar' ) !== false ? 'tabindex="0"' : 'tabindex="-1"';
 
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-			$title = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
+			$args->before = '<div class="wrap" style="padding: 15px 0; white-space: unset; display: flex; justify-content: space-between; align-items: center;">';
+			$args->after  = '</div>';
+			$title        = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
 
-			$title .= '<div ' . $expanded . ' class="caret-wrap ' . $item->menu_order . '">';
-			$title .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
-			$title .= '</div>';
+			$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '" style="border: unset; height: 100%;">';
+			$caret .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
+			$caret .= '</button>';
+
+			$args->after = $caret . $args->after;
 		}
 
 		return $title;

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -69,7 +69,9 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		$expanded = $is_sidebar_item ? 'tabindex="0"' : 'tabindex="-1"';
 
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-			$title     = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
+			if ( strpos( $title, 'menu-item-title-wrap' ) === false ) {
+				$title = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
+			}
 			$caret_svg = '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
 
 			if ( $is_sidebar_item ) {

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -27,6 +27,13 @@ class Nav_Walker extends \Walker_Nav_Menu {
 	public static $mega_menu_enqueued = false;
 
 	/**
+	 * Flag used to add inline mobile submenu button styles.
+	 *
+	 * @var bool
+	 */
+	public static $add_mobile_caret_button_style = false;
+
+	/**
 	 * Nav_Walker constructor.
 	 */
 	public function __construct() {
@@ -75,10 +82,12 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			$caret_svg = '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
 
 			if ( $is_sidebar_item ) {
-				$args->before = '<div class="wrap" style="padding: 15px 0; white-space: unset; display: flex; justify-content: space-between; align-items: center;">';
+				self::$add_mobile_caret_button_style = true;
+
+				$args->before = '<div class="wrap">';
 				$args->after  = '</div>';
 
-				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '" style="border: unset; height: 100%;">';
+				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '">';
 				$caret .= $caret_svg;
 				$caret .= '</button>';
 
@@ -91,7 +100,39 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			}
 		}
 
+
+
 		return $title;
+	}
+
+	/**
+	 * Ends the list of after the elements are added.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @see Walker::end_lvl()
+	 *
+	 * @param string   $output Used to append additional content (passed by reference).
+	 * @param int      $depth  Depth of menu item. Used for padding.
+	 * @param stdClass $args   An object of wp_nav_menu() arguments.
+	 */
+	public function end_lvl( &$output, $depth = 0, $args = null ) {
+		parent::end_lvl( $output, $depth, $args );
+
+		if ( $depth === 0 && self::$add_mobile_caret_button_style ) {
+			$output .= '<style>' . $this->get_mobile_submenu_style() . '</style>';
+		}
+	}
+
+	/**
+	 * Get mobile submenu inline styles
+	 */
+	public function get_mobile_submenu_style() {
+		$mobile_button_caret_css  = '.header-menu-sidebar .nav-ul li .wrap { padding: 15px 0; white-space: unset; display: flex; justify-content: space-between; align-items: center; }';
+		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap a { width: 100%; }';
+		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap a:hover { color: var(--hovercolor); }';
+		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap button { border: unset; height: 100%; }';
+		return Dynamic_Css::minify_css( $mobile_button_caret_css );
 	}
 
 	/**

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -64,19 +64,29 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			return $title;
 		}
 
+		$is_sidebar_item = strpos( $args->menu_id, 'sidebar' ) !== false;
 		// We add tabindex 0 for sidebar in order for the caret to  be focusable.
-		$expanded = strpos( $args->menu_id, 'sidebar' ) !== false ? 'tabindex="0"' : 'tabindex="-1"';
+		$expanded = $is_sidebar_item ? 'tabindex="0"' : 'tabindex="-1"';
 
 		if ( in_array( 'menu-item-has-children', $item->classes, true ) ) {
-			$args->before = '<div class="wrap" style="padding: 15px 0; white-space: unset; display: flex; justify-content: space-between; align-items: center;">';
-			$args->after  = '</div>';
-			$title        = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
+			$title     = '<span class="menu-item-title-wrap dd-title">' . $title . '</span>';
+			$caret_svg = '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
 
-			$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '" style="border: unset; height: 100%;">';
-			$caret .= '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
-			$caret .= '</button>';
+			if ( $is_sidebar_item ) {
+				$args->before = '<div class="wrap" style="padding: 15px 0; white-space: unset; display: flex; justify-content: space-between; align-items: center;">';
+				$args->after  = '</div>';
 
-			$args->after = $caret . $args->after;
+				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '" style="border: unset; height: 100%;">';
+				$caret .= $caret_svg;
+				$caret .= '</button>';
+
+				$args->after = $caret . $args->after;
+			} else {
+				$caret  = '<div ' . $expanded . ' class="caret-wrap ' . $item->menu_order . '">';
+				$caret .= $caret_svg;
+				$caret .= '</div>';
+				$title .= $caret;
+			}
 		}
 
 		return $title;

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -42,6 +42,17 @@ class Nav_Walker extends \Walker_Nav_Menu {
 	}
 
 	/**
+	 * Print inline styles if mobile submenu is used.
+	 */
+	public function inline_style_for_sidebar() {
+		if ( self::$add_mobile_caret_button_style ) {
+			return;
+		}
+		echo '<style>' . wp_kses_post( $this->get_mobile_submenu_style() ) . '</style>';
+		self::$add_mobile_caret_button_style = true;
+	}
+
+	/**
 	 * Add the caret inside the menu item link.
 	 *
 	 * @param string    $title menu item title.
@@ -82,7 +93,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			$caret_svg = '<span class="caret"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg></span>';
 
 			if ( $is_sidebar_item ) {
-				self::$add_mobile_caret_button_style = true;
+				add_action( 'neve_after_header_wrapper_hook', [ $this, 'inline_style_for_sidebar' ], 9 );
 
 				$args->before = '<div class="wrap">';
 				$args->after  = '</div>';
@@ -103,25 +114,6 @@ class Nav_Walker extends \Walker_Nav_Menu {
 
 
 		return $title;
-	}
-
-	/**
-	 * Ends the list of after the elements are added.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @see Walker::end_lvl()
-	 *
-	 * @param string   $output Used to append additional content (passed by reference).
-	 * @param int      $depth  Depth of menu item. Used for padding.
-	 * @param stdClass $args   An object of wp_nav_menu() arguments.
-	 */
-	public function end_lvl( &$output, $depth = 0, $args = null ) {
-		parent::end_lvl( $output, $depth, $args );
-
-		if ( $depth === 0 && self::$add_mobile_caret_button_style ) {
-			$output .= '<style>' . $this->get_mobile_submenu_style() . '</style>';
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Changed dropdown links to use the button tag.

Merged changes from #3339
Cleaned up CSS to not trigger the size limit
Removed tab open for dropdown only opens on the `Enter` key or click

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that the navigation looks the same as before
2. Check that the dropdown caret is now a button tag
3. Check that can be opened on the `Enter` key or  click
4. Check the same for Mega Menu

<!-- Issues that this pull request closes. -->
Closes #3258.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
