### PR TITLE
fix: hook into expand panel or section to clear search

### DIFF
--- a/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
+++ b/assets/apps/customizer-controls/src/customizer-search/SearchComponent.tsx
@@ -110,6 +110,25 @@ const SearchComponent: React.FC<SearchComponentProps> = ({
 	) as Control[];
 
 	/**
+	 * This `useEffect()` is being used to bind into panel and section expand
+	 * to allow for search clear on transitions from other clickable elements.
+	 */
+	useEffect(() => {
+		window.wp.customize.state('expandedPanel').bind(() => {
+			clearField();
+			if (customizerPanels?.classList.contains('search-not-found')) {
+				customizerPanels?.classList.remove('search-not-found');
+			}
+		});
+		window.wp.customize.state('expandedSection').bind(() => {
+			clearField();
+			if (customizerPanels?.classList.contains('search-not-found')) {
+				customizerPanels?.classList.remove('search-not-found');
+			}
+		});
+	}, []);
+
+	/**
 	 * This `useEffect()` is being used to listen for the toggleEvent
 	 * from `SearchToggle` component.
 	 */


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added clear field and results on customizer search if a section transition or panel transition is triggered.
Previously if a transition was triggered, eg. the edit button, the results would remain listed hiding the section or panel.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Search for something using the Customizer Search
2. Instead of clicking on the result, click on the edit button from the Customizer Preview
3. Check that the results are hidden and the section is displayed correctly.

<!-- Issues that this pull request closes. -->
Closes #3627.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
