### PR TITLE
fix: acf field select not triggering update

### DIFF
--- a/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
+++ b/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
@@ -102,7 +102,7 @@ const RepeaterItemContent = ({
 				return (
 					<SelectControl
 						label={currentField.label}
-						value={value[index][key]}
+						value={value[index][key] || ''}
 						onChange={(newData) => changeContent(key, newData)}
 						options={defaultOption.concat(
 							Object.entries(currentField.choices).map(


### PR DESCRIPTION
### Summary
Added default value if no option is selected to trigger the change event on repeater select control.


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install ACF and create a field group -> field.
2. Populate it for a particular post.
3. Go to Appearance > Customize > Layout > Single Post > Post Meta.
4. Add a new item there and click on ACF.
5. Select the field that was populated before and check if it appears.

<!-- Issues that this pull request closes. -->
Closes #3519.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
