### PR TITLE
feat: adds theme.json & enable "appearanceTools"

### DIFF
--- a/assets/scss/gutenberg-editor-style.scss
+++ b/assets/scss/gutenberg-editor-style.scss
@@ -6,6 +6,11 @@
 	background-color: var(--nv-site-bg);
   }
 
+  .wp-block {
+	margin-left: auto;
+	margin-right: auto;
+  }
+
   .editor-post-title__input, .block-list-appender textarea {
 	&::placeholder {
 	  color: var(--nv-text-color);

--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,6 @@
+{
+  "version": 2,
+  "settings": {
+	"appearanceTools": true
+  }
+}


### PR DESCRIPTION
### Summary
Adds the `theme.json` file, thus enabling additional features inside the editor mentioned in the issue (#3485).

More on what gets enabled using this flag [🔗 here](https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-json/#opt-in-into-ui-controls).
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Add a group block inside the editor;
- It should now have the options mentioned inside the issue;
- Other blocks get new options as well, so we might need to test for compatibility with Otter and anything that might be out of order with core blocks; 

<!-- Issues that this pull request closes. -->
Closes #3485.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
