### PR TITLE
fix: breadcrumbs and results in woo display on mobile #3621

### DIFF
--- a/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
+++ b/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
@@ -3,6 +3,7 @@
 .woocommerce .woocommerce-breadcrumb {
 	color: var(--nv-text-color);
 	font-size: 14px;
+	white-space: nowrap;
 
 	a {
 		color: var(--nv-secondary-accent);
@@ -26,4 +27,8 @@
 	display: flex;
 	font-size: 14px;
 	justify-content: space-between;
+
+	@media (min-width: #{$tablet-sm}) {
+		flex-direction: column;
+	}
 }

--- a/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
+++ b/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
@@ -27,11 +27,12 @@
 	display: flex;
 	font-size: 14px;
 	justify-content: space-between;
+	flex-direction: column;
 }
 
 @mixin bc-count-wrap() {
 
 	.nv-bc-count-wrap {
-		flex-direction: column;
+		flex-direction: row;
 	}
 }

--- a/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
+++ b/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
@@ -27,8 +27,11 @@
 	display: flex;
 	font-size: 14px;
 	justify-content: space-between;
+}
 
-	@media (min-width: #{$tablet-sm}) {
+@mixin bc-count-wrap() {
+
+	.nv-bc-count-wrap {
 		flex-direction: column;
 	}
 }

--- a/assets/scss/components/compat/woocommerce/_media-queries.scss
+++ b/assets/scss/components/compat/woocommerce/_media-queries.scss
@@ -2,7 +2,6 @@
 
 	@include notices--tablet-sm();
 	@include shop-loop--tablet-sm();
-	@include bc-count-wrap();
 }
 
 @media (min-width: #{$tablet}) {
@@ -10,6 +9,7 @@
 	@include cart--tablet();
 	@include account--tablet();
 	@include product--tablet();
+	@include bc-count-wrap();
 }
 
 @media (min-width: #{$laptop}) {

--- a/assets/scss/components/compat/woocommerce/_media-queries.scss
+++ b/assets/scss/components/compat/woocommerce/_media-queries.scss
@@ -2,6 +2,7 @@
 
 	@include notices--tablet-sm();
 	@include shop-loop--tablet-sm();
+	@include bc-count-wrap();
 }
 
 @media (min-width: #{$tablet}) {

--- a/assets/scss/woocommerce.scss
+++ b/assets/scss/woocommerce.scss
@@ -11,6 +11,6 @@
 @import "components/compat/woocommerce/widgets";
 @import "components/compat/woocommerce/nav-cart";
 @import "components/compat/woocommerce/account";
-@import "components/compat/woocommerce/media-queries";
 @import "components/compat/woocommerce/breadcrumbs";
 @import "components/compat/woocommerce/blocks";
+@import "components/compat/woocommerce/media-queries";


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Adjusted the breadcrumbs and the text for the results display on mobile for WooCommerce.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/192747602-f3f2835d-264c-484a-83d4-f8d92b2e60d1.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Check that on WooCommerce templates on mobile the Breadcrumbs and Product Results text are being displayed correctly without getting squashed together.

<!-- Issues that this pull request closes. -->
Closes #3621.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
