### PR TITLE
fix: sticky footer z-index Codeinwp/neve-pro-addon#2092

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_footer.scss
+++ b/assets/scss/components/hfg/frontend/layout/_footer.scss
@@ -1,6 +1,6 @@
 .site-footer {
 	position: relative;
-	z-index: 10;
+	z-index: 11;
 
 	.item--inner {
 		width: 100%;

--- a/header-footer-grid/assets/scss/frontend/layout/_footer.scss
+++ b/header-footer-grid/assets/scss/frontend/layout/_footer.scss
@@ -17,7 +17,7 @@
 
 .site-footer {
   position: relative;
-  z-index: 10;
+  z-index: 11;
   .item--inner.has_menu {
     width: 100%;
     max-width: 100%;


### PR DESCRIPTION
### Summary
Changed the `z-index` for the footer, when sticky it would not display over some elements.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Enable the sticky footer row
2. Enable the wishlist icon for products, and the sale label
3. Scroll the page on the shop and single product pages - on the product page it happens with the related/exclusive products
4. Check no items or badges are displayed over the footer.


<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2092.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
