### PR TITLE
fix: enqueue google fonts on editor preview #3654

### DIFF
--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -13,7 +13,6 @@ body & p {
 }
 
 .wp-block {
-	font-family: var(--bodyfontfamily);
 	// Group colors
 	&.has-text-color .wp-block {
 		color: inherit;
@@ -41,6 +40,7 @@ body & p {
 p {
 	margin-top: 0;
 	margin-bottom: $spacing-lg;
+	font-family: var(--bodyfontfamily);
 }
 
 h1,

--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -13,6 +13,7 @@ body & p {
 }
 
 .wp-block {
+	font-family: var(--bodyfontfamily);
 	// Group colors
 	&.has-text-color .wp-block {
 		color: inherit;

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -192,7 +192,7 @@ class Font_Manager extends Base_View {
 
 		// Make sure font is in our list of fonts.
 		if ( ! in_array( $font, array_keys( $google_fonts ), true ) ) {
-			return;
+			return '';
 		}
 
 		// Make sure 400 font weight is always included.
@@ -251,6 +251,7 @@ class Font_Manager extends Base_View {
 		}
 
 		wp_enqueue_style( 'neve-google-font-' . str_replace( ' ', '-', strtolower( $font ) ), $url, array(), NEVE_VERSION );
+		return $url;
 	}
 
 	/**

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -91,6 +91,7 @@ class Font_Manager extends Base_View {
 		$this->add_body_variants();
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_google_fonts' ), 200 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_google_fonts' ), 200 );
+		add_action( 'after_setup_theme', array( $this, 'do_editor_styles_google_fonts' ) );
 		add_action( 'wp_print_styles', array( $this, 'load_external_fonts_locally' ), PHP_INT_MAX );
 	}
 
@@ -151,14 +152,39 @@ class Font_Manager extends Base_View {
 	}
 
 	/**
+	 * Will register fonts for the editor preview (mobile|tablet)
+	 */
+	public function do_editor_styles_google_fonts() {
+		if ( empty( self::$font_families ) ) {
+			return;
+		}
+		add_theme_support( 'editor-styles' );
+		$style_array = array(
+			'editor-styles.css',
+		);
+		foreach ( self::$font_families as $font_family => $font_weights ) {
+			$url = $this->enqueue_google_font( $font_family, $font_weights, true );
+			if ( ! empty( $url ) ) {
+				array_push( $style_array, 'https:' . $url );
+			}
+		}
+
+		add_editor_style(
+			$style_array
+		);
+	}
+
+	/**
 	 * Enqueues a Google Font
 	 *
-	 * @param string $font font string.
-	 * @param array  $weights font weights.
+	 * @param string  $font font string.
+	 * @param array   $weights font weights.
+	 * @param boolean $skip_enqueue flag to skip enqueue and return url.
 	 *
 	 * @since 1.1.38
+	 * @return void|string Will return the URL of the font if `$skip_enqueue` is `true`
 	 */
-	private function enqueue_google_font( $font, $weights = [] ) {
+	private function enqueue_google_font( $font, $weights = [], $skip_enqueue = false ) {
 		// Get list of all Google Fonts.
 		$google_fonts = neve_get_google_fonts( true );
 
@@ -219,14 +245,18 @@ class Font_Manager extends Base_View {
 			$query_args['subset'] = urlencode( $subsets[ $locale ] );
 		}
 		$url = add_query_arg( $query_args, $base_url );
-		
+
+		if ( $skip_enqueue ) {
+			return $url;
+		}
+
 		wp_enqueue_style( 'neve-google-font-' . str_replace( ' ', '-', strtolower( $font ) ), $url, array(), NEVE_VERSION );
 	}
 
 	/**
 	 * Load Google Fonts locally.
 	 *
-	 * @return void 
+	 * @return void
 	 */
 	public function load_external_fonts_locally() {
 
@@ -253,22 +283,22 @@ class Font_Manager extends Base_View {
 		}
 
 		/**
-		 * Bail when in Elementor edit mode. 
-		 * 
+		 * Bail when in Elementor edit mode.
+		 *
 		 * We do this so that initial load of Elementor editor will not be slowed down by Neve Pro downloading Roboto fonts.
-		 */ 
+		 */
 		if ( class_exists( '\Elementor\Plugin' ) ) {
 			global $post;
-			if ( \Elementor\Plugin::$instance->editor->is_edit_mode() || 
+			if ( \Elementor\Plugin::$instance->editor->is_edit_mode() ||
 				\Elementor\Plugin::$instance->preview->is_preview_mode()
 				) {
 				return;
-			}       
+			}
 		}
 
 		/**
 		 * Allow filtering for additional external font providers.
-		 * 
+		 *
 		 * The domains provided to this filter should be from services that link directly to a CSS file or else WPTT will not be able to download the fonts.
 		 */
 		$external_font_domains = apply_filters(
@@ -303,9 +333,9 @@ class Font_Manager extends Base_View {
 					$normalized_source = 'https://' . $parts['host'] . $parts['path'] . ( isset( $parts['query'] ) ? '?' . $parts['query'] : '' );
 					$external_fonts[]  = $normalized_source;
 					// Dequeue this handle since we are going to load the font locally
-					wp_dequeue_style( $style ); 
-				}           
-			}       
+					wp_dequeue_style( $style );
+				}
+			}
 		}
 
 		$external_fonts = array_unique( $external_fonts );

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -182,7 +182,7 @@ class Font_Manager extends Base_View {
 	 * @param boolean $skip_enqueue flag to skip enqueue and return url.
 	 *
 	 * @since 1.1.38
-	 * @return void|string Will return the URL of the font if `$skip_enqueue` is `true`
+	 * @return string Will return the URL of the font if `$skip_enqueue` is `true`
 	 */
 	private function enqueue_google_font( $font, $weights = [], $skip_enqueue = false ) {
 		// Get list of all Google Fonts.

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -181,7 +181,6 @@ class Font_Manager extends Base_View {
 	 * @param boolean $skip_enqueue flag to skip enqueue and return url.
 	 *
 	 * @since 1.1.38
-	 * @return string Will return the URL of the font if `$skip_enqueue` is `true`
 	 */
 	private function enqueue_google_font( $font, $weights = [], $skip_enqueue = false ) {
 		// Get list of all Google Fonts.
@@ -191,7 +190,7 @@ class Font_Manager extends Base_View {
 
 		// Make sure font is in our list of fonts.
 		if ( ! in_array( $font, array_keys( $google_fonts ), true ) ) {
-			return '';
+			return;
 		}
 
 		// Make sure 400 font weight is always included.
@@ -250,7 +249,6 @@ class Font_Manager extends Base_View {
 		}
 
 		wp_enqueue_style( 'neve-google-font-' . str_replace( ' ', '-', strtolower( $font ) ), $url, array(), NEVE_VERSION );
-		return $url;
 	}
 
 	/**

--- a/inc/views/font_manager.php
+++ b/inc/views/font_manager.php
@@ -91,7 +91,7 @@ class Font_Manager extends Base_View {
 		$this->add_body_variants();
 		add_action( 'wp_enqueue_scripts', array( $this, 'register_google_fonts' ), 200 );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'register_google_fonts' ), 200 );
-		add_action( 'after_setup_theme', array( $this, 'do_editor_styles_google_fonts' ) );
+		add_action( 'enqueue_block_editor_assets', array( $this, 'do_editor_styles_google_fonts' ), 210 );
 		add_action( 'wp_print_styles', array( $this, 'load_external_fonts_locally' ), PHP_INT_MAX );
 	}
 
@@ -168,7 +168,6 @@ class Font_Manager extends Base_View {
 				array_push( $style_array, 'https:' . $url );
 			}
 		}
-
 		add_editor_style(
 			$style_array
 		);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Enqueue google fonts for editor preview (iFrame).

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/200851162-c842138b-04b6-40d8-bf69-b2c22c004b65.png)


### Video
https://vertis.d.pr/v/Q7SV8g

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Have a Google Font defined in General
2. Check inside the Gutenberg Editor on the Preview (Mobile Tablet) that the font is being loaded and displayed.

<!-- Issues that this pull request closes. -->
Closes #3654.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
