### PR TITLE
Fix for two issue related between Exclusive Products section and Sparks Variation Swatches

### DIFF
--- a/assets/js/src/shop/app.js
+++ b/assets/js/src/shop/app.js
@@ -1,4 +1,5 @@
 /* jshint esversion: 6 */
+/* global CustomEvent */
 import { tns } from 'tiny-slider/src/tiny-slider';
 
 /**
@@ -54,7 +55,7 @@ function handleExclusiveSlider() {
 		1200: { items: 4, gutter: 30 },
 	};
 
-	tns({
+	const slider = tns({
 		container: 'ul.exclusive-products',
 		slideBy: 1,
 		arrowKeys: true,
@@ -73,6 +74,19 @@ function handleExclusiveSlider() {
 		navAsThumbnails: true,
 		responsive,
 	});
+
+	// [If Sparks Variation Swatches is enabled and ] Initialize Sparks Variation Swatches for cloned products.
+	if (document.body.classList.contains('sparks-vs-shop-attribute')) {
+		slider.events.on('transitionEnd', () => {
+			document.dispatchEvent(
+				new CustomEvent('sparksVSNeedsInit', {
+					detail: {
+						container: '.products.exclusive',
+					},
+				})
+			);
+		});
+	}
 }
 
 /**

--- a/assets/js/src/shop/app.js
+++ b/assets/js/src/shop/app.js
@@ -10,8 +10,9 @@ function initShop() {
 	}
 
 	const countExclusive = document.querySelectorAll(
-		'.exclusive-products li'
+		'.exclusive-products li.product'
 	).length;
+
 	if (
 		document.body.classList.contains('nv-exclusive') &&
 		countExclusive > 4


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
**The changes contains:**
1.  Fix for the https://github.com/Codeinwp/neve/issues/3591 issue

2. Fix for the: https://github.com/Codeinwp/sparks-for-woocommerce/pull/134#issuecomment-1229888627 issue(second TODO in the comment that added by @irinelenache )
-- The https://github.com/Codeinwp/neve/commit/df70e7f3c0ec7670f3f30c62b5480ba7b1e0a771 commit is responsible for the fix. I'll make performance improvements and move some code to the Neve Pro side probably.



**! Note: This PR(https://github.com/Codeinwp/neve/pull/3592) is relative to https://github.com/Codeinwp/sparks-for-woocommerce/pull/134**

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Activate stable Neve Pro
- Activate Sparks from [this](https://github.com/Codeinwp/sparks-for-woocommerce/pull/134) PR.
- Activate Sparks Variation Swatches and make sure catalog attributes mode is on.
- Have some products. Make sure some of them are variable and have attributes (attributes should be matched with Sparks Variation Swatches attributes; color type etc.)
- Enable the "exclusive products" feature in customizer. And match the category and make sure the category has less than 4 products and some of them are variable and contains property.
- Everything should work fine on there.

<!-- Issues that this pull request closes. -->
Closes #3591 .

In addition to Closes announcement on the above; this PR(https://github.com/Codeinwp/neve/pull/3592) fixes the second TODO on the Codeinwp/sparks-for-woocommerce#134 (comment) comment.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
