### PR TITLE
chore: added notice if premium template used w.o pro

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -324,6 +324,17 @@ class Main {
 			}
 		}
 
+		if ( get_option( 'templates_patterns_collection_pro_import' ) && ( 'valid' !== apply_filters( 'product_neve_license_status', false ) || ! is_plugin_active( $plugin_path ) ) ) {
+			$notifications['pro-tpc-import'] = [
+				'text'   => __( 'You are using a premium template without an active Neve Pro license.', 'neve' ),
+				'update' => [
+					'type' => 'tpc-import',
+					'slug' => 'pro-tpc-import',
+				],
+				'type'   => 'error',
+			];
+		}
+
 		$notifications = apply_filters( 'neve_dashboard_notifications', $notifications );
 
 		return $notifications;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added non-dismissable notice if PRO template is imported and license or plugin is not active

Works with the changes from TPC.
References: Codeinwp/templates-patterns-collection/pull/171

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/198058175-e64f09d7-d2f8-434e-88fb-f561dc544509.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
Use the test instructions from here: https://github.com/Codeinwp/templates-patterns-collection/pull/171

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2018.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
