### PR TITLE
feat: removed custom content control for full-width

### DIFF
--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -157,7 +157,9 @@ class MetaFieldsManager extends Component {
 		}
 		const css =
 			'.wp-block:not([data-align="full"]) { max-width: ' +
-			('on' === isCustomContentWidth ? blocKWidth : blockWidthDefault) +
+			('on' === isCustomContentWidth && 'full-width' !== containerType
+				? blocKWidth
+				: blockWidthDefault) +
 			'; }';
 
 		const head = document.head;
@@ -333,75 +335,83 @@ class MetaFieldsManager extends Component {
 						</ButtonGroup>
 					</BaseControl>
 
-					<BaseControl
-						id="neve_meta_enable_content_width"
-						className="neve-meta-control neve-meta-checkbox neve_meta_enable_content_width"
-					>
-						<ToggleControl
-							label={__('Custom Content Width (%)', 'neve')}
-							checked={
-								'on' ===
-								this.props.metaValue(
-									'neve_meta_enable_content_width'
-								)
-							}
-							onChange={(value) => {
-								this.updateValues(
-									'neve_meta_enable_content_width',
-									value ? 'on' : 'off'
-								);
-								this.updateValues(
-									'neve_meta_content_width',
-									this.props.metaValue(
-										'neve_meta_content_width'
-									) || 70
-								);
-							}}
-						/>
-					</BaseControl>
-
-					{'on' ===
-					this.props.metaValue('neve_meta_enable_content_width') ? (
+					{'full-width' !==
+						this.props.metaValue('neve_meta_container') && (
 						<BaseControl
-							id="neve_meta_content_width"
-							className="neve-meta-control neve-meta-range neve_meta_content_width"
+							id="neve_meta_enable_content_width"
+							className="neve-meta-control neve-meta-checkbox neve_meta_enable_content_width"
 						>
-							<RangeControl
-								value={this.props.metaValue(
-									'neve_meta_content_width'
-								)}
+							<ToggleControl
+								label={__('Custom Content Width (%)', 'neve')}
+								checked={
+									'on' ===
+									this.props.metaValue(
+										'neve_meta_enable_content_width'
+									)
+								}
 								onChange={(value) => {
 									this.updateValues(
+										'neve_meta_enable_content_width',
+										value ? 'on' : 'off'
+									);
+									this.updateValues(
 										'neve_meta_content_width',
-										value
+										this.props.metaValue(
+											'neve_meta_content_width'
+										) || 70
 									);
 								}}
-								min={0}
-								max={100}
-								step="1"
 							/>
-							{this.props.metaValue('neve_meta_content_width') &&
-								this.props.metaValue(
-									'neve_meta_content_width'
-								) > 80 &&
-								(this.props.metaValue('neve_meta_sidebar') ===
-									'left' ||
-									this.props.metaValue(
-										'neve_meta_sidebar'
-									) === 'right') && (
-									<Notice isDismissible={false}>
-										<small>
-											{__(
-												'Note: Setting the content width over 80% might affect the sidebar width. Sidebar will ultimately disappear at 95%.',
-												'neve'
-											)}
-										</small>
-									</Notice>
-								)}
 						</BaseControl>
-					) : (
-						''
 					)}
+
+					{'on' ===
+						this.props.metaValue(
+							'neve_meta_enable_content_width'
+						) &&
+						'full-width' !==
+							this.props.metaValue('neve_meta_container') && (
+							<BaseControl
+								id="neve_meta_content_width"
+								className="neve-meta-control neve-meta-range neve_meta_content_width"
+							>
+								<RangeControl
+									value={this.props.metaValue(
+										'neve_meta_content_width'
+									)}
+									onChange={(value) => {
+										this.updateValues(
+											'neve_meta_content_width',
+											value
+										);
+									}}
+									min={0}
+									max={100}
+									step="1"
+								/>
+								{this.props.metaValue(
+									'neve_meta_content_width'
+								) &&
+									this.props.metaValue(
+										'neve_meta_content_width'
+									) > 80 &&
+									(this.props.metaValue(
+										'neve_meta_sidebar'
+									) === 'left' ||
+										this.props.metaValue(
+											'neve_meta_sidebar'
+										) === 'right') && (
+										<Notice isDismissible={false}>
+											<small>
+												{__(
+													'Note: Setting the content width over 80% might affect the sidebar width. Sidebar will ultimately disappear at 95%.',
+													'neve'
+												)}
+											</small>
+										</Notice>
+									)}
+							</BaseControl>
+						)}
 				</PanelBody>
 			</div>
 		);

--- a/e2e-tests/cypress/integration/editor/modern/post-meta-sidebar.spec.ts
+++ b/e2e-tests/cypress/integration/editor/modern/post-meta-sidebar.spec.ts
@@ -110,6 +110,14 @@ describe('Single post meta sidebar', function () {
 		cy.get('#wp-admin-bar-edit a').click();
 		cy.clearWelcome();
 
+		cy.updatePageOrPostByRequest(window.localStorage.getItem('postId'), 'posts', {
+			meta: {
+				neve_meta_container: 'contained',
+			},
+		});
+
+		cy.visit(postSetup.url);
+
 		cy.openNeveSidebar();
 
 		cy.activateCheckbox('.components-toggle-control__label', 'Custom Content Width (%');


### PR DESCRIPTION
### Summary
I've removed the toggle control and dependent control from being available on `full-width`
Also on `full-width` the custom width is ignored.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Before:
![image](https://user-images.githubusercontent.com/23024731/177149766-055d5865-39a3-4b8a-9b84-c467f770dcfb.png)

After: 
![image](https://user-images.githubusercontent.com/23024731/177149570-cdd37429-9c1a-4169-9d05-ed360c097327.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a New Post
2. Inside the Neve Sidebar set the container to `Full Width`
3. Check that `Custom Content Width (%)` is not being displayed and that the width used is the default one set for `Full Width`.

<!-- Issues that this pull request closes. -->
Closes #3478.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
