### PR TITLE
fix: missing caret of form select with background color

### DIFF
--- a/assets/scss/components/elements/form-elements/_inputs.scss
+++ b/assets/scss/components/elements/form-elements/_inputs.scss
@@ -93,6 +93,10 @@ form.wp-block-search input.wp-block-search__input,
 	@extend %nv-form-fields;
 }
 
+form select {
+	background: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyMCAyMCI+PHBhdGggZmlsbD0iIzYyNjI2MiIgZD0iTTE1IDhsLTQgNi00LTZoOHoiLz48L3N2Zz4=) right center / 18px no-repeat, var(--formfieldbgcolor);
+}
+
 form label,
 .wpforms-container .wpforms-field-label {
 

--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -109,7 +109,7 @@
 	border-color: var(--formfieldbordercolor);
 	border-width: var(--formfieldborderwidth);
 	border-radius: var(--formfieldborderradius, 3px);
-	background-color: var(--formfieldbgcolor);
+	background: var(--formfieldbgcolor);
 	color: var(--formfieldcolor);
 	padding: var(--formfieldpadding);
 

--- a/assets/scss/lifter.scss
+++ b/assets/scss/lifter.scss
@@ -117,7 +117,7 @@
 }
 
 .llms-form-field .select2-container .select2-selection--single{
-  background-color: var(--formfieldbgcolor);
+  background: var(--formfieldbgcolor);
   border-style: solid;
   border-color: var(--formfieldbordercolor);
   border-width: var(--formfieldborderwidth);


### PR DESCRIPTION
### Summary
- reverted the changes previously made and found a way to have the caret for select inputs and also keep the gradient

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->

### Test instructions
- See if the reported problem was fixed
- Check and make sure the gradient for inputs is still working

<!-- Issues that this pull request closes. -->
Closes #3635.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
