### PR TITLE
Caret for select dropdown not appearing

### DIFF
--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -109,7 +109,7 @@
 	border-color: var(--formfieldbordercolor);
 	border-width: var(--formfieldborderwidth);
 	border-radius: var(--formfieldborderradius, 3px);
-	background: var(--formfieldbgcolor);
+	background-color: var(--formfieldbgcolor);
 	color: var(--formfieldcolor);
 	padding: var(--formfieldpadding);
 

--- a/assets/scss/lifter.scss
+++ b/assets/scss/lifter.scss
@@ -117,7 +117,7 @@
 }
 
 .llms-form-field .select2-container .select2-selection--single{
-  background: var(--formfieldbgcolor);
+  background-color: var(--formfieldbgcolor);
   border-style: solid;
   border-color: var(--formfieldbordercolor);
   border-width: var(--formfieldborderwidth);


### PR DESCRIPTION
### Summary
- The dropdown icon for select inputs was missing because we applied the background color through `background` property. Changing it to `background-color` fixes the issue

### Will affect visual aspect of the product
NO


### Test instructions
- Create a form with a select input, not necessarily Gravity forms
- Set a color in customizer in Form Fields section
- Check the form on frontend

<!-- Issues that this pull request closes. -->
Closes #3635.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
