### PR TITLE
Add another check for component id

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -94,8 +94,9 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			'icon_type' => 'icon',
 			'icon'      => '<svg aria-label="' . esc_attr__( 'Dropdown', 'neve' ) . '" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><path d="M207.029 381.476L12.686 187.132c-9.373-9.373-9.373-24.569 0-33.941l22.667-22.667c9.357-9.357 24.522-9.375 33.901-.04L224 284.505l154.745-154.021c9.379-9.335 24.544-9.317 33.901.04l22.667 22.667c9.373 9.373 9.373 24.569 0 33.941L240.971 381.476c-9.373 9.372-24.569 9.372-33.942 0z"/></svg>',
 		];
-		$caret_settings         = apply_filters( 'neve_submenu_icon_settings', $default_caret_settings, $args->component_id );
 
+		$component_id    = $args->component_id ?? '';
+		$caret_settings  = apply_filters( 'neve_submenu_icon_settings', $default_caret_settings, $component_id );
 		$caret_pictogram = $this->get_caret_pictogram( $caret_settings );
 
 


### PR DESCRIPTION
### Summary
I cannot replicate the main issue. By the looks of it, the client either has a child theme and overwrites files from the theme or did some modifications inside the theme files.
I've added a supplementary check for it as it does no harm but the problem shouldn't appear.

### Will affect the visual aspect of the product
NO


### Test instructions
- Install neve and add a menu
- In the theme's files, go and comment this line https://github.com/Codeinwp/neve/blob/master/header-footer-grid/templates/components/component-nav.php#L38
- With or without that line commented, there should be no error on frontend

<!-- Issues that this pull request closes. -->
Closes #3660.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
