### PR TITLE
GitHub Actions: Updating action-required-review tag

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -56,7 +56,7 @@ jobs:
           ${GITHUB_WORKSPACE}/neve-head/bin/pot-diff.sh ./neve-base/languages/neve.pot ./neve-head/languages/neve.pot $PERCENT_TRESHOLD
       - name: Step require review
         if: steps.translation_status.outputs.has_pot_diff != 'success'
-        uses: Automattic/action-required-review@master
+        uses: Automattic/action-required-review@v2
         with:
           requirements: |
             - name: Everything else


### PR DESCRIPTION

### Summary

Later today the default branch for the  [Automattic/action-required-review](https://github.com/Automattic/action-required-review) repository will change from `master` to `trunk`. This file references the `master` version, which will result in issues after the branch rename.

I'd recommend changing that to a tagged version (v2 in this case).

### Will affect visual aspect of the product

No.

### Screenshots

### Test instructions

- Translations diff tests should pass, particularly when using the required review action where appropriate.
