### PR TITLE
Expand first level of submenu fix

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -153,20 +153,5 @@
 				padding-left: 10px;
 			}
 		}
-
-		&.dropdowns-expanded {
-
-			> li > .sub-menu {
-				display: block;
-				padding-left: 10px;
-			}
-
-			> li > a {
-
-				.caret-wrap {
-					display: none;
-				}
-			}
-		}
 	}
 }

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -57,6 +57,27 @@ class Nav extends Abstract_Component {
 				'filter_neve_last_menu_setting_slug',
 			)
 		);
+		add_filter( 'nav_menu_submenu_css_class', [ $this, 'filter_menu_item_class' ], 10, 3 );
+	}
+
+	/**
+	 * Add open class on submenu if 'Expand the first level of dropdowns...' option is on.
+	 *
+	 * @param array $classes Submenu classes.
+	 * @param array $args Submenu args.
+	 * @param int   $depth Submenu depth.
+	 *
+	 * @return array
+	 */
+	public function filter_menu_item_class( $classes, $args, $depth ) {
+		$expand_dropdowns = get_theme_mod( $this->get_id() . '_' . self::EXPAND_DROPDOWNS, false );
+		if ( ! $expand_dropdowns ) {
+			return $classes;
+		}
+		if ( $depth === 0 ) {
+			$classes[] = 'dropdown-open';
+		}
+		return $classes;
 	}
 
 	/**
@@ -526,31 +547,31 @@ class Nav extends Abstract_Component {
 			],
 		];
 
-		if ( get_theme_mod( $this->get_id() . '_' . self::EXPAND_DROPDOWNS, false ) ) {
-			$selector    = '.header-menu-sidebar-inner  .builder-item--' . $this->get_id() . ' .primary-menu-ul.dropdowns-expanded > li ';
-			$css_array[] = [
-				Dynamic_Selector::KEY_SELECTOR => $selector . ' > .sub-menu',
-				Dynamic_Selector::KEY_RULES    => [
-					'max-height' => [
-						Dynamic_Selector::META_KEY    => $this->get_id() . '_' . self::EXPAND_DROPDOWNS,
-						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
-							return sprintf( 'max-height: unset;' );
-						},
-					],
-				],
-			];
-			$css_array[] = [
-				Dynamic_Selector::KEY_SELECTOR => $selector . ' > a > .caret-wrap,' . $selector . ' > .has-caret .caret',
-				Dynamic_Selector::KEY_RULES    => [
-					'display' => [
-						Dynamic_Selector::META_KEY    => $this->get_id() . '_' . self::EXPAND_DROPDOWNS,
-						Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
-							return sprintf( 'display: none;' );
-						},
-					],
-				],
-			];
-		}
+		// if ( get_theme_mod( $this->get_id() . '_' . self::EXPAND_DROPDOWNS, false ) ) {
+		// $selector    = '.header-menu-sidebar-inner  .builder-item--' . $this->get_id() . ' .primary-menu-ul.dropdowns-expanded > li ';
+		// $css_array[] = [
+		// Dynamic_Selector::KEY_SELECTOR => $selector . ' > .sub-menu',
+		// Dynamic_Selector::KEY_RULES    => [
+		// 'max-height' => [
+		// Dynamic_Selector::META_KEY    => $this->get_id() . '_' . self::EXPAND_DROPDOWNS,
+		// Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
+		// return sprintf( 'max-height: unset;' );
+		// },
+		// ],
+		// ],
+		// ];
+		// $css_array[] = [
+		// Dynamic_Selector::KEY_SELECTOR => $selector . ' > a > .caret-wrap,' . $selector . ' > .has-caret .caret',
+		// Dynamic_Selector::KEY_RULES    => [
+		// 'display' => [
+		// Dynamic_Selector::META_KEY    => $this->get_id() . '_' . self::EXPAND_DROPDOWNS,
+		// Dynamic_Selector::META_FILTER => function ( $css_prop, $value, $meta, $device ) {
+		// return sprintf( 'display: none;' );
+		// },
+		// ],
+		// ],
+		// ];
+		// }
 
 		return parent::add_style( $css_array );
 	}

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -12,10 +12,8 @@ namespace HFG;
 use HFG\Core\Components\Nav;
 use HFG\Core\Builder\Header as HeaderBuilder;
 
-$style                 = component_setting( Nav::STYLE_ID );
-$dropdowns_expanded    = component_setting( Nav::EXPAND_DROPDOWNS );
-$additional_menu_class = $dropdowns_expanded && current_row( HeaderBuilder::BUILDER_NAME ) === 'sidebar' ? ' ' . Nav::DROPDOWNS_EXPANDED_CLASS : '';
-$container_classes     = [ $style ];
+$style             = component_setting( Nav::STYLE_ID );
+$container_classes = [ $style ];
 
 $container_classes[] = 'nav-menu-primary';
 
@@ -30,7 +28,7 @@ $menu_id = Nav::NAV_MENU_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 			[
 				'theme_location' => 'primary',
 				'menu_id'        => $menu_id,
-				'menu_class'     => 'primary-menu-ul nav-ul' . $additional_menu_class,
+				'menu_class'     => 'primary-menu-ul nav-ul',
 				'container'      => 'ul',
 				'walker'         => '\Neve\Views\Nav_Walker',
 				'fallback_cb'    => '\Neve\Views\Nav_Walker::fallback',


### PR DESCRIPTION
### Summary
- Changed the behavior of this feature. Until now, the first level was expanded but you couldn't toggle it after, altho the submenu icons were clickable.
- Right now, if this option is enabled, the first level of submenus will be expanded by default but you will be able to retract them after.
- I chose this solution because it removes some additional CSS and justifies the presence of the submenu toggles.

### Will affect the visual aspect of the product
NO


### Test instructions
- On mobile, enable the "Expand the first level of dropdowns when the menu is in mobile menu content." option
- Check on desktop and make sure the submenus are not expanded
- Check on mobile, the first level of submenus should be expanded and you should be able to retract them

<!-- Issues that this pull request closes. -->
Closes #3583.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
