### PR TITLE
fix: hide doc section when whitelabel is active

### DIFF
--- a/header-footer-grid/Core/Customizer.php
+++ b/header-footer-grid/Core/Customizer.php
@@ -242,7 +242,10 @@ class Customizer {
 		foreach ( $this->builders as $builder ) {
 			$builder->customize_register( $wp_customize );
 		}
-		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Documentation_Section' );
+		$is_whitelabel = apply_filters( 'neve_is_theme_whitelabeled', false ) || apply_filters( 'neve_is_plugin_whitelabeled', false );
+		if ( ! $is_whitelabel ) {
+			$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Documentation_Section' );
+		}
 		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Instructions_Section' );
 		$wp_customize->register_section_type( '\Neve\Customizer\Controls\React\Upsell_Section' );
 


### PR DESCRIPTION
### Summary
Don't register the Documentation Section if the Whitelabel feature is used.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check inside Customizer that the Documentation Section is loaded only if Whitelabel is not active or not configured.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2046.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
