### PR TITLE
fix: secondary button options applying on search submit button

### DIFF
--- a/header-footer-grid/Core/Components/Search.php
+++ b/header-footer-grid/Core/Components/Search.php
@@ -538,9 +538,22 @@ class Search extends Abstract_Component {
 	 * @access  public
 	 */
 	public function render_component() {
+		add_filter( 'get_search_form', [ $this, 'add_submit_button_classes' ] );
 		add_filter( 'nv_search_placeholder', [ $this, 'change_placeholder' ] );
 		Main::get_instance()->load( 'components/component-search' );
+		remove_filter( 'get_search_form', [ $this, 'add_submit_button_classes' ] );
 		remove_filter( 'nv_search_placeholder', [ $this, 'change_placeholder' ] );
+	}
+
+	/**
+	 * Add nv-submit class on submit button for search component.
+	 *
+	 * @param string $form Form HTML.
+	 *
+	 * @return string
+	 */
+	public function add_submit_button_classes( $form ) {
+		return str_replace( 'search-submit', 'search-submit nv-submit', $form );
 	}
 
 	/**

--- a/inc/core/settings/config.php
+++ b/inc/core/settings/config.php
@@ -224,8 +224,8 @@ class Config {
 		self::CSS_SELECTOR_FORM_INPUTS_WITH_SPACING    => 'form:not([role="search"]):not(.woocommerce-cart-form):not(.woocommerce-ordering):not(.cart) input:read-write:not(#coupon_code), form textarea, form select, .widget select',
 		self::CSS_SELECTOR_FORM_INPUTS                 => 'form input:read-write, form textarea, form select, form select option, form.wp-block-search input.wp-block-search__input, .widget select',
 		self::CSS_SELECTOR_FORM_INPUTS_LABELS          => 'form label, .wpforms-container .wpforms-field-label',
-		self::CSS_SELECTOR_FORM_BUTTON                 => 'form input[type="submit"], form button[type="submit"], form *[value*="ubmit"], #comments input[type="submit"]',
-		self::CSS_SELECTOR_FORM_BUTTON_HOVER           => 'form input[type="submit"]:hover, form button[type="submit"]:hover, form *[value*="ubmit"]:hover, #comments input[type="submit"]:hover',
+		self::CSS_SELECTOR_FORM_BUTTON                 => 'form input[type="submit"], form button[type="submit"]:not(.nv-submit), form *[value*="ubmit"], #comments input[type="submit"]',
+		self::CSS_SELECTOR_FORM_BUTTON_HOVER           => 'form input[type="submit"]:hover, form button[type="submit"]:not(.nv-submit):hover, form *[value*="ubmit"]:hover, #comments input[type="submit"]:hover',
 		self::CSS_SELECTOR_FORM_SEARCH_INPUTS          => 'form.search-form input:read-write',
 	];
 }


### PR DESCRIPTION
### Summary
Exclude button submit from secondary button style

### Will affect visual aspect of the product
NO


### Test instructions
- Import the Photography starter site and add the search component in the header 
- Check if secondary button settings are still applying

<!-- Issues that this pull request closes. -->
Closes #3586.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
