### PR TITLE
Fix plugin path issues with bedrock

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -13,6 +13,8 @@ define( 'NEVE_INC_DIR', trailingslashit( get_template_directory() ) . 'inc/' );
 define( 'NEVE_ASSETS_URL', trailingslashit( get_template_directory_uri() ) . 'assets/' );
 define( 'NEVE_MAIN_DIR', get_template_directory() . '/' );
 define( 'NEVE_BASENAME', basename( NEVE_MAIN_DIR ) );
+define( 'NEVE_PLUGINS_DIR', plugin_dir_path( dirname( __DIR__ ) ) . 'plugins/' );
+
 if ( ! defined( 'NEVE_DEBUG' ) ) {
 	define( 'NEVE_DEBUG', false );
 }
@@ -115,7 +117,7 @@ add_filter(
 		];
 
 		return $compatibilities;
-	} 
+	}
 );
 require_once 'globals/migrations.php';
 require_once 'globals/utilities.php';

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -22,7 +22,7 @@ class Plugin_Helper {
 	 */
 	public function get_plugin_state( $slug ) {
 		$plugin_link_suffix = $this->get_plugin_path( $slug );
-		if ( file_exists( ABSPATH . 'wp-content/plugins/' . $plugin_link_suffix ) ) {
+		if ( file_exists( NEVE_PLUGINS_DIR . $plugin_link_suffix ) ) {
 			return is_plugin_active( $plugin_link_suffix ) ? 'deactivate' : 'activate';
 		}
 
@@ -129,7 +129,7 @@ class Plugin_Helper {
 			return $default;
 		}
 
-		$plugin_data = get_plugin_data( ABSPATH . 'wp-content/plugins/' . $plugin_file );
+		$plugin_data = get_plugin_data( NEVE_PLUGINS_DIR . $plugin_file );
 		if ( ! empty( $plugin_data ) && array_key_exists( 'Version', $plugin_data ) ) {
 			return $plugin_data['Version'];
 		}


### PR DESCRIPTION
### Summary
- Defined a variable in `functions.php` pointing to the plugins directory
- Tested on both Bedrock and WordPress and everything seems to be fine.

### Will affect the visual aspect of the product
NO


### Test instructions
- Test if the plugins install/activate/deactivate from the dashboard are still working fine.
- Test if TPC is installing.
- Check if the import works correctly.
- To test the Bedrock side, you'll need to install https://github.com/roots/bedrock/ on your local environment. Please ping me if you need help with the installation.
- Test the first three steps mentioned above.

<!-- Issues that this pull request closes. -->
Closes #3690.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
