### PR TITLE
Remove comment-reply.js when not needed

### DIFF
--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -375,7 +375,7 @@ class Front_End {
 			wp_script_add_data( 'neve-shop-script', 'async', true );
 		}
 
-		if ( is_singular() ) {
+		if ( is_singular() & comments_open() && get_option( 'thread_comments' ) ) {
 			wp_enqueue_script( 'comment-reply' );
 		}
 	}

--- a/inc/views/partials/excerpt.php
+++ b/inc/views/partials/excerpt.php
@@ -43,7 +43,7 @@ class Excerpt extends Base_View {
 	 * @return string
 	 */
 	private function get_post_excerpt( $context, $post_id = null ) {
-		$length = $this->get_excerpt_lenght();
+		$length = $this->get_excerpt_length();
 
 		$output  = '';
 		$output .= '<div class="excerpt-wrap entry-summary">';
@@ -89,7 +89,7 @@ class Excerpt extends Base_View {
 	 *
 	 * @return int
 	 */
-	private function get_excerpt_lenght() {
+	private function get_excerpt_length() {
 		return absint( round( get_theme_mod( 'neve_post_excerpt_length', '25' ) ) );
 	}
 
@@ -99,6 +99,6 @@ class Excerpt extends Base_View {
 	 * @return int
 	 */
 	public function change_excerpt_length() {
-		return $this->get_excerpt_lenght();
+		return $this->get_excerpt_length();
 	}
 }

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -29,6 +29,28 @@ class Post_Layout extends Base_View {
 	 */
 	public function init() {
 		add_action( 'neve_do_single_post', [ $this, 'render_post' ] );
+		add_filter( 'comments_open', [ $this, 'filter_comments_open' ] );
+	}
+
+	/**
+	 * Dequeue comments-reply script if comments are closed.
+	 *
+	 * @param bool $open Comments open status.
+	 *
+	 * @return bool
+	 */
+	public function filter_comments_open( $open ) {
+		$content_order = $this->get_content_order();
+
+		if ( empty( $content_order ) ) {
+			return $open;
+		}
+
+		if ( ! in_array( 'comments', $content_order ) ) {
+			return false;
+		}
+
+		return $open;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Should remove comment-reply script in all instances where comments aren't available on the page. Be it they are disabled from the global core settings under Discussion, for the individual post, or from our metabox/customizer settings.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Test with comments opened, closed (on post level and on the whole website);
- Test with the customizer post element ordering and with the metabox one;
- The comment-reply JS file should not be loaded unless comments are;

<!-- Issues that this pull request closes. -->
Closes #732, closes #3469.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
