### PR TITLE
Drop tag cloud block custom styling

### DIFF
--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -74,7 +74,6 @@
 }
 
 .nv-tags-list,
-.wp-block-tag-cloud,
 .tagcloud {
 
 	a {


### PR DESCRIPTION
### Summary
Removes the tag cloud block custom styling, to allow core options through.

cc: @Codeinwp/design-team @cristian-ungureanu, I would like to hear your input on this, as I'm not 100% sure that removing our style is a great idea. From a logical standpoint, I agree that core styles should work, though.

<!-- Please describe the changes you made. -->

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

Before:
---
![image](https://user-images.githubusercontent.com/15010186/177083831-d2b349ec-afd9-4755-b017-94f0e95722a4.png)


After:
---
![image](https://user-images.githubusercontent.com/15010186/177083798-399b7dd5-c394-4294-86be-7f179f55e800.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add the tag cloud block to the page;
- It should use the core styles, instead of the custom style of the theme;
- Other tags markup should still look as before (i.e. single post tags);

<!-- Issues that this pull request closes. -->
Closes #3495.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
