### PR TITLE
Dropdown arrow for customizer headings

### DIFF
--- a/assets/customizer/css/heading.css
+++ b/assets/customizer/css/heading.css
@@ -58,6 +58,6 @@
 	color: #A0A5AA;
 }
 
-.customize-control-customizer-heading.expanded .accordion-expand-button:after {
+.customize-control.expanded .accordion-expand-button:after {
 	transform: rotate(180deg);
 }


### PR DESCRIPTION
### Summary
Updated the CSS so it will work for both type of Heading controls, the template one and the react one

### Will affect visual aspect of the product
NO

### Test instructions
- Check the H1 - H6 headings in typography panel
- Install Neve Pro and check if the dropdown works for headings in the primary menu component

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2221.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
