### PR TITLE
Add margin control for menu label

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-toggle.scss
+++ b/assets/scss/components/elements/navigation/_nav-toggle.scss
@@ -1,6 +1,6 @@
 .nav-toggle-label {
-	margin-right: 5px;
 	line-height: 1;
+	margin: var(--label-margin, 0 5px 0 0);
 }
 
 .navbar-toggle-wrapper {

--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -738,12 +738,14 @@ abstract class Abstract_Component implements Component {
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::PADDING_ID,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::PADDING_ID ),
+				Dynamic_Selector::META_SUFFIX        => 'responsive_unit',
 				'directional-prop'                   => Config::CSS_PROP_PADDING,
 			],
 			'--margin'  => [
 				Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::MARGIN_ID,
 				Dynamic_Selector::META_IS_RESPONSIVE => true,
 				Dynamic_Selector::META_DEFAULT       => SettingsManager::get_instance()->get_default( $this->get_id() . '_' . self::MARGIN_ID ),
+				Dynamic_Selector::META_SUFFIX        => 'responsive_unit',
 				'directional-prop'                   => Config::CSS_PROP_MARGIN,
 			],
 		];

--- a/header-footer-grid/Core/Components/MenuIcon.php
+++ b/header-footer-grid/Core/Components/MenuIcon.php
@@ -32,6 +32,7 @@ class MenuIcon extends Abstract_Component {
 	const BUTTON_APPEARANCE = 'button_appearance';
 	const COMPONENT_SLUG    = 'nav-icon';
 	const QUICK_LINKS_ID    = 'quick-links';
+	const LABEL_MARGIN_ID   = 'label_margin';
 	const MENU_ICON         = 'menu_icon';
 
 	/**
@@ -58,6 +59,35 @@ class MenuIcon extends Abstract_Component {
 			'right'  => 15,
 			'bottom' => 10,
 			'left'   => 15,
+		),
+		'mobile-unit'  => 'px',
+		'tablet-unit'  => 'px',
+		'desktop-unit' => 'px',
+	);
+
+	/**
+	 * Label margin settings default values.
+	 *
+	 * @var array
+	 */
+	protected $default_label_margin_value = array(
+		'mobile'       => array(
+			'top'    => 0,
+			'right'  => 5,
+			'bottom' => 0,
+			'left'   => 0,
+		),
+		'tablet'       => array(
+			'top'    => 0,
+			'right'  => 5,
+			'bottom' => 0,
+			'left'   => 0,
+		),
+		'desktop'      => array(
+			'top'    => 0,
+			'right'  => 5,
+			'bottom' => 0,
+			'left'   => 0,
 		),
 		'mobile-unit'  => 'px',
 		'tablet-unit'  => 'px',
@@ -434,6 +464,30 @@ CSS;
 
 		SettingsManager::get_instance()->add(
 			[
+				'id'                    => self::LABEL_MARGIN_ID,
+				'group'                 => $this->get_id(),
+				'transport'             => 'postMessage',
+				'tab'                   => SettingsManager::TAB_LAYOUT,
+				'sanitize_callback'     => array( $this, 'sanitize_spacing_array' ),
+				'label'                 => __( 'Margin', 'neve' ) . ' (' . __( 'Label', 'neve' ) . ')',
+				'type'                  => '\Neve\Customizer\Controls\React\Spacing',
+				'default'               => $this->default_label_margin_value,
+				'live_refresh_selector' => '.builder-item--' . $this->get_id(),
+				'live_refresh_css_prop' => array(
+					'cssVar' => [
+						'vars'       => '--label-margin',
+						'responsive' => true,
+						'selector'   => '.builder-item--' . $this->get_id(),
+					],
+					'prop'   => 'margin',
+				),
+				'section'               => $this->section,
+				'conditional_header'    => $this->get_builder_id() === 'header',
+			]
+		);
+
+		SettingsManager::get_instance()->add(
+			[
 				'id'                    => self::MENU_ICON,
 				'group'                 => $this->get_id(),
 				'tab'                   => SettingsManager::TAB_STYLE,
@@ -586,6 +640,18 @@ CSS;
 		$css_array[] = [
 			Dynamic_Selector::KEY_SELECTOR => '.builder-item--' . $this->get_id() . ',' . $this->close_button,
 			Dynamic_Selector::KEY_RULES    => $rules,
+		];
+
+		$css_array[] = [
+			Dynamic_Selector::KEY_SELECTOR => '.builder-item--' . $this->get_id(),
+			Dynamic_Selector::KEY_RULES    => [
+				'--label-margin' => [
+					Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::LABEL_MARGIN_ID,
+					Dynamic_Selector::META_IS_RESPONSIVE => true,
+					Dynamic_Selector::META_DEFAULT       => $this->default_label_margin_value,
+					'directional-prop'                   => Config::CSS_PROP_MARGIN,
+				],
+			],
 		];
 
 		return parent::add_style( $css_array );

--- a/header-footer-grid/Core/Components/MenuIcon.php
+++ b/header-footer-grid/Core/Components/MenuIcon.php
@@ -649,6 +649,7 @@ CSS;
 					Dynamic_Selector::META_KEY           => $this->get_id() . '_' . self::LABEL_MARGIN_ID,
 					Dynamic_Selector::META_IS_RESPONSIVE => true,
 					Dynamic_Selector::META_DEFAULT       => $this->default_label_margin_value,
+					Dynamic_Selector::META_SUFFIX        => 'responsive_unit',
 					'directional-prop'                   => Config::CSS_PROP_MARGIN,
 				],
 			],


### PR DESCRIPTION
### Summary
- Adds a new margin control for the Menu Icon component 

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->
<img width="852" alt="Screenshot 2022-08-02 at 12 23 41" src="https://user-images.githubusercontent.com/9929553/182340850-7eeb012c-28c2-4c27-a0d9-1a59a0ba5252.png">

### Test instructions
- See if the control applies properly in the customizer and on the front end

<!-- Issues that this pull request closes. -->
Closes  Codeinwp/neve-pro-addon#2095.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
