### PR TITLE
Show comments but hide reply form if "allow comments" settings is unchecked

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -8,10 +8,6 @@ if ( post_password_required() ) {
 	return;
 }
 
-if ( ! comments_open() ) {
-	return;
-}
-
 ?>
 
 <div id="comments" class="<?php echo esc_attr( apply_filters( 'neve_comments_area_class', 'comments-area' ) ); ?>">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Before this PR; if "allow comments" is unchecked in Post Settings->Discussion part (https://vertis.d.pr/y58XyU); comments and reply form were hidden.

With this PR; I've changed the behavior on there. From now on, if comments disabled; only reply form is hidden but comments are visible.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
**If "allow comments" is deactivated:**
before: https://vertis.d.pr/ctJa1U
after: https://vertis.d.pr/nWf5d7

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Visit a single post and submit some comments
- Go post edit screen, play with the "Allow comments" checkbox. If it's disabled, the post should be closed for the new comments but old comments still should be visible. If its state is checked; old comments & the reply form should be visible together.

<!-- Issues that this pull request closes. -->
Closes #3459 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
