### PR TITLE
Active menu item color to secondary nav component

### DIFF
--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -24,12 +24,13 @@ use Neve\Core\Styles\Dynamic_Selector;
  */
 class SecondNav extends Abstract_Component {
 
-	const COMPONENT_ID   = 'secondary-menu';
-	const STYLE_ID       = 'style';
-	const COLOR_ID       = 'color';
-	const HOVER_COLOR_ID = 'hover_color';
-	const ITEM_HEIGHT    = 'item_height';
-	const SPACING        = 'spacing';
+	const COMPONENT_ID    = 'secondary-menu';
+	const STYLE_ID        = 'style';
+	const COLOR_ID        = 'color';
+	const HOVER_COLOR_ID  = 'hover_color';
+	const ACTIVE_COLOR_ID = 'active_color';
+	const ITEM_HEIGHT     = 'item_height';
+	const SPACING         = 'spacing';
 
 	/**
 	 * Nav constructor.
@@ -101,7 +102,27 @@ class SecondNav extends Abstract_Component {
 				],
 			]
 		);
-
+		SettingsManager::get_instance()->add(
+			[
+				'id'                    => self::ACTIVE_COLOR_ID,
+				'group'                 => $this->get_class_const( 'COMPONENT_ID' ),
+				'tab'                   => SettingsManager::TAB_STYLE,
+				'transport'             => 'postMessage',
+				'sanitize_callback'     => 'neve_sanitize_colors',
+				'default'               => '',
+				'label'                 => __( 'Active Item Color', 'neve' ),
+				'type'                  => 'neve_color_control',
+				'section'               => $this->section,
+				'conditional_header'    => true,
+				'live_refresh_selector' => true,
+				'live_refresh_css_prop' => [
+					'cssVar' => [
+						'vars'     => '--activecolor',
+						'selector' => '.builder-item--' . $this->get_id(),
+					],
+				],
+			]
+		);
 		SettingsManager::get_instance()->add(
 			[
 				'id'                    => self::HOVER_COLOR_ID,
@@ -231,20 +252,24 @@ class SecondNav extends Abstract_Component {
 		}
 
 		$rules = [
-			'--color'      => [
+			'--color'       => [
 				Dynamic_Selector::META_KEY => $this->get_id() . '_' . self::COLOR_ID,
 			],
-			'--hovercolor' => [
+			'--hovercolor'  => [
 				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::HOVER_COLOR_ID,
 				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::HOVER_COLOR_ID ),
 			],
-			'--spacing'    => [
+			'--activecolor' => [
+				Dynamic_Selector::META_KEY     => $this->get_id() . '_' . self::ACTIVE_COLOR_ID,
+				Dynamic_Selector::META_DEFAULT => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::ACTIVE_COLOR_ID ),
+			],
+			'--spacing'     => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::SPACING,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::SPACING ),
 			],
-			'--height'     => [
+			'--height'      => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::ITEM_HEIGHT,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_SUFFIX        => 'px',


### PR DESCRIPTION
### Summary
Adds active menu item color for the secondary navigation header component.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- The secondary navigation component should have an active item color control; 
- The color should show up fine in the front end;

<!-- Issues that this pull request closes. -->
Closes #3426.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
