### PR TITLE
chore: added active class to wrapper to allow cl popup design

### DIFF
--- a/assets/apps/components/src/Controls/RadioImage.js
+++ b/assets/apps/components/src/Controls/RadioImage.js
@@ -51,7 +51,7 @@ const RadioImage = ({ choices, onClick, value, label, documentation }) => {
 					return (
 						<div className={divClass} key={index}>
 							{/*eslint-disable-next-line jsx-a11y/label-has-for */}
-							<label data-option={choice}>
+							<label data-option={choice} className={buttonClass}>
 								{upsellUrl && (
 									<span className="dashicons dashicons-lock" />
 								)}

--- a/header-footer-grid/Core/Components/Search.php
+++ b/header-footer-grid/Core/Components/Search.php
@@ -538,9 +538,22 @@ class Search extends Abstract_Component {
 	 * @access  public
 	 */
 	public function render_component() {
+		add_filter( 'get_search_form', [ $this, 'add_submit_button_classes' ] );
 		add_filter( 'nv_search_placeholder', [ $this, 'change_placeholder' ] );
 		Main::get_instance()->load( 'components/component-search' );
+		remove_filter( 'get_search_form', [ $this, 'add_submit_button_classes' ] );
 		remove_filter( 'nv_search_placeholder', [ $this, 'change_placeholder' ] );
+	}
+
+	/**
+	 * Add nv-submit class on submit button for search component.
+	 *
+	 * @param string $form Form HTML.
+	 *
+	 * @return string
+	 */
+	public function add_submit_button_classes( $form ) {
+		return str_replace( 'search-submit', 'search-submit nv-submit', $form );
 	}
 
 	/**

--- a/inc/core/settings/config.php
+++ b/inc/core/settings/config.php
@@ -224,8 +224,8 @@ class Config {
 		self::CSS_SELECTOR_FORM_INPUTS_WITH_SPACING    => 'form:not([role="search"]):not(.woocommerce-cart-form):not(.woocommerce-ordering):not(.cart) input:read-write:not(#coupon_code), form textarea, form select, .widget select',
 		self::CSS_SELECTOR_FORM_INPUTS                 => 'form input:read-write, form textarea, form select, form select option, form.wp-block-search input.wp-block-search__input, .widget select',
 		self::CSS_SELECTOR_FORM_INPUTS_LABELS          => 'form label, .wpforms-container .wpforms-field-label',
-		self::CSS_SELECTOR_FORM_BUTTON                 => 'form input[type="submit"], form button[type="submit"], form *[value*="ubmit"], #comments input[type="submit"]',
-		self::CSS_SELECTOR_FORM_BUTTON_HOVER           => 'form input[type="submit"]:hover, form button[type="submit"]:hover, form *[value*="ubmit"]:hover, #comments input[type="submit"]:hover',
+		self::CSS_SELECTOR_FORM_BUTTON                 => 'form input[type="submit"], form button[type="submit"]:not(.nv-submit), form *[value*="ubmit"], #comments input[type="submit"]',
+		self::CSS_SELECTOR_FORM_BUTTON_HOVER           => 'form input[type="submit"]:hover, form button[type="submit"]:not(.nv-submit):hover, form *[value*="ubmit"]:hover, #comments input[type="submit"]:hover',
 		self::CSS_SELECTOR_FORM_SEARCH_INPUTS          => 'form.search-form input:read-write',
 	];
 }


### PR DESCRIPTION
### Summary
Added the active class also to the wrapper to allow the design for custom layout pop-up select.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/189100277-36090b41-73cf-488f-a4dd-350cb04c2bf0.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check that the RadioImage options in Neve don't change design wise
2. No regression was introduced

<!-- Issues that this pull request closes. -->
References Codeinwp/neve-pro-addon#2045.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
