### PR TITLE
feat: Customizer Search component for Settings

### DIFF
--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -37,8 +37,7 @@ import Documentation from './documentation-section/Documentation.tsx';
 import Instructions from './builder-instructions/Instructions.tsx';
 import Upsells from './builder-upsell/Upsells.tsx';
 
-import SearchToggle from './customizer-search/SearchToggle.tsx';
-import SearchComponent from './customizer-search/SearchComponent.tsx';
+import MainSearch from './customizer-search/MainSearch.tsx';
 
 const { controlConstructor } = wp.customize;
 
@@ -102,44 +101,54 @@ const initDocSection = () => {
 };
 
 const initSearchCustomizer = () => {
-	const toggleSearchID = 'neve-customize-search';
-	const searchComponentID = 'neve-customize-search-field';
-	const searchResultsID = 'neve-customize-search-results';
-	const isSearchButton = document.querySelectorAll(`#${toggleSearchID}`);
-	if (isSearchButton.length === 0) {
-		const title = document.querySelectorAll(
-			'#customize-info .accordion-section-title'
-		);
-		if (title.length !== 0) {
-			const targetNode = document.createElement('div');
-			targetNode.setAttribute('id', toggleSearchID);
-			title[0].append(targetNode);
-			const searchButtonTarget = document.querySelectorAll(
-				`#${toggleSearchID}`
+	// will remove the search icon if another plugin or WordPress add this feature
+	const checkSearchIcon = () => {
+		const searchCount = document.querySelectorAll(
+			'#customize-info .accordion-section-title .dashicons-search'
+		).length;
+		if (searchCount > 1) {
+			document.removeEventListener(
+				'DOMNodeInserted',
+				checkSearchIcon,
+				false
 			);
-			if (searchButtonTarget.length !== 0) {
-				render(<SearchToggle />, searchButtonTarget[0]);
-			}
-
-			const targetFieldNode = document.createElement('div');
-			targetFieldNode.setAttribute('id', searchComponentID);
-			const titleSection = document.getElementById('customize-info');
-			titleSection.append(targetFieldNode);
-			const searchFieldTarget = document.querySelectorAll(
-				`#${searchComponentID}`
-			);
-			if (searchFieldTarget.length !== 0) {
-				render(<SearchComponent />, searchFieldTarget[0]);
-			}
-
-			const customizerPanels = document.getElementById(
-				'customize-theme-controls'
-			);
-			const targetSearchResultsNode = document.createElement('div');
-			targetSearchResultsNode.setAttribute('id', searchResultsID);
-			customizerPanels.after(targetSearchResultsNode);
+			document.getElementById('neve-customize-search')?.remove();
 		}
-	}
+	};
+	document.addEventListener('DOMNodeInserted', checkSearchIcon, false);
+
+	const customizePreview = document.getElementById('customize-controls');
+	const mount = document.createElement('div');
+	customizePreview.appendChild(mount);
+
+	const title = document.querySelector(
+		'#customize-info .accordion-section-title'
+	);
+	const customizerPanels = document.getElementById(
+		'customize-theme-controls'
+	);
+	const titleSection = document.getElementById('customize-info');
+
+	const targetNode = document.createElement('div');
+	const targetFieldNode = document.createElement('div');
+	const targetSearchResultsNode = document.createElement('div');
+
+	targetNode.setAttribute('id', 'neve-customize-search');
+	targetFieldNode.setAttribute('id', 'neve-customize-search-field');
+	targetSearchResultsNode.setAttribute('id', 'neve-customize-search-results');
+
+	title.append(targetNode);
+	titleSection.append(targetFieldNode);
+	customizerPanels.after(targetSearchResultsNode);
+
+	render(
+		<MainSearch
+			search={targetFieldNode}
+			button={targetNode}
+			results={targetSearchResultsNode}
+		/>,
+		mount
+	);
 };
 
 const initCustomPagesFocus = () => {

--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -37,6 +37,9 @@ import Documentation from './documentation-section/Documentation.tsx';
 import Instructions from './builder-instructions/Instructions.tsx';
 import Upsells from './builder-upsell/Upsells.tsx';
 
+import SearchToggle from './customizer-search/SearchToggle.tsx';
+import SearchComponent from './customizer-search/SearchComponent.tsx';
+
 const { controlConstructor } = wp.customize;
 
 controlConstructor.neve_toggle_control = ToggleControl;
@@ -96,6 +99,47 @@ const initDocSection = () => {
 
 		render(<Documentation control={section} />, section.container[0]);
 	});
+};
+
+const initSearchCustomizer = () => {
+	const toggleSearchID = 'neve-customize-search';
+	const searchComponentID = 'neve-customize-search-field';
+	const searchResultsID = 'neve-customize-search-results';
+	const isSearchButton = document.querySelectorAll(`#${toggleSearchID}`);
+	if (isSearchButton.length === 0) {
+		const title = document.querySelectorAll(
+			'#customize-info .accordion-section-title'
+		);
+		if (title.length !== 0) {
+			const targetNode = document.createElement('div');
+			targetNode.setAttribute('id', toggleSearchID);
+			title[0].append(targetNode);
+			const searchButtonTarget = document.querySelectorAll(
+				`#${toggleSearchID}`
+			);
+			if (searchButtonTarget.length !== 0) {
+				render(<SearchToggle />, searchButtonTarget[0]);
+			}
+
+			const targetFieldNode = document.createElement('div');
+			targetFieldNode.setAttribute('id', searchComponentID);
+			const titleSection = document.getElementById('customize-info');
+			titleSection.append(targetFieldNode);
+			const searchFieldTarget = document.querySelectorAll(
+				`#${searchComponentID}`
+			);
+			if (searchFieldTarget.length !== 0) {
+				render(<SearchComponent />, searchFieldTarget[0]);
+			}
+
+			const customizerPanels = document.getElementById(
+				'customize-theme-controls'
+			);
+			const targetSearchResultsNode = document.createElement('div');
+			targetSearchResultsNode.setAttribute('id', searchResultsID);
+			customizerPanels.after(targetSearchResultsNode);
+		}
+	}
 };
 
 const initCustomPagesFocus = () => {
@@ -234,6 +278,7 @@ window.wp.customize.bind('ready', () => {
 	checkHasElementorTemplates();
 	initDeviceSwitchers();
 	initBlogPageFocus();
+	initSearchCustomizer();
 });
 
 window.HFG = {

--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -1,4 +1,4 @@
-/* global CustomEvent, NeveReactCustomize */
+/* global CustomEvent, NeveReactCustomize, MutationObserver */
 import './public-path.js';
 import { render } from '@wordpress/element';
 
@@ -102,20 +102,26 @@ const initDocSection = () => {
 
 const initSearchCustomizer = () => {
 	// will remove the search icon if another plugin or WordPress add this feature
-	const checkSearchIcon = () => {
-		const searchCount = document.querySelectorAll(
-			'#customize-info .accordion-section-title .dashicons-search'
-		).length;
-		if (searchCount > 1) {
-			document.removeEventListener(
-				'DOMNodeInserted',
-				checkSearchIcon,
-				false
-			);
-			document.getElementById('neve-customize-search')?.remove();
+	const callback = (mutationList, observer) => {
+		for (const mutation of mutationList) {
+			if (mutation.type === 'childList') {
+				const searchCount = document.querySelectorAll(
+					'#customize-info .accordion-section-title .dashicons-search'
+				).length;
+				if (searchCount > 1) {
+					observer.disconnect();
+					document.getElementById('neve-customize-search')?.remove();
+				}
+			}
 		}
 	};
-	document.addEventListener('DOMNodeInserted', checkSearchIcon, false);
+
+	const targetNodeMutation = document.querySelector(
+		'#customize-info .accordion-section-title'
+	);
+	const observer = new MutationObserver(callback);
+	const config = { attributes: false, childList: true, subtree: false };
+	observer.observe(targetNodeMutation, config);
 
 	const customizePreview = document.getElementById('customize-controls');
 	const mount = document.createElement('div');

--- a/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
@@ -39,6 +39,7 @@ const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
 					isOpened={isOpened}
 					search={query}
 					setSearch={setQuery}
+					matchResults={matchResults}
 					setMatchResults={setMatchResults}
 				/>,
 				search
@@ -46,7 +47,6 @@ const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
 			{createPortal(
 				<SearchResults
 					matchResults={matchResults}
-					setMatchResults={setMatchResults}
 					query={query}
 					setQuery={setQuery}
 				/>,

--- a/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
@@ -1,7 +1,8 @@
 import { createPortal } from '@wordpress/element';
 import React, { useState } from 'react';
 import SearchToggle from './SearchToggle';
-import SearchComponent from './SearchComponent';
+import SearchComponent, { Control } from './SearchComponent';
+import SearchResults from './SearchResults';
 
 /**
  * Type MainSearchProps
@@ -20,6 +21,8 @@ type MainSearchProps = {
  */
 const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
 	const [isOpened, setIsOpened] = useState(false);
+	const [query, setQuery] = useState('');
+	const [matchResults, setMatchResults] = useState([] as Control[]);
 
 	return (
 		<>
@@ -31,8 +34,25 @@ const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
 				/>,
 				button
 			)}
-			{createPortal(<SearchComponent isOpened={isOpened} />, search)}
-			{createPortal(<div id="neve-customize-search-results" />, results)}
+			{createPortal(
+				<SearchComponent
+					isOpened={isOpened}
+					search={query}
+					setSearch={setQuery}
+					matchResults={matchResults}
+					setMatchResults={setMatchResults}
+				/>,
+				search
+			)}
+			{createPortal(
+				<SearchResults
+					matchResults={matchResults}
+					setMatchResults={setMatchResults}
+					query={query}
+					setQuery={setQuery}
+				/>,
+				results
+			)}
 		</>
 	);
 };

--- a/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
@@ -39,7 +39,6 @@ const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
 					isOpened={isOpened}
 					search={query}
 					setSearch={setQuery}
-					matchResults={matchResults}
 					setMatchResults={setMatchResults}
 				/>,
 				search

--- a/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/MainSearch.tsx
@@ -1,0 +1,40 @@
+import { createPortal } from '@wordpress/element';
+import React, { useState } from 'react';
+import SearchToggle from './SearchToggle';
+import SearchComponent from './SearchComponent';
+
+/**
+ * Type MainSearchProps
+ */
+type MainSearchProps = {
+	search: HTMLDivElement;
+	button: HTMLDivElement;
+	results: HTMLDivElement;
+};
+
+/**
+ * MainSearch Component
+ *
+ * @param {MainSearchProps} MainSearchProps
+ * @class
+ */
+const MainSearch: React.FC<MainSearchProps> = ({ search, button, results }) => {
+	const [isOpened, setIsOpened] = useState(false);
+
+	return (
+		<>
+			{createPortal(
+				<SearchToggle
+					onToggle={() => {
+						setIsOpened(!isOpened);
+					}}
+				/>,
+				button
+			)}
+			{createPortal(<SearchComponent isOpened={isOpened} />, search)}
+			{createPortal(<div id="neve-customize-search-results" />, results)}
+		</>
+	);
+};
+
+export default MainSearch;

--- a/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
@@ -1,4 +1,4 @@
-/* global  _wpCustomizeSettings wp */
+/* global  _wpCustomizeSettings */
 
 import React from 'react';
 import { __ } from '@wordpress/i18n';
@@ -47,10 +47,10 @@ declare global {
 	const wp: {
 		customize: {
 			section: (sectionName: string) => {
-				expand: (p: { duration: number }) => void;
+				expand: (p?: { duration: number }) => void;
 			};
 			panel: (sectionName: string) => {
-				expand: (p: { duration: number }) => void;
+				expand: (p?: { duration: number }) => void;
 			};
 		};
 	};

--- a/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
@@ -1,0 +1,327 @@
+/* global  _wpCustomizeSettings wp */
+
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Customizer Control Type
+ */
+type Control = {
+	section: string;
+	panelName: string | null;
+	sectionName: string;
+	panel: string;
+	label: string;
+};
+
+/**
+ * Customizer Section Type
+ */
+type Section = {
+	id: string;
+	panel: string;
+	title: string;
+};
+
+/**
+ * Customizer Panel Type
+ */
+type Panel = {
+	id: string;
+	title: string;
+};
+
+/**
+ * Global for TypeScript
+ */
+declare global {
+	const _wpCustomizeSettings: {
+		controls: Control[];
+		sections: Section[];
+		panels: Panel[];
+	};
+
+	const wp: {
+		customize: {
+			section: (sectionName: string) => { expand: () => void };
+		};
+	};
+}
+
+/**
+ * Search Component
+ * Handles search input, filtering and display of results.
+ *
+ * @class
+ */
+const SearchComponent: React.FC = () => {
+	const [search, setSearch] = useState('');
+	const [resultsHTML, setResultsHTML] = useState('');
+	const [isSearchOpen, setIsSearchOpen] = useState(false);
+	const [matchResults, setMatchResults] = useState([] as Control[]);
+
+	const customizerPanels = document.getElementById(
+		'customize-theme-controls'
+	);
+	const searchResults = document.getElementById(
+		'neve-customize-search-results'
+	);
+
+	const controls = Object.values(_wpCustomizeSettings.controls).map(
+		(control) => {
+			Object.values(_wpCustomizeSettings.sections).forEach((section) => {
+				if (control.section === section.id) {
+					Object.values(_wpCustomizeSettings.panels).forEach(
+						(panel) => {
+							if ('' === section.panel) {
+								control.panelName = section.title;
+							}
+
+							if (section.panel === panel.id) {
+								control.sectionName = section.title;
+								control.panel = section.panel;
+								control.panelName = panel.title;
+							}
+						}
+					);
+				}
+			});
+
+			return control;
+		}
+	) as unknown as Control[];
+
+	/**
+	 * This `useEffect()` is being used to listen for the toggleEvent
+	 * from `SearchToggle` component.
+	 */
+	useEffect(() => {
+		const toggleSearch = () => {
+			document
+				.getElementById('neve-customize-search-field')
+				?.classList.toggle('visible');
+
+			if (isSearchOpen) {
+				clearField();
+				setIsSearchOpen(false);
+				return;
+			}
+			setIsSearchOpen(true);
+			document.getElementById('nv-customizer-search-input')?.focus();
+		};
+
+		document.addEventListener('nv-customizer-search-toggle', toggleSearch);
+
+		return () =>
+			document.removeEventListener(
+				'nv-customizer-search-toggle',
+				toggleSearch
+			);
+	}, [isSearchOpen]);
+
+	/**
+	 * This `useEffect()` only handles displaying results for the search;
+	 */
+	useEffect(() => {
+		if (search === '') {
+			clearField();
+			return;
+		}
+		if (matchResults.length === 0) {
+			return;
+		}
+		displayQueryMatch(search);
+	}, [matchResults, search]);
+
+	/**
+	 * This `useEffect()` only handles adding and removing event listeners to redirect to desired sections;
+	 */
+	useEffect(() => {
+		if (searchResults) {
+			searchResults.innerHTML = `<ul id="customizer-search-results">${resultsHTML}</ul>`;
+			const searchSettings = document.querySelectorAll(
+				'#customizer-search-results .accordion-section'
+			);
+			searchSettings.forEach((setting) =>
+				setting.addEventListener(
+					'click',
+					expandSection as unknown as EventListener
+				)
+			);
+		}
+
+		return () => {
+			const searchSettings = document.querySelectorAll(
+				'#customizer-search-results .accordion-section'
+			);
+			searchSettings.forEach((setting) =>
+				setting.removeEventListener(
+					'click',
+					expandSection as unknown as EventListener
+				)
+			);
+		};
+	}, [resultsHTML]);
+
+	/**
+	 * Clear the search input field.
+	 *
+	 * @return {void}
+	 */
+	const clearField = () => {
+		setSearch('');
+		document.getElementById('nv-customizer-search-input')?.focus();
+
+		customizerPanels?.classList.remove('search-not-found');
+		if (searchResults) {
+			searchResults.innerHTML = '';
+		}
+	};
+
+	/**
+	 * Handle input field change.
+	 *
+	 * @param {Event} event
+	 * @param {Event.target} event.target
+	 * @param {string} event.target.value
+	 * @return {void}
+	 */
+	const onInputChange = (event: { target: { value: string } }) => {
+		const query = event.target.value;
+		setSearch(query);
+		const newResults = getControlsMatch(query);
+		setMatchResults(newResults);
+	};
+
+	/**
+	 * Handle redirect to specific section on click.
+	 *
+	 * @param {Event} event
+	 * @param {Event.target} event.target
+	 * @param {string} event.target.getAttribute
+	 * @param {Element} event.target.parentNode
+	 * @param {string} event.target.parentNode.getAttribute
+	 * @return {void}
+	 */
+	const expandSection = (event: {
+		target: {
+			getAttribute: (data: string) => string;
+			parentNode: { getAttribute: (data: string) => string };
+		};
+	}) => {
+		const sectionName =
+			event.target.getAttribute('data-section') ||
+			event.target.parentNode.getAttribute('data-section');
+		const section = wp.customize.section(sectionName);
+		clearField();
+		section.expand();
+	};
+
+	/**
+	 * Return all controls that match query.
+	 *
+	 * @param {string} query
+	 * @return {Control[]} controls
+	 */
+	const getControlsMatch = (query: string) => {
+		return controls.filter((control) => {
+			if (!control.label) control.label = '';
+			if (!control.panelName) control.panelName = '';
+			if (!control.sectionName) control.sectionName = '';
+
+			const regex = new RegExp(query, 'gi');
+
+			return (
+				control.label.match(regex) ||
+				control.panelName.match(regex) ||
+				control.sectionName.match(regex)
+			);
+		});
+	};
+
+	/**
+	 * Handles results HTML generation.
+	 *
+	 * @param {string} query
+	 * @return {void}
+	 */
+	const displayQueryMatch = (query: string) => {
+		if (0 === matchResults.length) return;
+
+		const htmlString = matchResults
+			.map((control) => {
+				if ('' === control.label) return '';
+
+				let breadcrumbs = control.panelName;
+				if ('' !== control.sectionName) {
+					breadcrumbs = `${breadcrumbs} ▸ ${control.sectionName}`;
+				}
+
+				const regex = new RegExp(`(${query})`, 'gi');
+
+				const label = control.label.replace(
+					regex,
+					'<span class="hl">$1</span>'
+				);
+
+				if (breadcrumbs !== null) {
+					breadcrumbs = breadcrumbs.replace(
+						regex,
+						'<span class="hl">$1</span>'
+					);
+				}
+
+				return `
+					<li id="accordion-section-${control.section}" class="accordion-section control-section control-section-default" aria-owns="sub-accordion-section-${control.section}" data-section="${control.section}">
+						<h3 class="accordion-section-title" tabindex="0">
+							${label}
+							<span class="screen-reader-text">Press return or enter to open this section</span>
+						</h3>
+						<span class="search-setting-path">${breadcrumbs}</i></span>
+					</li>
+				`;
+			})
+			.join('');
+
+		customizerPanels?.classList.add('search-not-found');
+		setResultsHTML(htmlString);
+	};
+
+	return (
+		<>
+			<span className="accordion-section">
+				<span className="search-input">
+					{__('Search', 'neve') +
+						' ' +
+						__('Settings', 'neve').toLowerCase()}
+				</span>
+				<span className="nv-search-wrap">
+					<input
+						type="text"
+						placeholder={__('Search', 'neve')}
+						id="nv-customizer-search-input"
+						className="nv-customizer-search-input"
+						value={search}
+						onChange={onInputChange}
+					/>
+
+					<Button
+						label={__('Clear', 'neve')}
+						isSmall
+						isSecondary
+						onClick={clearField}
+					>
+						{__('Clear', 'neve')}
+						<span className="screen-reader-text">
+							{__('Clear', 'neve')}
+						</span>
+					</Button>
+				</span>
+			</span>
+		</>
+	);
+};
+
+export default SearchComponent;

--- a/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Customizer Control Type
@@ -46,7 +46,9 @@ declare global {
 
 	const wp: {
 		customize: {
-			section: (sectionName: string) => { expand: () => void };
+			section: (sectionName: string) => {
+				expand: (p: { duration: number }) => void;
+			};
 		};
 	};
 }
@@ -58,6 +60,7 @@ type SearchComponentProps = {
 	isOpened: boolean;
 	search: string;
 	setSearch: (value: string) => void;
+	matchResults: Control[];
 	setMatchResults: (value: Control[]) => void;
 };
 
@@ -72,6 +75,7 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
 	isOpened,
 	search,
 	setSearch,
+	matchResults,
 	setMatchResults,
 }) => {
 	const customizerPanels = document.getElementById(
@@ -120,6 +124,22 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
 		}
 	}, [isOpened]);
 
+	useEffect(() => {
+		if (search === '') {
+			if (customizerPanels?.classList.contains('search-not-found')) {
+				customizerPanels?.classList.remove('search-not-found');
+			}
+		} else if (!customizerPanels?.classList.contains('search-not-found')) {
+			customizerPanels?.classList.add('search-not-found');
+		}
+
+		if (matchResults.length === 0) {
+			if (customizerPanels?.classList.contains('search-not-found')) {
+				customizerPanels?.classList.remove('search-not-found');
+			}
+		}
+	}, [search, matchResults]);
+
 	/**
 	 * Clear the search input field.
 	 *
@@ -142,17 +162,8 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
 	const onInputChange = (event: { target: { value: string } }) => {
 		const query = event.target.value;
 		setSearch(query);
-		const newResults = getControlsMatch(query);
+		const newResults = getControlsMatch(search);
 		setMatchResults(newResults);
-		if (query === '') {
-			customizerPanels?.classList.remove('search-not-found');
-		} else {
-			customizerPanels?.classList.add('search-not-found');
-		}
-
-		if (newResults.length === 0) {
-			customizerPanels?.classList.remove('search-not-found');
-		}
 	};
 
 	/**

--- a/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
@@ -51,15 +51,22 @@ declare global {
 }
 
 /**
+ * Type SearchComponentProps
+ */
+type SearchComponentProps = {
+	isOpened: boolean;
+};
+
+/**
  * Search Component
  * Handles search input, filtering and display of results.
  *
+ * @param {SearchComponentProps} SearchComponentProps
  * @class
  */
-const SearchComponent: React.FC = () => {
+const SearchComponent: React.FC<SearchComponentProps> = ({ isOpened }) => {
 	const [search, setSearch] = useState('');
 	const [resultsHTML, setResultsHTML] = useState('');
-	const [isSearchOpen, setIsSearchOpen] = useState(false);
 	const [matchResults, setMatchResults] = useState([] as Control[]);
 
 	const customizerPanels = document.getElementById(
@@ -91,35 +98,25 @@ const SearchComponent: React.FC = () => {
 
 			return control;
 		}
-	) as unknown as Control[];
+	) as Control[];
 
 	/**
 	 * This `useEffect()` is being used to listen for the toggleEvent
 	 * from `SearchToggle` component.
 	 */
 	useEffect(() => {
-		const toggleSearch = () => {
+		if (isOpened) {
 			document
 				.getElementById('neve-customize-search-field')
-				?.classList.toggle('visible');
-
-			if (isSearchOpen) {
-				clearField();
-				setIsSearchOpen(false);
-				return;
-			}
-			setIsSearchOpen(true);
+				?.classList.add('visible');
 			document.getElementById('nv-customizer-search-input')?.focus();
-		};
-
-		document.addEventListener('nv-customizer-search-toggle', toggleSearch);
-
-		return () =>
-			document.removeEventListener(
-				'nv-customizer-search-toggle',
-				toggleSearch
-			);
-	}, [isSearchOpen]);
+		} else {
+			document
+				.getElementById('neve-customize-search-field')
+				?.classList.remove('visible');
+			clearField();
+		}
+	}, [isOpened]);
 
 	/**
 	 * This `useEffect()` only handles displaying results for the search;
@@ -145,10 +142,7 @@ const SearchComponent: React.FC = () => {
 				'#customizer-search-results .accordion-section'
 			);
 			searchSettings.forEach((setting) =>
-				setting.addEventListener(
-					'click',
-					expandSection as unknown as EventListener
-				)
+				setting.addEventListener('click', expandSection)
 			);
 		}
 
@@ -157,10 +151,7 @@ const SearchComponent: React.FC = () => {
 				'#customizer-search-results .accordion-section'
 			);
 			searchSettings.forEach((setting) =>
-				setting.removeEventListener(
-					'click',
-					expandSection as unknown as EventListener
-				)
+				setting.removeEventListener('click', expandSection)
 			);
 		};
 	}, [resultsHTML]);
@@ -198,22 +189,18 @@ const SearchComponent: React.FC = () => {
 	/**
 	 * Handle redirect to specific section on click.
 	 *
-	 * @param {Event} event
-	 * @param {Event.target} event.target
-	 * @param {string} event.target.getAttribute
-	 * @param {Element} event.target.parentNode
-	 * @param {string} event.target.parentNode.getAttribute
+	 * @param {Event} evt
 	 * @return {void}
 	 */
-	const expandSection = (event: {
-		target: {
-			getAttribute: (data: string) => string;
-			parentNode: { getAttribute: (data: string) => string };
-		};
-	}) => {
+	const expandSection = (evt: Event) => {
+		if (evt === null) {
+			return;
+		}
+		const target = evt.target as HTMLElement;
+		const targetParent = target.parentNode as HTMLElement;
 		const sectionName =
-			event.target.getAttribute('data-section') ||
-			event.target.parentNode.getAttribute('data-section');
+			target.getAttribute('data-section') ||
+			(targetParent.getAttribute('data-section') as string);
 		const section = wp.customize.section(sectionName);
 		clearField();
 		section.expand();

--- a/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
@@ -35,11 +35,11 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 		}
 
 		if (panelName) {
-			wp.customize.panel(panelName)?.expand({ duration: 0 });
+			wp.customize.panel(panelName)?.expand();
 		}
 
 		if (sectionName) {
-			wp.customize.section(sectionName)?.expand({ duration: 0 });
+			wp.customize.section(sectionName)?.expand();
 		}
 
 		setQuery('');

--- a/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
@@ -1,0 +1,134 @@
+import React from 'react';
+import { Control } from './SearchComponent';
+import classnames from 'classnames';
+
+/**
+ * Type SearchComponentProps
+ */
+type SearchResultsProps = {
+	matchResults: Control[];
+	setMatchResults: (value: Control[]) => void;
+	query: string;
+	setQuery: (value: string) => void;
+};
+
+/**
+ * SearchResults Component
+ *
+ * @param {SearchResultsProps} params
+ * @class
+ */
+const SearchResults: React.FC<SearchResultsProps> = ({
+	matchResults,
+	setMatchResults,
+	query,
+	setQuery,
+}) => {
+	const customizerPanels = document.getElementById(
+		'customize-theme-controls'
+	);
+
+	/**
+	 * Handle redirect to specific section on click.
+	 *
+	 * @param {string} sectionName
+	 * @return {void}
+	 */
+	const expandSection = (sectionName: string) => {
+		if (!sectionName) {
+			return;
+		}
+
+		const section = wp.customize.section(sectionName);
+		setQuery('');
+		setMatchResults([]);
+		customizerPanels?.classList.remove('search-not-found');
+		section.expand();
+	};
+
+	/**
+	 * Highlight text from search query.
+	 *
+	 * @param {string} text
+	 * @param {string} highlight
+	 */
+	const getHighlightedText = (text: string, highlight: string) => {
+		const matchQuery = highlight.replace(
+			/[-[\]{}()*+?.,\\^$|#\s]/g,
+			'\\$&'
+		);
+		const parts = text.split(new RegExp(`(${matchQuery})`, 'gi'));
+		return (
+			<span>
+				{' '}
+				{parts.map((part, i) => (
+					<span
+						key={i}
+						className={classnames({
+							hl: part.toLowerCase() === highlight.toLowerCase(),
+						})}
+						style={
+							part.toLowerCase() === highlight.toLowerCase()
+								? { fontWeight: 'bold' }
+								: {}
+						}
+					>
+						{part}
+					</span>
+				))}{' '}
+			</span>
+		);
+	};
+
+	return (
+		<>
+			{query !== '' && (
+				<ul id="customizer-search-results">
+					{matchResults.map((control) => {
+						if ('' === control.label) return '';
+
+						let breadcrumbs = control.panelName;
+						if (breadcrumbs === null) {
+							breadcrumbs = '';
+						}
+
+						if ('' !== control.sectionName) {
+							breadcrumbs = `${breadcrumbs} ▸ ${control.sectionName}`;
+						}
+
+						const label = control.label;
+
+						return (
+							// eslint-disable-next-line jsx-a11y/click-events-have-key-events,jsx-a11y/no-noninteractive-element-interactions
+							<li
+								id={`accordion-section-${control.section}`}
+								className="accordion-section control-section control-section-default"
+								aria-owns={`sub-accordion-section-${control.section}`}
+								key={control.instanceNumber}
+								onClick={() => {
+									expandSection(control.section);
+								}}
+							>
+								<h3
+									className="accordion-section-title"
+									tabIndex={0}
+								>
+									{getHighlightedText(label, query)}
+									<span className="screen-reader-text">
+										Press return or enter to open this
+										section
+									</span>
+								</h3>
+								<span className="search-setting-path">
+									{getHighlightedText(breadcrumbs, query)}
+								</span>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</>
+	);
+};
+
+export default SearchResults;

--- a/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchResults.tsx
@@ -7,7 +7,6 @@ import classnames from 'classnames';
  */
 type SearchResultsProps = {
 	matchResults: Control[];
-	setMatchResults: (value: Control[]) => void;
 	query: string;
 	setQuery: (value: string) => void;
 };
@@ -20,14 +19,9 @@ type SearchResultsProps = {
  */
 const SearchResults: React.FC<SearchResultsProps> = ({
 	matchResults,
-	setMatchResults,
 	query,
 	setQuery,
 }) => {
-	const customizerPanels = document.getElementById(
-		'customize-theme-controls'
-	);
-
 	/**
 	 * Handle redirect to specific section on click.
 	 *
@@ -39,11 +33,9 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 			return;
 		}
 
-		const section = wp.customize.section(sectionName);
+		wp.customize.section(sectionName)?.expand({ duration: 0 });
+
 		setQuery('');
-		setMatchResults([]);
-		customizerPanels?.classList.remove('search-not-found');
-		section.expand();
 	};
 
 	/**
@@ -105,7 +97,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({
 								className="accordion-section control-section control-section-default"
 								aria-owns={`sub-accordion-section-${control.section}`}
 								key={control.instanceNumber}
-								onClick={() => {
+								onClick={(event) => {
+									event.preventDefault();
 									expandSection(control.section);
 								}}
 							>

--- a/assets/apps/customizer-controls/src/customizer-search/SearchToggle.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchToggle.tsx
@@ -3,24 +3,19 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
 /**
+ * Type SearchToggleProps
+ */
+type SearchToggleProps = {
+	onToggle: () => void;
+};
+
+/**
  * Search Toggle.
  *
+ * @param {SearchToggleProps} SearchToggleProps
  * @class
  */
-const SearchToggle: React.FC = () => {
-	/**
-	 * Trigger toggle event.
-	 *
-	 * @return {void}
-	 */
-	const searchToggle = () => {
-		document.dispatchEvent(
-			new window.CustomEvent('nv-customizer-search-toggle', {
-				detail: {},
-			})
-		);
-	};
-
+const SearchToggle: React.FC<SearchToggleProps> = ({ onToggle }) => {
 	return (
 		<>
 			<Button
@@ -29,7 +24,7 @@ const SearchToggle: React.FC = () => {
 				isSmall
 				isLink
 				label={__('Search', 'neve') + ' ' + __('Toggle', 'neve')}
-				onClick={searchToggle}
+				onClick={onToggle}
 			>
 				<span className="screen-reader-text">
 					{__('Search', 'neve')}

--- a/assets/apps/customizer-controls/src/customizer-search/SearchToggle.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchToggle.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button } from '@wordpress/components';
+
+/**
+ * Search Toggle.
+ *
+ * @class
+ */
+const SearchToggle: React.FC = () => {
+	/**
+	 * Trigger toggle event.
+	 *
+	 * @return {void}
+	 */
+	const searchToggle = () => {
+		document.dispatchEvent(
+			new window.CustomEvent('nv-customizer-search-toggle', {
+				detail: {},
+			})
+		);
+	};
+
+	return (
+		<>
+			<Button
+				icon="search"
+				iconSize={28}
+				isSmall
+				isLink
+				label={__('Search', 'neve') + ' ' + __('Toggle', 'neve')}
+				onClick={searchToggle}
+			>
+				<span className="screen-reader-text">
+					{__('Search', 'neve')}
+				</span>
+			</Button>
+		</>
+	);
+};
+
+export default SearchToggle;

--- a/assets/apps/customizer-controls/src/scss/_customizer-search.scss
+++ b/assets/apps/customizer-controls/src/scss/_customizer-search.scss
@@ -1,0 +1,113 @@
+#neve-customize-search {
+  position: absolute;
+  top: 40px;
+  right: 0;
+  width: 40px;
+  height: 28px;
+  overflow: hidden;
+  z-index: 1000;
+
+  button {
+    text-decoration: none;
+    &:focus:not(:disabled) {
+      box-shadow: none;
+      outline: none;
+    }
+  }
+}
+
+
+#neve-customize-search-field {
+  display: none;
+  &.visible {
+    display: block;
+  }
+
+  .accordion-section {
+    background-color: #fff;
+    display: block;
+    padding: 14px;
+  }
+
+  .search-input {
+    font-weight: bold;
+  }
+
+  .nv-search-wrap {
+    display: flex;
+    align-items: center;
+  }
+
+  .nv-customizer-search-input {
+    font-size: 12px;
+    min-height: 24px;
+    width: 100%;
+  }
+}
+
+#neve-customize-search-results {
+  .hl {
+	background: rgba(23, 146, 255, 0.14);
+  }
+
+  .accordion-section {
+    border-left: none;
+    border-right: none;
+    padding: 10px 10px 11px 14px;
+    line-height: 21px;
+    background: #fff;
+    position: relative;
+	&:hover {
+	  background: #f3f3f5;
+	}
+
+    h3 {
+      padding: 0;
+      margin: 0;
+	  width: 90%;
+	  &:after {
+		content: none;
+	  }
+	  &:hover, &:focus {
+		background: inherit;
+	  }
+    }
+
+    &:after {
+      font: normal 20px/1 dashicons;
+      display: block;
+      content: "\f345";
+      position: absolute;
+      right: 10px;
+      z-index: 1;
+      top: calc(50% - 10px);
+      -moz-osx-font-smoothing: grayscale;
+      text-decoration: none !important;
+    }
+  }
+
+  .accordion-section-title:after {
+	content: none;
+  }
+
+  .search-setting-path {
+    display: flex;
+    cursor: pointer;
+	width: 90%;
+  }
+}
+
+.search-not-found {
+  height: 0;
+  transition: height 0.3s ease-in-out;
+  visibility: hidden;
+  opacity: 0;
+  display: none;
+}
+
+.search-found {
+  height: 100%;
+  transition: height 0.3s ease-in-out;
+  visibility: visible;
+  opacity: 1;
+}

--- a/assets/apps/customizer-controls/src/scss/_customizer-search.scss
+++ b/assets/apps/customizer-controls/src/scss/_customizer-search.scss
@@ -31,11 +31,13 @@
 
   .search-input {
     font-weight: bold;
+    padding-left: 2px;
   }
 
   .nv-search-wrap {
     display: flex;
     align-items: center;
+    margin-top: 6px;
   }
 
   .nv-customizer-search-input {
@@ -47,7 +49,7 @@
 
 #neve-customize-search-results {
   .hl {
-	background: rgba(23, 146, 255, 0.14);
+    background: rgba(23, 146, 255, 0.14);
   }
 
   .accordion-section {
@@ -57,20 +59,20 @@
     line-height: 21px;
     background: #fff;
     position: relative;
-	&:hover {
-	  background: #f3f3f5;
-	}
+    &:hover {
+      background: #f6f7f7;
+    }
 
     h3 {
       padding: 0;
       margin: 0;
-	  width: 90%;
-	  &:after {
-		content: none;
-	  }
-	  &:hover, &:focus {
-		background: inherit;
-	  }
+      width: 90%;
+      &:after {
+        content: none;
+      }
+      &:hover, &:focus {
+        background: inherit;
+      }
     }
 
     &:after {
@@ -87,13 +89,13 @@
   }
 
   .accordion-section-title:after {
-	content: none;
+    content: none;
   }
 
   .search-setting-path {
     display: flex;
     cursor: pointer;
-	width: 90%;
+    width: 90%;
   }
 }
 

--- a/assets/apps/customizer-controls/src/style.scss
+++ b/assets/apps/customizer-controls/src/style.scss
@@ -16,6 +16,7 @@
 @import "scss/repeater";
 @import "scss/documentation";
 @import "scss/upsell";
+@import "scss/customizer-search";
 
 @import "logo-palette/scss/logo-palette";
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a new component for the Customizer that allows the user to search through all Customizer sections and panels.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Demo:
https://vertis.d.pr/zXX7gg

Preview:
![image](https://user-images.githubusercontent.com/23024731/188234200-a7d25de8-0575-4f03-8cb9-c68513723c5d.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Go into Customizer
2. Toggle the search feature on the main page:
![image](https://user-images.githubusercontent.com/23024731/188233803-403b42b3-bdcd-4f17-96d5-2300e3c9c01a.png)
3. Check the search results and the navigation

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1438.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
