### PR TITLE
fix: button border default and default import #3565 #3570

### DIFF
--- a/globals/migrations.php
+++ b/globals/migrations.php
@@ -53,10 +53,10 @@ function neve_get_button_appearance_default( $button = 'button' ) {
 
 		return [
 			'type'                  => 'fill',
-			'background'            => 'var(--nv-secondary-accent)',
-			'backgroundHover'       => 'var(--nv-secondary-accent)',
-			'text'                  => 'var(--nv-text-color)',
-			'textHover'             => 'var(--nv-text-color)',
+			'background'            => 'var(--nv-primary-accent)',
+			'backgroundHover'       => 'var(--nv-primary-accent)',
+			'text'                  => '#fff',
+			'textHover'             => '#fff',
 			'borderRadius'          => [
 				'top'    => 3,
 				'right'  => 3,

--- a/header-footer-grid/Core/Components/Button.php
+++ b/header-footer-grid/Core/Components/Button.php
@@ -256,10 +256,22 @@ class Button extends Abstract_Component {
 		$value = get_theme_mod( $id );
 
 		$rules = [
-			'--primarybtnbg'           => [ Dynamic_Selector::META_KEY => $id . '.background' ],
-			'--primarybtncolor'        => [ Dynamic_Selector::META_KEY => $id . '.text' ],
-			'--primarybtnhoverbg'      => [ Dynamic_Selector::META_KEY => $id . '.backgroundHover' ],
-			'--primarybtnhovercolor'   => [ Dynamic_Selector::META_KEY => $id . '.textHover' ],
+			'--primarybtnbg'           => [
+				Dynamic_Selector::META_KEY     => $id . '.background',
+				Dynamic_Selector::META_DEFAULT => 'var(--nv-primary-accent)',
+			],
+			'--primarybtncolor'        => [
+				Dynamic_Selector::META_KEY     => $id . '.text',
+				Dynamic_Selector::META_DEFAULT => '#fff',
+			],
+			'--primarybtnhoverbg'      => [
+				Dynamic_Selector::META_KEY     => $id . '.backgroundHover',
+				Dynamic_Selector::META_DEFAULT => 'var(--nv-primary-accent)',
+			],
+			'--primarybtnhovercolor'   => [
+				Dynamic_Selector::META_KEY     => $id . '.textHover',
+				Dynamic_Selector::META_DEFAULT => '#fff',
+			],
 			'--primarybtnborderradius' => [
 				Dynamic_Selector::META_KEY => $id . '.borderRadius',
 				'directional-prop'         => Config::CSS_PROP_BORDER_RADIUS,

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -311,6 +311,10 @@ class Css_Prop {
 		if ( count( array_unique( $filtered ) ) === 1 ) {
 
 			if ( neve_value_is_zero( $value['top'] ) ) {
+				$suffix = '';
+			}
+
+			if ( empty( $value['top'] ) && ! neve_value_is_zero( $value['top'] ) ) {
 				return '';
 			}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fix `border-radius` with 0 values not being respected on buttons.
Fix default appearance on a new import for header buttons and fix regression

### Will affect the visual aspect of the product
<!-- It includes visible changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Test on a fresh instance of Neve
2. Check that the default Header Button displays the same in Customizer and on the Frontend
3. Check that the Woo button displays as before
4. Check that the `border-radius` can now have 0 values

<!-- Issues that this pull request closes. -->
Closes #3565.
Closes #3570.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
