### PR TITLE
fix: toggle of page header on rows

### DIFF
--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -78,10 +78,6 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 			.state('expandedPanel')
 			.bind((panel: Record<string, unknown>) => {
 				if (panel.id && panel.id === `hfg_${builder}` && isHidden) {
-					if (panel.id === `hfg_page_header`) {
-						setHidden(true);
-						return true;
-					}
 					setHidden(false);
 					return false;
 				}
@@ -162,7 +158,6 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 						].includes(activeSection.id)
 					) {
 						setMounted(true);
-						setHidden(false);
 					}
 				});
 		});

--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -142,31 +142,17 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 			window.wp.customize
 				.state('expandedSection')
 				.bind((activeSection: Record<string, string>) => {
-					if (!activeSection) {
-						const currentPanel = window.wp.customize
-							.state('expandedPanel')
-							.get();
-						if (
-							currentPanel.id &&
-							currentPanel.id === 'hfg_page_header'
-						) {
-							setMounted(false);
-							setHidden(true);
-						}
-						return;
-					}
-
-					if (!activeSection.id) {
-						return;
-					}
-
+					const currentPanel = window.wp.customize
+						.state('expandedPanel')
+						.get();
 					if (
-						[
-							'neve_pro_global_page_header_settings',
-							'hfg_page_header_layout_top',
-							'hfg_page_header_layout_bottom',
-						].includes(activeSection.id)
+						currentPanel.id &&
+						currentPanel.id === 'hfg_page_header'
 					) {
+						if (!activeSection) {
+							setMounted(false);
+							return;
+						}
 						setMounted(true);
 					}
 				});

--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -143,6 +143,16 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 				.state('expandedSection')
 				.bind((activeSection: Record<string, string>) => {
 					if (!activeSection) {
+						const currentPanel = window.wp.customize
+							.state('expandedPanel')
+							.get();
+						if (
+							currentPanel.id &&
+							currentPanel.id === 'hfg_page_header'
+						) {
+							setMounted(false);
+							setHidden(true);
+						}
 						return;
 					}
 

--- a/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
+++ b/assets/apps/customizer-controls/src/builder/HFGBuilderComponent.tsx
@@ -78,6 +78,10 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 			.state('expandedPanel')
 			.bind((panel: Record<string, unknown>) => {
 				if (panel.id && panel.id === `hfg_${builder}` && isHidden) {
+					if (panel.id === `hfg_page_header`) {
+						setHidden(true);
+						return true;
+					}
 					setHidden(false);
 					return false;
 				}
@@ -151,10 +155,14 @@ const HFGBuilderComponent: React.FC<Props> = ({ control, portalMount }) => {
 					}
 
 					if (
-						activeSection.id ===
-						'neve_pro_global_page_header_settings'
+						[
+							'neve_pro_global_page_header_settings',
+							'hfg_page_header_layout_top',
+							'hfg_page_header_layout_bottom',
+						].includes(activeSection.id)
 					) {
 						setMounted(true);
+						setHidden(false);
 					}
 				});
 		});


### PR DESCRIPTION
### Summary
Improved the toggle for the page header.
Previously it would only mount on Global Page Header Settings.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/192231032-b60ed4ff-3a74-4786-a311-c67918906fb6.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Go to Customizer > Page Header > Page Header Top or Page Header Bottom
2. Check that the builder opens
3. Check the builder opens as before for the Header section

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2173.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
