### PR TITLE
fix: call to static method in trait #3662

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -705,3 +705,63 @@ function neve_do_loop_hook( $position ) {
 	 */
 	do_action( "neve_loop_{$current_post_type}_{$position}" );
 }
+
+/**
+ * Get meta default data
+ *
+ * @param string $field Meta field name.
+ * @param string $default Default value.
+ *
+ * @return array
+ */
+function neve_get_default_meta_value( $field, $default ) {
+	$new_control_data = [];
+
+	$components = apply_filters(
+		'neve_meta_filter',
+		array(
+			'author'   => __( 'Author', 'neve' ),
+			'category' => __( 'Category', 'neve' ),
+			'date'     => __( 'Date', 'neve' ),
+			'comments' => __( 'Comments', 'neve' ),
+		)
+	);
+
+	$default_data = get_theme_mod( $field, $default );
+	if ( empty( $default_data ) ) {
+		return $new_control_data;
+	}
+
+	$default_data = json_decode( $default_data, true );
+	if ( ! is_array( $default_data ) ) {
+		return $new_control_data;
+	}
+
+	foreach ( $default_data as $meta_component ) {
+		if ( ! array_key_exists( $meta_component, $components ) ) {
+			continue;
+		}
+		$new_control_data[ $meta_component ] = (object) [
+			'slug'           => $meta_component,
+			'title'          => $components[ $meta_component ],
+			'visibility'     => 'yes',
+			'hide_on_mobile' => false,
+			'blocked'        => 'yes',
+		];
+	}
+
+	foreach ( $components as $component_id => $label ) {
+		if ( array_key_exists( $component_id, $new_control_data ) ) {
+			continue;
+		}
+		$new_control_data[ $component_id ] = (object) [
+			'slug'           => $component_id,
+			'title'          => $label,
+			'visibility'     => 'no',
+			'hide_on_mobile' => false,
+			'blocked'        => 'yes',
+		];
+	}
+
+	return array_values( $new_control_data );
+}

--- a/inc/customizer/defaults/layout.php
+++ b/inc/customizer/defaults/layout.php
@@ -92,57 +92,11 @@ trait Layout {
 	/**
 	 * Get meta default data
 	 *
+	 * @deprecated 3.4.5 Use neve_get_default_meta_value( $field, $default ) instead.
+	 *
 	 * @return array
 	 */
 	public static function get_meta_default_data( $field, $default ) {
-		$new_control_data = [];
-
-		$components = apply_filters(
-			'neve_meta_filter',
-			array(
-				'author'   => __( 'Author', 'neve' ),
-				'category' => __( 'Category', 'neve' ),
-				'date'     => __( 'Date', 'neve' ),
-				'comments' => __( 'Comments', 'neve' ),
-			)
-		);
-
-		$default_data = get_theme_mod( $field, $default );
-		if ( empty( $default_data ) ) {
-			return $new_control_data;
-		}
-
-		$default_data = json_decode( $default_data, true );
-		if ( ! is_array( $default_data ) ) {
-			return $new_control_data;
-		}
-
-		foreach ( $default_data as $meta_component ) {
-			if ( ! array_key_exists( $meta_component, $components ) ) {
-				continue;
-			}
-			$new_control_data[ $meta_component ] = (object) [
-				'slug'           => $meta_component,
-				'title'          => $components[ $meta_component ],
-				'visibility'     => 'yes',
-				'hide_on_mobile' => false,
-				'blocked'        => 'yes',
-			];
-		}
-
-		foreach ( $components as $component_id => $label ) {
-			if ( array_key_exists( $component_id, $new_control_data ) ) {
-				continue;
-			}
-			$new_control_data[ $component_id ] = (object) [
-				'slug'           => $component_id,
-				'title'          => $label,
-				'visibility'     => 'no',
-				'hide_on_mobile' => false,
-				'blocked'        => 'yes',
-			];
-		}
-
-		return array_values( $new_control_data );
+		return neve_get_default_meta_value( $field, $default );
 	}
 }

--- a/inc/customizer/options/layout_blog.php
+++ b/inc/customizer/options/layout_blog.php
@@ -471,7 +471,7 @@ class Layout_Blog extends Base_Customizer {
 
 
 		$default       = wp_json_encode( [ 'author', 'date', 'comments' ] );
-		$default_value = Layout::get_meta_default_data( 'neve_post_meta_ordering', $default );
+		$default_value = neve_get_default_meta_value( 'neve_post_meta_ordering', $default );
 		$this->add_control(
 			new Control(
 				'neve_blog_post_meta_fields',

--- a/inc/customizer/options/layout_single_post.php
+++ b/inc/customizer/options/layout_single_post.php
@@ -252,7 +252,7 @@ class Layout_Single_Post extends Base_Layout_Single {
 			]
 		);
 		$default       = wp_json_encode( [ 'author', 'date', 'comments' ] );
-		$default_value = Layout::get_meta_default_data( 'neve_post_meta_ordering', $default );
+		$default_value = neve_get_default_meta_value( 'neve_post_meta_ordering', $default );
 		$default_value = get_theme_mod( 'neve_blog_post_meta_fields', wp_json_encode( $default_value ) );
 		$default_value = get_theme_mod( 'neve_single_post_meta_fields', $default_value );
 

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -148,68 +148,68 @@ class Post_Meta extends Base_View {
 					$markup      .= '</' . $tag . '>';
 					break;
 				case 'date':
-					$date_meta_classes = array(
-						'meta',
-						'date',
-						'posted-on',
-					);
-
-					$created           = get_the_time( 'U' );
-					$modified          = get_the_modified_time( 'U' );
-					$has_updated_time  = $created !== $modified;
-					$show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
-					if ( is_singular( 'post' ) ) {
-						$show_updated_time = get_theme_mod( 'neve_single_post_show_last_updated_date', $show_updated_time );
-					}
-					if ( $show_updated_time && $has_updated_time ) {
-						$date_meta_classes[] = 'nv-show-updated';
-					}
-					$meta_content = str_replace( '{meta}', self::get_time_tags( $pid ), $format );
-					$markup      .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . ' ' . esc_attr( $element_class ) . '">';
-					$markup      .= $meta_content;
-					$markup      .= '</' . $tag . '>';
+					// $date_meta_classes = array(
+					// 'meta',
+					// 'date',
+					// 'posted-on',
+					// );
+					//
+					// $created           = get_the_time( 'U' );
+					// $modified          = get_the_modified_time( 'U' );
+					// $has_updated_time  = $created !== $modified;
+					// $show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
+					// if ( is_singular( 'post' ) ) {
+					// $show_updated_time = get_theme_mod( 'neve_single_post_show_last_updated_date', $show_updated_time );
+					// }
+					// if ( $show_updated_time && $has_updated_time ) {
+					// $date_meta_classes[] = 'nv-show-updated';
+					// }
+					// $meta_content = str_replace( '{meta}', self::get_time_tags( $pid ), $format );
+					// $markup      .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . ' ' . esc_attr( $element_class ) . '">';
+					// $markup      .= $meta_content;
+					// $markup      .= '</' . $tag . '>';
 					break;
 				case 'category':
-					if ( ! in_array( 'category', get_object_taxonomies( $post_type ) ) ) {
-						break;
-					}
-					$meta_content = str_replace( '{meta}', get_the_category_list( ', ', '', $pid ), $format );
-					$markup      .= '<' . $tag . ' class="meta category ' . esc_attr( $element_class ) . '">';
-					$markup      .= wp_kses_post( $meta_content );
-					$markup      .= '</' . $tag . '>';
+					// if ( ! in_array( 'category', get_object_taxonomies( $post_type ) ) ) {
+					// break;
+					// }
+					// $meta_content = str_replace( '{meta}', get_the_category_list( ', ', '', $pid ), $format );
+					// $markup      .= '<' . $tag . ' class="meta category ' . esc_attr( $element_class ) . '">';
+					// $markup      .= wp_kses_post( $meta_content );
+					// $markup      .= '</' . $tag . '>';
 					break;
 				case 'comments':
-					$comments = self::get_comments( $pid );
-					if ( empty( $comments ) ) {
-						break;
-					}
-					$meta_content = str_replace( '{meta}', $comments, $format );
-					$markup      .= '<' . $tag . ' class="meta comments ' . esc_attr( $element_class ) . '">';
-					$markup      .= wp_kses_post( $meta_content );
-					$markup      .= '</' . $tag . '>';
+					// $comments = self::get_comments( $pid );
+					// if ( empty( $comments ) ) {
+					// break;
+					// }
+					// $meta_content = str_replace( '{meta}', $comments, $format );
+					// $markup      .= '<' . $tag . ' class="meta comments ' . esc_attr( $element_class ) . '">';
+					// $markup      .= wp_kses_post( $meta_content );
+					// $markup      .= '</' . $tag . '>';
 					break;
 				case 'reading':
-					$allowed_context = apply_filters( 'neve_post_type_supported_list', [ 'post' ], 'block_editor' );
-					if ( ! in_array( $post_type, $allowed_context ) ) {
-						break;
-					}
-					$reading_time = apply_filters( 'neve_do_read_time', $pid );
-					if ( empty( $reading_time ) ) {
-						break;
-					}
-					$meta_content = str_replace( '{meta}', $reading_time, $format );
-					$markup      .= '<' . $tag . ' class="meta reading-time ' . esc_attr( $element_class ) . '">';
-					$markup      .= wp_kses_post( $meta_content );
-					$markup      .= '</' . $tag . '>';
+					// $allowed_context = apply_filters( 'neve_post_type_supported_list', [ 'post' ], 'block_editor' );
+					// if ( ! in_array( $post_type, $allowed_context ) ) {
+					// break;
+					// }
+					// $reading_time = apply_filters( 'neve_do_read_time', $pid );
+					// if ( empty( $reading_time ) ) {
+					// break;
+					// }
+					// $meta_content = str_replace( '{meta}', $reading_time, $format );
+					// $markup      .= '<' . $tag . ' class="meta reading-time ' . esc_attr( $element_class ) . '">';
+					// $markup      .= wp_kses_post( $meta_content );
+					// $markup      .= '</' . $tag . '>';
 					break;
 				case 'custom':
-					$custom_meta = apply_filters( 'neve_do_custom_meta', '', $meta, $tag, $pid );
-					if ( empty( $custom_meta ) ) {
-						break;
-					}
-					$markup .= '<' . $tag . ' class="meta custom ' . esc_attr( $element_class ) . '">';
-					$markup .= wp_kses_post( $custom_meta );
-					$markup .= '</' . $tag . '>';
+					// $custom_meta = apply_filters( 'neve_do_custom_meta', '', $meta, $tag, $pid );
+					// if ( empty( $custom_meta ) ) {
+					// break;
+					// }
+					// $markup .= '<' . $tag . ' class="meta custom ' . esc_attr( $element_class ) . '">';
+					// $markup .= wp_kses_post( $custom_meta );
+					// $markup .= '</' . $tag . '>';
 					break;
 				case 'default':
 				default:
@@ -275,7 +275,7 @@ class Post_Meta extends Base_View {
 		);
 		$display_avatar = apply_filters( 'neve_display_author_avatar', false );
 		$avatar_url     = get_avatar_url( $author_email, $gravatar_args );
-		$avatar_markup  = '<img class="photo" alt="' . get_the_author() . '" src="' . esc_url( $avatar_url ) . '" />&nbsp;';
+		$avatar_markup  = '<img class="photo" alt="' . esc_attr( $display_name ) . '" src="' . esc_url( $avatar_url ) . '" />&nbsp;';
 
 		$markup = '';
 		if ( $display_avatar ) {

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -148,68 +148,68 @@ class Post_Meta extends Base_View {
 					$markup      .= '</' . $tag . '>';
 					break;
 				case 'date':
-					// $date_meta_classes = array(
-					// 'meta',
-					// 'date',
-					// 'posted-on',
-					// );
-					//
-					// $created           = get_the_time( 'U' );
-					// $modified          = get_the_modified_time( 'U' );
-					// $has_updated_time  = $created !== $modified;
-					// $show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
-					// if ( is_singular( 'post' ) ) {
-					// $show_updated_time = get_theme_mod( 'neve_single_post_show_last_updated_date', $show_updated_time );
-					// }
-					// if ( $show_updated_time && $has_updated_time ) {
-					// $date_meta_classes[] = 'nv-show-updated';
-					// }
-					// $meta_content = str_replace( '{meta}', self::get_time_tags( $pid ), $format );
-					// $markup      .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . ' ' . esc_attr( $element_class ) . '">';
-					// $markup      .= $meta_content;
-					// $markup      .= '</' . $tag . '>';
+					$date_meta_classes = array(
+						'meta',
+						'date',
+						'posted-on',
+					);
+
+					$created           = get_the_time( 'U' );
+					$modified          = get_the_modified_time( 'U' );
+					$has_updated_time  = $created !== $modified;
+					$show_updated_time = get_theme_mod( 'neve_show_last_updated_date', false );
+					if ( is_singular( 'post' ) ) {
+						$show_updated_time = get_theme_mod( 'neve_single_post_show_last_updated_date', $show_updated_time );
+					}
+					if ( $show_updated_time && $has_updated_time ) {
+						$date_meta_classes[] = 'nv-show-updated';
+					}
+					$meta_content = str_replace( '{meta}', self::get_time_tags( $pid ), $format );
+					$markup      .= '<' . $tag . ' class="' . esc_attr( implode( ' ', $date_meta_classes ) ) . ' ' . esc_attr( $element_class ) . '">';
+					$markup      .= $meta_content;
+					$markup      .= '</' . $tag . '>';
 					break;
 				case 'category':
-					// if ( ! in_array( 'category', get_object_taxonomies( $post_type ) ) ) {
-					// break;
-					// }
-					// $meta_content = str_replace( '{meta}', get_the_category_list( ', ', '', $pid ), $format );
-					// $markup      .= '<' . $tag . ' class="meta category ' . esc_attr( $element_class ) . '">';
-					// $markup      .= wp_kses_post( $meta_content );
-					// $markup      .= '</' . $tag . '>';
+					if ( ! in_array( 'category', get_object_taxonomies( $post_type ) ) ) {
+						break;
+					}
+					$meta_content = str_replace( '{meta}', get_the_category_list( ', ', '', $pid ), $format );
+					$markup      .= '<' . $tag . ' class="meta category ' . esc_attr( $element_class ) . '">';
+					$markup      .= wp_kses_post( $meta_content );
+					$markup      .= '</' . $tag . '>';
 					break;
 				case 'comments':
-					// $comments = self::get_comments( $pid );
-					// if ( empty( $comments ) ) {
-					// break;
-					// }
-					// $meta_content = str_replace( '{meta}', $comments, $format );
-					// $markup      .= '<' . $tag . ' class="meta comments ' . esc_attr( $element_class ) . '">';
-					// $markup      .= wp_kses_post( $meta_content );
-					// $markup      .= '</' . $tag . '>';
+					$comments = self::get_comments( $pid );
+					if ( empty( $comments ) ) {
+						break;
+					}
+					$meta_content = str_replace( '{meta}', $comments, $format );
+					$markup      .= '<' . $tag . ' class="meta comments ' . esc_attr( $element_class ) . '">';
+					$markup      .= wp_kses_post( $meta_content );
+					$markup      .= '</' . $tag . '>';
 					break;
 				case 'reading':
-					// $allowed_context = apply_filters( 'neve_post_type_supported_list', [ 'post' ], 'block_editor' );
-					// if ( ! in_array( $post_type, $allowed_context ) ) {
-					// break;
-					// }
-					// $reading_time = apply_filters( 'neve_do_read_time', $pid );
-					// if ( empty( $reading_time ) ) {
-					// break;
-					// }
-					// $meta_content = str_replace( '{meta}', $reading_time, $format );
-					// $markup      .= '<' . $tag . ' class="meta reading-time ' . esc_attr( $element_class ) . '">';
-					// $markup      .= wp_kses_post( $meta_content );
-					// $markup      .= '</' . $tag . '>';
+					$allowed_context = apply_filters( 'neve_post_type_supported_list', [ 'post' ], 'block_editor' );
+					if ( ! in_array( $post_type, $allowed_context ) ) {
+						break;
+					}
+					$reading_time = apply_filters( 'neve_do_read_time', $pid );
+					if ( empty( $reading_time ) ) {
+						break;
+					}
+					$meta_content = str_replace( '{meta}', $reading_time, $format );
+					$markup      .= '<' . $tag . ' class="meta reading-time ' . esc_attr( $element_class ) . '">';
+					$markup      .= wp_kses_post( $meta_content );
+					$markup      .= '</' . $tag . '>';
 					break;
 				case 'custom':
-					// $custom_meta = apply_filters( 'neve_do_custom_meta', '', $meta, $tag, $pid );
-					// if ( empty( $custom_meta ) ) {
-					// break;
-					// }
-					// $markup .= '<' . $tag . ' class="meta custom ' . esc_attr( $element_class ) . '">';
-					// $markup .= wp_kses_post( $custom_meta );
-					// $markup .= '</' . $tag . '>';
+					$custom_meta = apply_filters( 'neve_do_custom_meta', '', $meta, $tag, $pid );
+					if ( empty( $custom_meta ) ) {
+						break;
+					}
+					$markup .= '<' . $tag . ' class="meta custom ' . esc_attr( $element_class ) . '">';
+					$markup .= wp_kses_post( $custom_meta );
+					$markup .= '</' . $tag . '>';
 					break;
 				case 'default':
 				default:

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -178,7 +178,7 @@ class Post_Layout extends Base_View {
 		 */
 
 		// Take the old control value and bring it to a form that can be used in a repeater.
-		$default_value = Layout::get_meta_default_data( 'neve_post_meta_ordering', wp_json_encode( [ 'author', 'date', 'comments' ] ) );
+		$default_value = neve_get_default_meta_value( 'neve_post_meta_ordering', wp_json_encode( [ 'author', 'date', 'comments' ] ) );
 
 		// We need to get the value of the meta on blogs and pass it as default for meta on single.
 		$default_value = get_theme_mod( 'neve_blog_post_meta_fields', wp_json_encode( $default_value ) );

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -291,7 +291,7 @@ class Template_Parts extends Base_View {
 	 */
 	private function get_meta( $post_id = null ) {
 		$default       = wp_json_encode( [ 'author', 'date', 'comments' ] );
-		$default_value = Layout::get_meta_default_data( 'neve_post_meta_ordering', $default );
+		$default_value = neve_get_default_meta_value( 'neve_post_meta_ordering', $default );
 		$meta_order    = get_theme_mod( 'neve_blog_post_meta_fields', wp_json_encode( $default_value ) );
 
 		if ( ! is_array( $meta_order ) ) {


### PR DESCRIPTION
### Summary
This PR fixes the two errors described in the issue thread.
- I've taken that method and made another one global with the same functionality;
- I kept the previous method to avoid any compatibility issues with the pro version ( since the method is used in pro ) but I've added the deprecated tag
- For the second issue, I've replaced the alt attribute with the display name since the `get_the_author` function produces the notice

### Will affect the visual aspect of the product
NO


### Test instructions
- Install PHP8.1
- Import the  data from https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml
- Check the blog for any related issues with Neve
- Make sure there aren't any issues with neve old / neve pro new, neve new/ neve pro old. For neve new test with this PR https://github.com/Codeinwp/neve-pro-addon/pull/2226

<!-- Issues that this pull request closes. -->
Closes #3662.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
