### PR TITLE
fix: critical error when header is empty [#3557]

### DIFF
--- a/header-footer-grid/functions-template.php
+++ b/header-footer-grid/functions-template.php
@@ -92,6 +92,9 @@ function current_row( $builder_name = '' ) {
  */
 function component_setting( $id, $default = null, $component_id = null ) {
 	if ( null === $component_id ) {
+		if ( empty( current_component() ) ) {
+			return false;
+		}
 		$component_id = current_component()->get_id();
 	}
 

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -21,7 +21,6 @@ $close_contained  = $interaction_type === 'dropdown';
 $inner_classes    = 'header-menu-sidebar-inner ' . ( $is_contained ? ' container' : '' );
 $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 $close_classes    = 'close-sidebar-panel navbar-toggle-wrapper' . ( $close_contained ? ' container' : '' );
-$menu_icon        = component_setting( MenuIcon::MENU_ICON );
 
 $menu_icon_class = apply_filters( 'neve_menu_icon_classes', 'hamburger is-active ' );
 ?>


### PR DESCRIPTION
### Summary
- Fixes the error thrown if you have an empty header.

### Will affect visual aspect of the product
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->
- On a clean instance of a local environment ( not tastewp ) install just neve free.
- Go in customizer and apply the starter content
- Save customizer and refresh
- Empty the header both on mobile and desktop and hit publish
- Exit the customizer and see the frontpage. Without this fix you should see an error.
- Try the previous steps for footer too and make sure the issue doesn't happen there as well

<!-- Issues that this pull request closes. -->
Closes #3557.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
