### PR TITLE
Fix elementor checkout

### DIFF
--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -33,7 +33,7 @@
 		float: none;
 	}
 
-	form.checkout {
+	.nv-checkout-wrap form.checkout {
 		display: grid;
 		grid-template-columns: 1fr;
 	}
@@ -152,7 +152,7 @@
 			margin-bottom: $spacing-xxl;
 		}
 
-		form.checkout {
+		.nv-checkout-wrap form.checkout {
 			grid-template-columns: 3fr 2fr;
 			grid-column-gap: $spacing-aired;
 		}

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -386,4 +386,47 @@ class Elementor extends Page_Builder_Base {
 		set_transient( $transient_key, 1, $transient_expiry_sec );
 		return true;
 	}
+
+	/**
+	 * Detect if current page has elementor checkout widget.
+	 *
+	 * @return bool
+	 */
+	public static function is_elementor_checkout() {
+		if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
+			return false;
+		}
+
+		$page_id      = get_the_id();
+		$is_elementor = get_post_meta( $page_id, '_elementor_edit_mode', true ) === 'builder';
+		if ( ! $is_elementor ) {
+			return false;
+		}
+
+		$elementor_data = get_post_meta( $page_id, '_elementor_data', true );
+		if ( ! empty( $elementor_data ) && is_string( $elementor_data ) ) {
+			$elementor_data = json_decode( $elementor_data, true );
+		}
+
+		if ( empty( $elementor_data ) ) {
+			return false;
+		}
+
+		$has_checkout_widget = false;
+		array_walk_recursive(
+			$elementor_data,
+			function ( $value, $key ) use ( &$has_checkout_widget ) {
+				static $done = false;
+				if ( $done ) {
+					return;
+				}
+				if ( $key === 'widgetType' && $value === 'woocommerce-checkout-page' ) {
+					$has_checkout_widget = true;
+					$done                = true;
+				}
+			}
+		);
+
+		return $has_checkout_widget;
+	}
 }

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -254,7 +254,9 @@ class Woocommerce {
 		add_action( 'neve_bc_count', 'woocommerce_result_count' );
 
 		$this->edit_woocommerce_header();
-		$this->move_checkout_coupon();
+		if ( ! Elementor::is_elementor_checkout() ) {
+			$this->move_checkout_coupon();
+		}
 		$this->add_inline_selectors();
 		add_action( 'wp', [ $this, 'setup_form_buttons' ] );
 
@@ -263,14 +265,13 @@ class Woocommerce {
 			/**
 			 * Checkout page tweaks.
 			 */
-			$is_elementor = get_post_meta( get_the_id(), '_elementor_edit_mode', true ) === 'builder';
-			if ( ! $is_elementor ) {
+			if ( ! Elementor::is_elementor_checkout() ) {
 				add_action(
 					'woocommerce_before_checkout_form',
 					function () {
 						echo '<div class="nv-checkout-wrap">';
 					},
-					PHP_INT_MAX 
+					PHP_INT_MAX
 				);
 				add_action( 'woocommerce_after_checkout_form', [ $this, 'close_div' ], PHP_INT_MIN );
 				add_action(

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -259,21 +259,36 @@ class Woocommerce {
 		add_action( 'wp', [ $this, 'setup_form_buttons' ] );
 
 		if ( neve_is_new_skin() ) {
-			add_action(
-				'woocommerce_checkout_before_customer_details',
-				function () {
-					echo '<div class="nv-customer-details">';
-				},
-				0
-			);
-			add_action( 'woocommerce_checkout_after_customer_details', [ $this, 'close_div' ], PHP_INT_MAX );
-			add_action(
-				'woocommerce_checkout_before_order_review_heading',
-				function () {
-					echo '<div class="nv-order-review">';
-				}
-			);
-			add_action( 'woocommerce_checkout_after_order_review', [ $this, 'close_div' ] );
+
+			/**
+			 * Checkout page tweaks.
+			 */
+			$is_elementor = get_post_meta( get_the_id(), '_elementor_edit_mode', true ) === 'builder';
+			if ( ! $is_elementor ) {
+				add_action(
+					'woocommerce_before_checkout_form',
+					function () {
+						echo '<div class="nv-checkout-wrap">';
+					},
+					PHP_INT_MAX 
+				);
+				add_action( 'woocommerce_after_checkout_form', [ $this, 'close_div' ], PHP_INT_MIN );
+				add_action(
+					'woocommerce_checkout_before_customer_details',
+					function () {
+						echo '<div class="nv-customer-details">';
+					},
+					0
+				);
+				add_action( 'woocommerce_checkout_after_customer_details', [ $this, 'close_div' ], PHP_INT_MAX );
+				add_action(
+					'woocommerce_checkout_before_order_review_heading',
+					function () {
+						echo '<div class="nv-order-review">';
+					}
+				);
+				add_action( 'woocommerce_checkout_after_order_review', [ $this, 'close_div' ] );
+			}
 
 			add_action(
 				'woocommerce_before_single_product_summary',


### PR DESCRIPTION
### Summary
- Prevent Neve from doing any modifications for the checkout page if the page is edited with Elementor

### Will affect the visual aspect of the product
NO


### Test instructions
- Install Elementor and create a page with the checkout widget on it
- The page should look good, with no other modifications made
- The customizer controls should not apply on this page
- Check the default checkout page and make sure the settings from customizer are still working

Please test with Neve PRO PR: https://github.com/Codeinwp/neve-pro-addon/pull/2196

<!-- Issues that this pull request closes. -->
Closes #3610.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
