### PR TITLE
fix: meta sidebar styling for wp6.1 [#3640]

### DIFF
--- a/assets/apps/metabox/src/editor.scss
+++ b/assets/apps/metabox/src/editor.scss
@@ -11,6 +11,11 @@
 		}
 	}
 
+	.components-flex{
+	  flex-direction: row;
+	  gap: 0;
+	}
+
 	.components-base-control__field {
 		display: inherit;
 	}
@@ -177,9 +182,11 @@
 	}
 }
 
-.components-button.has-icon[aria-label^="Neve"] {
+.components-button.has-icon[aria-label^="Neve"]:not(.is-tertiary) {
 	background: #0073aa;
-
+	&:hover:not(:disabled){
+	  background: #1e1e1e;
+	}
 	svg * {
 		fill: #ffffff;
 	}


### PR DESCRIPTION
### Summary
- Fixed the way the meta sidebar looks on wp 61

### Will affect visual aspect of the product
NO



<!-- Issues that this pull request closes. -->
Closes #3640.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
