### PR TITLE
fix: gradient picker size for wp6.1

### DIFF
--- a/assets/apps/components/src/Controls/ColorControl.js
+++ b/assets/apps/components/src/Controls/ColorControl.js
@@ -151,6 +151,7 @@ const ColorControl = ({
 											width: '100%',
 											height: '177px',
 											border: '1px solid #eee',
+											minWidth: '215px',
 										}}
 									/>
 									<GradientPicker

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -1,65 +1,23 @@
 .neve-color-component {
   .components-popover {
 	position: fixed !important;
+	.components-popover {
+	  position: absolute !important;
+	}
   }
   .components-popover .components-popover__content {
 	overflow: unset !important;
   }
-  .components-circular-option-picker {
-	min-width: 216px;
-  }
 
-  .components-popover.is-from-bottom {
-	margin-top: 20px;
-	margin-left: 40px;
-  }
-
-  .components-popover__content .components-popover__content {
-	bottom: inherit;
-  }
-
-  .components-custom-gradient-picker .components-popover__content {
-	position: relative !important;
-	bottom: 0 !important;
-	left: 0 !important;
-	top: 0 !important;
-  }
-
-  .components-custom-gradient-picker .components-popover {
-	position: fixed;
-	top: auto !important;
-	bottom: auto !important;
-	left: 0 !important;
-	margin-left: 130px;
-	margin-top: -250px;
-	.components-popover__content {
-	  transform: translateX(0%);
-	}
+  .components-custom-gradient-picker__gradient-bar {
+	position: relative;
+	border-radius: 24px;
+	z-index: 1;
   }
 
   .components-custom-gradient-picker__gradient-bar {
-	width: inherit;
-	border-radius: 24px;
-
-	.components-custom-gradient-picker__markers-container {
-	  width: calc(100% - 16px);
-	}
-
 	&:not(.has-gradient) {
-	  opacity: 1;
-	}
-  }
-
-  .components-input-control__suffix {
-	.components-truncate.components-text.components-spacer {
-	  margin: 0 calc(8px) calc(8px) 0;
-	}
-  }
-
-  .color-toggle.components-button-group {
-	.components-button {
-	  height: 26px;
-	  padding: 6px 8px;
+		opacity: 1;
 	}
   }
 }

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -1,4 +1,10 @@
 .neve-color-component {
+  .components-popover {
+	position: fixed !important;
+  }
+  .components-popover .components-popover__content {
+	overflow: unset !important;
+  }
   .components-circular-option-picker {
 	min-width: 216px;
   }
@@ -24,8 +30,8 @@
 	top: auto !important;
 	bottom: auto !important;
 	left: 0 !important;
-	margin-left: 232px;
-	margin-top: -232px;
+	margin-left: 130px;
+	margin-top: -250px;
 	.components-popover__content {
 	  transform: translateX(0%);
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added a min with to keep the gradient picker from collapsing in WP6.1

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check the gradient color picker inside Customizer with WP6.1
2. Check that it maintains the proper width

<!-- Issues that this pull request closes. -->
Closes #3689.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
