### PR TITLE
AMP Style Cleanup

### DIFF
--- a/assets/scss/components/elements/blog/_blogpost-covers.scss
+++ b/assets/scss/components/elements/blog/_blogpost-covers.scss
@@ -33,7 +33,6 @@ $overlay: rgba(0, 0, 0, 0.75);
 		bottom: 0;
 	}
 
-	amp-img,
 	img {
 		--boxshadow: none;
 	}

--- a/assets/scss/components/elements/blog/_blogpost-index.scss
+++ b/assets/scss/components/elements/blog/_blogpost-index.scss
@@ -23,7 +23,6 @@
 		display: block;
 	}
 
-	amp-img,
 	img {
 		box-shadow: var(--boxshadow, none);
 	}

--- a/assets/scss/components/elements/navigation/_nav-brand.scss
+++ b/assets/scss/components/elements/navigation/_nav-brand.scss
@@ -4,10 +4,6 @@
 	align-items: center;
 	display: flex;
 
-	amp-img img {
-		max-height: 60px;
-	}
-
 	img {
 		max-width: var(--maxwidth);
 		display: block;

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -170,49 +170,4 @@
 			}
 		}
 	}
-
-	.has-caret.amp {
-		padding-right: 0;
-	}
-
-	.amp.dropdown-open + .sub-menu {
-		display: block !important;
-	}
-}
-
-// === AMP === //
-.amp-desktop-caret-wrap {
-	display: none;
-}
-
-.amp-caret-wrap {
-
-	svg {
-		fill: currentColor;
-		width: 1em;
-	}
-}
-
-.has-caret.amp {
-	display: flex;
-	align-items: center;
-
-	.caret-wrap {
-		margin-left: auto;
-	}
-}
-
-.sub-menu .has-caret.amp {
-	padding-right: $spacing-md;
-}
-
-@mixin nav-menu--laptop() {
-
-	.amp-desktop-caret-wrap {
-		display: none;
-	}
-
-	.amp-caret-wrap {
-		display: block;
-	}
 }

--- a/assets/scss/components/main/_media-queries.scss
+++ b/assets/scss/components/main/_media-queries.scss
@@ -6,7 +6,6 @@
 @media (min-width: #{$laptop}) {
 
 	@include content--laptop();
-	@include nav-menu--laptop();
 	@include blog-layout-default-alt--laptop();
 	@include sidebar--laptop();
 	@include gutenberg--laptop();

--- a/inc/compatibility/amp.php
+++ b/inc/compatibility/amp.php
@@ -46,12 +46,68 @@ class Amp {
 		add_filter( 'neve_search_menu_item_filter', array( $this, 'add_search_menu_item_attrs' ), 10, 2 );
 		add_action( 'neve_after_header_hook', array( $this, 'render_amp_states' ) );
 		add_filter( 'neve_nav_toggle_data_attrs', array( $this, 'add_nav_toggle_attrs' ) );
+		add_action( 'wp_head', array( $this, 'inline_styles' ) );
 
 
 		/**
 		 * Add infinite scroll for amp.
 		 */
 		$this->maybe_add_amp_infinite_scroll();
+	}
+
+	/**
+	 * Add inline styles for AMP.
+	 *
+	 * @return void
+	 */
+	public function inline_styles() {
+		echo '
+			<style>
+			.header-menu-sidebar .has-caret.amp {
+				padding: 15px 0 !important;
+			}
+			.header-menu-sidebar .amp.dropdown-open + .sub-menu {
+				display: block !important;
+			}
+			.site-logo amp-img img {
+				max-height: 60px;
+			}
+			.sub-menu .has-caret.amp {
+				padding: 10px 20px;
+			}
+			.amp-desktop-caret-wrap {
+				display: none;
+			}
+			.amp-caret-wrap svg {
+				fill: currentColor;
+				width: 1em;
+			}
+			.has-caret.amp {
+				height: 100%;
+				display: flex;
+				align-items: center;
+			}
+			.has-caret.amp a {
+				flex-grow: 1;
+			}
+			.has-caret.amp .caret-wrap {
+				margin-left: auto;
+			}
+			.nv-post-thumbnail-wrap amp-img {
+				box-shadow: var(--boxshadow, none);
+			}
+			.cover-post amp-img {
+				--boxshadow: none;
+			}
+			@media (min-width: 960px) {
+				.amp-desktop-caret-wrap {
+					display: none;
+				}
+				.amp-caret-wrap {
+					display: block;
+				}
+			}
+			</style>';
 	}
 
 	/**
@@ -68,6 +124,7 @@ class Amp {
 	 * @param object $item item information.
 	 * @param int    $depth item depth.
 	 * @param object $args menu args.
+	 *
 	 * @return string
 	 */
 	public function wrap_content( $item_output, $item, $depth, $args ) {
@@ -83,7 +140,7 @@ class Amp {
 			return $item_output;
 		}
 
-		if ( strpos( $item_output, 'has-caret' ) > -1 ) {
+		if ( strpos( $item_output, 'has-caret' ) > - 1 ) {
 			return $item_output;
 		}
 
@@ -103,6 +160,7 @@ class Amp {
 	 *
 	 * @param string $input input string.
 	 * @param int    $instance instance number of nav menu.
+	 *
 	 * @return string
 	 */
 	public function add_search_menu_item_attrs( $input, $instance ) {
@@ -252,6 +310,7 @@ class Amp {
 		global $post;
 
 		$post_type = get_post_type( $post );
+
 		return ( $post_type === 'post' ) && ( is_home() || is_archive() );
 	}
 
@@ -300,6 +359,7 @@ class Amp {
 		if ( $advanced_options !== false ) {
 			$option = 'neve_blog_archive_sidebar_layout';
 		}
+
 		return apply_filters( 'neve_sidebar_position', get_theme_mod( $option, 'right' ) ) !== 'full-width';
 	}
 


### PR DESCRIPTION
### Summary
Removes the AMP-specific style from the core stylesheet, bringing its' size down. This style will still be added but only when the AMP plugin is active, and the website is accessed through AMP.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The AMP integration should still work as expected;
- The styles should still apply; 
- This also fixes how the dropdowns used to look in the current version;

<!-- Issues that this pull request closes. -->
Closes #3495.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
