### PR TITLE
fix: expanded submenus on old skin

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1610,7 +1610,7 @@ abstract class Abstract_Builder implements Builder {
 				foreach ( $component_group['components'] as $component ) {
 					self::$current_component = $component;
 					$instance                = $this->builder_components[ $component ];
-					$instance->render();
+					$instance->render( $device );
 				}
 				echo '</div>';
 			}

--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -371,7 +371,16 @@ class Header extends Abstract_Builder {
 				function ( $classes ) {
 					$classes .= ' nv-mobile-menu';
 					return $classes;
-				} 
+				}
+			);
+			add_filter(
+				'nav_menu_submenu_css_class',
+				function( $classes ) {
+					$classes[] = 'mobile-subitem';
+					return $classes;
+				},
+				5,
+				3 
 			);
 		}
 

--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -366,22 +366,6 @@ class Header extends Abstract_Builder {
 
 		if ( $row_id === 'sidebar' && $device_id === 'mobile' ) {
 			$name = 'mobile';
-			add_filter(
-				'neve_additional_menu_class',
-				function ( $classes ) {
-					$classes .= ' nv-mobile-menu';
-					return $classes;
-				}
-			);
-			add_filter(
-				'nav_menu_submenu_css_class',
-				function( $classes ) {
-					$classes[] = 'mobile-subitem';
-					return $classes;
-				},
-				5,
-				3 
-			);
 		}
 
 		Main::get_instance()->load( 'row-wrapper', $name );

--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -307,6 +307,13 @@ abstract class Abstract_Component implements Component {
 	public $has_horizontal_alignment = false;
 
 	/**
+	 * Component arguments.
+	 *
+	 * @var array
+	 */
+	protected $args = [];
+
+	/**
 	 * Abstract_Component constructor.
 	 *
 	 * @param string $panel Builder panel.
@@ -327,6 +334,15 @@ abstract class Abstract_Component implements Component {
 			$this->set_property( 'section', $this->get_id() );
 		}
 		add_action( 'init', [ $this, 'define_settings' ] );
+	}
+
+	/**
+	 * Set component arguments.
+	 *
+	 * @param array $args Component arguments.
+	 */
+	public function set_args( $args ) {
+		$this->args = $args;
 	}
 
 	/**
@@ -600,11 +616,17 @@ abstract class Abstract_Component implements Component {
 
 	/**
 	 * Render component markup.
+	 *
+	 * @param string $device Current device.
 	 */
-	public function render() {
+	public function render( $device = '' ) {
+		$args = [];
+		if ( ! empty( $device ) && in_array( $device, [ 'desktop', 'tablet', 'mobile' ] ) ) {
+			$args['device'] = $device;
+		}
 		self::$current_component           = $this->get_id();
 		Abstract_Builder::$current_builder = $this->get_builder_id();
-		Main::get_instance()->load( 'component-wrapper' );
+		Main::get_instance()->load( 'component-wrapper', '', $args );
 	}
 
 	/**
@@ -1002,7 +1024,6 @@ abstract class Abstract_Component implements Component {
 			'desktop' => $old,
 		];
 	}
-
 
 	/**
 	 * Add horizontal alignment to component.

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -101,9 +101,9 @@ class Nav extends Abstract_Component {
 	/**
 	 * Add open class on submenu if 'Expand the first level of dropdowns...' option is on.
 	 *
-	 * @param array $classes Submenu classes.
-	 * @param array $args Submenu args.
-	 * @param int   $depth Submenu depth.
+	 * @param array     $classes Submenu classes.
+	 * @param \stdClass $args Submenu args.
+	 * @param int       $depth Submenu depth.
 	 *
 	 * @return array
 	 */
@@ -115,7 +115,7 @@ class Nav extends Abstract_Component {
 		if ( (bool) $expand_dropdowns === false ) {
 			return $classes;
 		}
-		if ( property_exists( $args, 'menu_class' ) && str_contains( $args->menu_class, 'menu-mobile' ) && $depth === 0 ) {
+		if ( property_exists( $args, 'menu_class' ) && strpos( $args->menu_class, 'menu-mobile' ) && $depth === 0 ) {
 			$classes[] = 'dropdown-open';
 		}
 		return $classes;

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -59,7 +59,27 @@ class Nav extends Abstract_Component {
 			)
 		);
 
-		add_filter( 'nav_menu_submenu_css_class', [ $this, 'filter_menu_item_class' ], 10, 3 );
+		add_action(
+			'neve_before_render_nav',
+			function ( $component_id ) {
+				if ( $this->get_id() !== $component_id ) {
+					return;
+				}
+				add_filter( 'nav_menu_submenu_css_class', [ $this, 'filter_menu_item_class' ], 10, 3 );
+			} 
+		);
+
+		add_action(
+			'neve_after_render_nav',
+			function ( $component_id ) {
+				if ( $this->get_id() !== $component_id ) {
+					return;
+				}
+				remove_filter( 'nav_menu_submenu_css_class', [ $this, 'filter_menu_item_class' ] );
+			}
+		);
+
+
 		add_action( 'init', [ $this, 'run_nav_init' ] );
 	}
 
@@ -73,6 +93,9 @@ class Nav extends Abstract_Component {
 	 * @return array
 	 */
 	public function filter_menu_item_class( $classes, $args, $depth ) {
+		if ( ! $this->is_component_active() ) {
+			return $classes;
+		}
 		$expand_dropdowns = get_theme_mod( $this->get_id() . '_' . self::EXPAND_DROPDOWNS, false );
 		if ( ! $expand_dropdowns ) {
 			return $classes;

--- a/header-footer-grid/Core/Components/Nav.php
+++ b/header-footer-grid/Core/Components/Nav.php
@@ -77,6 +77,9 @@ class Nav extends Abstract_Component {
 		if ( ! $expand_dropdowns ) {
 			return $classes;
 		}
+		if ( ! in_array( 'mobile-subitem', $classes ) ) {
+			return $classes;
+		}
 		if ( $depth === 0 ) {
 			$classes[] = 'dropdown-open';
 		}

--- a/header-footer-grid/Main.php
+++ b/header-footer-grid/Main.php
@@ -164,7 +164,7 @@ class Main {
 	 *
 	 * @param string $slug Template slug.
 	 * @param string $name Template variation.
-	 * @param string $args Component arguments.
+	 * @param array  $args Component arguments.
 	 */
 	public function load( $slug, $name = '', $args = [] ) {
 

--- a/header-footer-grid/Main.php
+++ b/header-footer-grid/Main.php
@@ -164,8 +164,9 @@ class Main {
 	 *
 	 * @param string $slug Template slug.
 	 * @param string $name Template variation.
+	 * @param string $args Component arguments.
 	 */
-	public function load( $slug, $name = '' ) {
+	public function load( $slug, $name = '', $args = [] ) {
 
 		$templates = array();
 		$name      = (string) $name;
@@ -177,7 +178,7 @@ class Main {
 		$located = '';
 
 		if ( count( self::$templates_location ) === 1 && count( $templates ) === 1 ) {
-			load_template( self::$templates_location[0] . $templates[0], false );
+			load_template( self::$templates_location[0] . $templates[0], false, $args );
 
 			return;
 		}
@@ -195,7 +196,7 @@ class Main {
 		}
 
 		if ( '' !== $located ) {
-			load_template( $located, false );
+			load_template( $located, false, $args );
 		}
 	}
 

--- a/header-footer-grid/templates/component-wrapper.php
+++ b/header-footer-grid/templates/component-wrapper.php
@@ -10,7 +10,11 @@
 
 namespace HFG;
 
-$_id = current_component()->get_id();
+$_id  = current_component()->get_id();
+$args = [];
+if ( isset( $args ) && ! empty( $args ) ) {
+	current_component()->set_args( $args );
+}
 
 $item_classes   = array();
 $item_classes[] = 'item--inner';

--- a/header-footer-grid/templates/component-wrapper.php
+++ b/header-footer-grid/templates/component-wrapper.php
@@ -10,8 +10,7 @@
 
 namespace HFG;
 
-$_id  = current_component()->get_id();
-$args = [];
+$_id = current_component()->get_id();
 if ( isset( $args ) && ! empty( $args ) ) {
 	current_component()->set_args( $args );
 }

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -12,9 +12,10 @@ namespace HFG;
 use HFG\Core\Components\Nav;
 use HFG\Core\Builder\Header as HeaderBuilder;
 
+$device_class          = isset( $args ) && ! empty( $args ) ? $args['device'] : '';
 $_id                   = current_component( HeaderBuilder::BUILDER_NAME )->get_id();
 $style                 = component_setting( Nav::STYLE_ID, 'style-plain' );
-$additional_menu_class = apply_filters( 'neve_additional_menu_class', ' ' );
+$additional_menu_class = apply_filters( 'neve_additional_menu_class', ' menu-' . $device_class );
 
 $container_classes = [ 'nav-menu-primary' ];
 if ( $style !== 'style-plain' ) {

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -111,6 +111,8 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			$caret_wrap_css = $caret_settings['side'] === 'right' ? 'margin-left:5px;' : 'margin-right:5px;';
 
 			if ( $is_sidebar_item && neve_is_new_skin() ) {
+				$expand_dropdowns = apply_filters( 'neve_first_level_expanded', false );
+				$additional_class = $expand_dropdowns && $depth === 0 ? 'dropdown-open' : '';
 				add_action( 'neve_after_header_wrapper_hook', [ $this, 'inline_style_for_sidebar' ], 9 );
 
 				if ( $item->url === '#' && ! self::$dropdowns_inline_js_enqueued ) {
@@ -120,7 +122,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 				$args->before = '<div class="wrap">';
 				$args->after  = '</div>';
 
-				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . $item->menu_order . '" style="' . esc_attr( $caret_wrap_css ) . '">';
+				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . esc_attr( $item->menu_order ) . ' ' . esc_attr( $additional_class ) . '" style="' . esc_attr( $caret_wrap_css ) . '">';
 				$caret .= $caret_pictogram;
 				$caret .= '</button>';
 

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -110,7 +110,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 
 			$caret_wrap_css = $caret_settings['side'] === 'right' ? 'margin-left:5px;' : 'margin-right:5px;';
 
-			if ( $is_sidebar_item ) {
+			if ( $is_sidebar_item && neve_is_new_skin() ) {
 				add_action( 'neve_after_header_wrapper_hook', [ $this, 'inline_style_for_sidebar' ], 9 );
 
 				if ( $item->url === '#' && ! self::$dropdowns_inline_js_enqueued ) {


### PR DESCRIPTION
### Summary
Fixing the "Expand first level of dropdowns when menu is in mobile menu content." setting brakes the menus on legacy skin. This PR should fix the problem.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
- On a fresh instance, install Neve 2.9, apply the starter content and add a new item to the header.
- Update to the latest version, migrate the HFG
- Switch to the legacy skin
- Enable the "Expand first level of dropdowns when menu is in mobile menu content." 
- Check and see if submenus are expanded.
- Check and see if the option still works on mobile
- Check if "Expand first level of dropdowns when menu is in mobile menu content." option applies only to current instance

<!-- Issues that this pull request closes. -->
Closes #3619.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
