### PR TITLE
fix: nested replies closing tags

### DIFF
--- a/inc/views/partials/comments.php
+++ b/inc/views/partials/comments.php
@@ -18,11 +18,11 @@ use Neve\Views\Base_View;
 class Comments extends Base_View {
 
 	/**
-	 * Holds if an open children tag is opened for replies.
+	 * Holds comment IDs that have an opened children tag.
 	 *
-	 * @var bool
+	 * @var array
 	 */
-	private $is_tag_open = false;
+	private $comments_with_children = [];
 
 	/**
 	 * Add in functionality.
@@ -156,8 +156,8 @@ class Comments extends Base_View {
 	 * @param int         $depth   the comments depth.
 	 */
 	public function end_comment_list_callback( $comment, $args, $depth ) {
-		if ( $this->is_tag_open && $comment->comment_parent == 0 ) {
-			$this->is_tag_open = false;
+		if ( in_array( $comment->comment_ID, $this->comments_with_children ) ) {
+			unset( $this->comments_with_children[ $comment->comment_ID ] );
 			echo '</ol></li><!-- close children li -->';
 		}
 	}
@@ -249,7 +249,7 @@ class Comments extends Base_View {
 				break;
 		}
 		if ( $args['has_children'] === true ) {
-			$this->is_tag_open = true;
+			array_push( $this->comments_with_children, $comment->comment_ID );
 			echo '<li class="children" role="listitem"><ol>';
 		}
 	}


### PR DESCRIPTION
### Summary
Fixed how the comment replies tag close.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/181223156-9dfbebdf-a551-4bbc-abb2-623236accedf.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Add 2 Comments on a Post
2. Reply to the First Comment
3. Reply to the Reply of the First Comment
4. Check that the indentation is preserved for replies and that the second Comment is not shown as a reply.

<!-- Issues that this pull request closes. -->
Closes #3546.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
