### PR TITLE
Missing title on page

### DIFF
--- a/inc/views/page_header.php
+++ b/inc/views/page_header.php
@@ -40,7 +40,7 @@ class Page_Header extends Base_View {
 	 * @return void
 	 */
 	public function run() {
-		$header_hook = get_theme_mod( 'neve_enable_featured_post', false ) ? 'neve_do_featured_post' : 'neve_page_header';
+		$header_hook = get_theme_mod( 'neve_enable_featured_post', false ) && is_home() ? 'neve_do_featured_post' : 'neve_page_header';
 		add_action( $header_hook, array( $this, 'render_page_header' ), 9 );
 		add_filter( 'get_the_archive_title', array( $this, 'filter_archive_title' ) );
 	}


### PR DESCRIPTION
### Summary
The title was missing from pages when featured posts were enabled

### Will affect the visual aspect of the product
NO


### Test instructions
- Enable the featured post in the customizer
- Check and see that the pages are still displaying the title.
Note: Make sure you reset the meta option from the Neve page edit sidebar. Some of the pages you import are disabling the actual page title and are adding it to the page content.

<!-- Issues that this pull request closes. -->
Closes #3491
<!-- Should look like this: `Closes #1, #2, #3.` . -->
