### PR TITLE
fix: solve extra divider when no description #3580

### DIFF
--- a/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
+++ b/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
@@ -36,8 +36,12 @@ const Instructions: React.FC<Props> = ({ control }) => {
 
 	return (
 		<div className="quick-links-inner">
-			{description && <p>{description}</p>}
-			<hr />
+			{description && (
+				<>
+					<p>{description}</p>
+					<hr />
+				</>
+			)}
 			{linkKeys.length && (
 				<div className="quick-links-wrap">
 					<span className="customize-control-title">


### PR DESCRIPTION
### Summary
Removed extra divider if no description is provided.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Go into Customizer > Typography
2. Check that there is only one divider at the top.
3. Check that on Customizer > Footer, where a description is provided there is a divider before and after the description of the section.

<!-- Issues that this pull request closes. -->
Closes #3580.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
