### PR TITLE
fix: magic tag can't be displayed inline with other text [#3504]

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -161,7 +161,7 @@ class Magic_Tags {
 			$allowed_tags['span'] = [
 				'class' => [],
 			];
-		
+
 		}
 
 		return wp_kses( call_user_func( [ $this, $tag ] ), $allowed_tags );
@@ -308,10 +308,10 @@ class Magic_Tags {
 
 			if ( is_shop() ) {
 				return get_the_title( get_option( 'woocommerce_shop_page_id' ) );
-			}       
+			}
 		}
 
-		return wp_title( '' );
+		return wp_title( '', false );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
wp_title needed false for the display parameter

### Will affect visual aspect of the product
NO


### Test instructions
- Add "Youe are viewing {current_query_title} page" in a HTML component in header
- Check the frontend

<!-- Issues that this pull request closes. -->
Closes #3504.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
