### PR TITLE
Fix comment reply script loading

### DIFF
--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -375,9 +375,43 @@ class Front_End {
 			wp_script_add_data( 'neve-shop-script', 'async', true );
 		}
 
-		if ( is_singular() & comments_open() && get_option( 'thread_comments' ) ) {
+		if ( $this->should_load_comments_reply() ) {
 			wp_enqueue_script( 'comment-reply' );
 		}
+	}
+
+	/**
+	 * Dequeue comments-reply script if comments are closed.
+	 *
+	 * @return bool
+	 */
+	public function should_load_comments_reply() {
+
+		if ( neve_is_amp() ) {
+			return false;
+		}
+
+		if ( ! is_singular() ) {
+			return false;
+		}
+
+		if ( ! comments_open() ) {
+			return false;
+		}
+
+		if ( ! (bool) get_option( 'thread_comments' ) ) {
+			return false;
+		}
+
+		if ( post_password_required() ) {
+			return false;
+		}
+
+		if ( is_singular( 'post' ) && ! apply_filters( 'neve_post_has_comments', false ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -387,10 +387,6 @@ class Front_End {
 	 */
 	public function should_load_comments_reply() {
 
-		if ( neve_is_amp() ) {
-			return false;
-		}
-
 		if ( ! is_singular() ) {
 			return false;
 		}

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -403,6 +403,11 @@ class Front_End {
 			return false;
 		}
 
+		$post_type = get_post_type();
+		if ( ! post_type_supports( $post_type, 'comments' ) ) {
+			return false;
+		}
+
 		if ( is_singular( 'post' ) && ! apply_filters( 'neve_post_has_comments', false ) ) {
 			return false;
 		}

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -408,7 +408,7 @@ class Front_End {
 			return false;
 		}
 
-		if ( is_singular( 'post' ) && ! apply_filters( 'neve_post_has_comments', false ) ) {
+		if ( ! apply_filters( 'neve_post_has_comments', false ) ) {
 			return false;
 		}
 

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -38,7 +38,14 @@ class Post_Layout extends Base_View {
 	 * @return bool
 	 */
 	public function post_has_comments() {
-		if ( ! is_singular( 'post' ) ) {
+		$post_type              = get_post_type();
+		$supported_post_types   = apply_filters( 'neve_post_type_supported_list', [], 'block_editor' );
+		$supported_post_types[] = 'post';
+		if ( ! in_array( $post_type, $supported_post_types, true ) ) {
+			return false;
+		}
+
+		if ( ! is_singular( $post_type ) ) {
 			return false;
 		}
 

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -29,32 +29,30 @@ class Post_Layout extends Base_View {
 	 */
 	public function init() {
 		add_action( 'neve_do_single_post', [ $this, 'render_post' ] );
-		add_filter( 'comments_open', [ $this, 'filter_comments_open' ] );
+		add_filter( 'neve_post_has_comments', [ $this, 'post_has_comments' ] );
 	}
 
 	/**
-	 * Dequeue comments-reply script if comments are closed.
-	 *
-	 * @param bool $open Comments open status.
+	 * Detect if comments post element is enabled.
 	 *
 	 * @return bool
 	 */
-	public function filter_comments_open( $open ) {
+	public function post_has_comments() {
 		if ( ! is_singular( 'post' ) ) {
-			return $open;
+			return false;
 		}
 
 		$content_order = $this->get_content_order();
 
 		if ( empty( $content_order ) ) {
-			return $open;
+			return false;
 		}
 
 		if ( ! in_array( 'comments', $content_order ) ) {
 			return false;
 		}
 
-		return $open;
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
### Summary
- Change the way we check if we add comments script or not

In order to load comment-reply script we are checking:

1. If comments are enabled
2. If current page is single ( post / page / cpt )
3. If thread comments are enabled ( https://vertis.d.pr/mCPDSn )
4. If post is password protected
5. For posts and CPT we check that the comments are enabled in customizer
6. If current post type supports comments

### Will affect visual aspect of the product
NO


### Test instructions
- Try each condition above and make each one to return false. Then, check if the script appears in your page:
<img width="972" alt="Screenshot 2022-07-29 at 16 28 19" src="https://user-images.githubusercontent.com/9929553/181770721-19c0eb2a-3eda-4cf5-b0c1-bbb89d4b5021.png">


<!-- Issues that this pull request closes. -->
Closes #3549.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
