### PR TITLE
fix: solve default for container width

### DIFF
--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -127,7 +127,7 @@ class MetaFieldsManager extends Component {
 			'neve_meta_enable_content_width'
 		);
 		let containerType = this.props.metaValue('neve_meta_container');
-		if ('default' === containerType) {
+		if ('default' === containerType || '' === containerType) {
 			containerType =
 				metaSidebar.actions.neve_meta_content_width.container;
 		}

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -188,6 +188,7 @@ class Metabox_Settings {
 	 * Set editor width.
 	 */
 	public function editor_content_width() {
+		global $post_type;
 		$meta_value = $this->get_content_width();
 		$container  = $this->get_current_layout();
 
@@ -197,7 +198,8 @@ class Metabox_Settings {
 			$editor_width = Mods::get( Config::MODS_CONTAINER_WIDTH );
 			$editor_width = isset( $editor_width['desktop'] ) ? (int) $editor_width['desktop'] : 1170;
 			if ( empty( $meta_value ) ) {
-				$meta_value = $this->get_content_width_default();
+				$meta_key   = $post_type === 'post' ? Config::MODS_SINGLE_CONTENT_WIDTH : Config::MODS_OTHERS_CONTENT_WIDTH;
+				$meta_value = Mods::get( $meta_key, $this->get_content_width_default() );
 			}
 			$editor_width_normal = round( ( $meta_value / 100 ) * $editor_width ) . 'px';
 		} else {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Use default style width when the container is not defined on new posts.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Go into the editor (either create a new page, or post);
2. Open up the Neve sidebar; 
3. The content width should be the same as for the frontend one;
4. If you click the "Default" option for the container, everything should remain the same. Previously it would update.

<!-- Issues that this pull request closes. -->
Closes #3522.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
