### PR TITLE
fix: toggle style

### DIFF
--- a/assets/apps/customizer-controls/src/scss/_controls-layout.scss
+++ b/assets/apps/customizer-controls/src/scss/_controls-layout.scss
@@ -6,8 +6,15 @@
   .customize-control-neve_color_control & {
 	padding-bottom: 10px;
   }
-}
 
+  .components-toggle-control{
+	margin-bottom: 0;
+  }
+
+  .components-form-toggle{
+	min-width: auto;
+  }
+}
 
 //
 //.customize-control-neve_responsive_range_control, .customize-control-neve_range_control, .customize-control-neve_toggle_control {


### PR DESCRIPTION
### Summary
Fix the style for toggle controls in WP 6.1. Seems they've added a `min-width: 0` on `components-base-control__field` class and a margin-bottom on `components-toggle-control`

### Will affect visual aspect of the product
NO


### Test instructions
- Upgrade to WP 6.1 ( I tried RC5 )
- Check customizer controls

<!-- Issues that this pull request closes. -->
Closes #3643.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
