### PR TITLE
fix: check if the defaultVal has the suffix prop or not

### DIFF
--- a/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
+++ b/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
@@ -40,13 +40,20 @@ const ResponsiveRangeComponent = ({ control }) => {
 		control.params.input_attrs;
 
 	const suffixValue = () => {
+		const fallbackSuffix = null;
+
 		if (!units) {
-			return null;
+			return fallbackSuffix;
 		}
+
+		const defaultSuffix =
+			defaultVal.suffix && defaultVal.suffix[currentDevice]
+				? defaultVal.suffix[currentDevice]
+				: fallbackSuffix;
 
 		return value.suffix && value.suffix[currentDevice]
 			? value.suffix[currentDevice]
-			: defaultVal.suffix[currentDevice];
+			: defaultSuffix;
 	};
 
 	const isRelativeUnit = () => ['em', 'rem'].includes(suffixValue());


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The browser console errors related relative CSS unit support (only happens with previous Neve Pro versions) that we've added in v3.4 has been fixed with the following way:
* I've added fallback CSS unit suffix for default control values in Responsive Range Slider component.



### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- All relative units (whatever Neve Pro is activated or not) still should work well
- No regression on entire of the customizer controls (saved values are preserved, default values still works well.)
- No browser error when customizer is opened (whatever Neve Pro is activated or not)

<!-- Issues that this pull request closes. -->
Closes #3614 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
