### PR TITLE
fix: solve migration button defaults missmatch #3560

### DIFF
--- a/globals/migrations.php
+++ b/globals/migrations.php
@@ -53,10 +53,10 @@ function neve_get_button_appearance_default( $button = 'button' ) {
 
 		return [
 			'type'                  => 'fill',
-			'background'            => 'var(--nv-primary-accent)',
-			'backgroundHover'       => 'var(--nv-primary-accent)',
-			'text'                  => '#ffffff',
-			'textHover'             => '#ffffff',
+			'background'            => 'var(--nv-secondary-accent)',
+			'backgroundHover'       => 'var(--nv-secondary-accent)',
+			'text'                  => 'var(--nv-text-color)',
+			'textHover'             => 'var(--nv-text-color)',
 			'borderRadius'          => [
 				'top'    => 3,
 				'right'  => 3,


### PR DESCRIPTION
### Summary
Fixed the migration defaults on the first install publish for header buttons.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install Neve free on a clean instance 
2. Enter the customizer and hit publish to apply the starter content
3. Exit the customizer and see the button in the header

<!-- Issues that this pull request closes. -->
Closes #3560.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
