### PR TITLE
Fix meta two dates

### DIFF
--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -166,7 +166,7 @@ class Post_Meta extends Base_View {
 					}
 					$meta_content = str_replace( '{meta}', self::get_time_tags( $pid ), $format );
 					$markup      .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . ' ' . esc_attr( $element_class ) . '">';
-					$markup      .= wp_kses_post( $meta_content );
+					$markup      .= $meta_content;
 					$markup      .= '</' . $tag . '>';
 					break;
 				case 'category':


### PR DESCRIPTION
### Summary
When changing the meta, I applied the wp_kses_post over the time tag and it will be stripped leaving it without classes.

### Will affect the visual aspect of the product
NO


### Test instructions
- Enable the date in Post Meta
- Check the blog and single layout pages
- Toggle this option - https://vertis.d.pr/PgKwQt


<!-- Issues that this pull request closes. -->
Closes #3503.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
