### PR TITLE
fix: update webfont loader [Codeinwp/neve-pro-addon#2228]

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -48,16 +48,16 @@
         },
         {
             "name": "wptt/webfont-loader",
-            "version": "v1.1.2",
+            "version": "v1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WPTT/webfont-loader.git",
-                "reference": "780e564bf0554c419ef447c2b5b768b497ecee40"
+                "reference": "19fa29ba8d82bed018fb8c6f949799739c61356c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WPTT/webfont-loader/zipball/780e564bf0554c419ef447c2b5b768b497ecee40",
-                "reference": "780e564bf0554c419ef447c2b5b768b497ecee40",
+                "url": "https://api.github.com/repos/WPTT/webfont-loader/zipball/19fa29ba8d82bed018fb8c6f949799739c61356c",
+                "reference": "19fa29ba8d82bed018fb8c6f949799739c61356c",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +89,7 @@
                 "issues": "https://github.com/WPTT/font-loader/issues",
                 "source": "https://github.com/WPTT/font-loader"
             },
-            "time": "2022-06-17T10:41:00+00:00"
+            "time": "2022-10-21T07:56:48+00:00"
         }
     ],
     "packages-dev": [
@@ -964,5 +964,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### Summary
Updated the webfont loader composer dependency. This should fix the issue.

### Will affect visual aspect of the product
NO


### Test instructions
1. Enable the Typekit module in the Neve dashboard, you can use this project ID: `xcw3ype`
2. Enable local font loading from the performance module
3. Select a Typekit font in the customizer.
4. In DevTools from Chrome, check and see how the selected font is loading.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2228.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
