### PR TITLE
fix: elementor header disappears

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -445,11 +445,11 @@ class Elementor extends Page_Builder_Base {
 		 */
 		$conditions_manager = self::get_condition_manager();
 
-		if ( ! is_object( $conditions_manager ) || ! method_exists( $conditions_manager, 'get_documents_for_location' ) ) {
+		if ( ! is_object( $conditions_manager ) || ! method_exists( $conditions_manager, 'get_location_templates' ) ) {
 			return false;
 		}
 
-		$templates = $conditions_manager->get_documents_for_location( $location );
+		$templates = $conditions_manager->get_location_templates( $location );
 
 		self::$cache_cp_has_template[ $location ] = ( count( $templates ) > 0 );
 


### PR DESCRIPTION
### Summary
The error occurs whenever the `get_documents_for_location` function was called. It wasn't necessary to call it since we could call the `get_location_templates`, a function that is used by `get_documents_for_location`.

### Will affect visual aspect of the product
NO

### Test instructions
- Follow the steps from the issue's body
- Since this is a regression, please test https://github.com/Codeinwp/neve-pro-addon/issues/2116 again


<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2277.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
