### PR TITLE
fix: missing css rules to fix #3729 has been re-added

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -157,14 +157,19 @@
 	transition: all 0.3s linear;
 	visibility: hidden;
 	opacity: 0;
-	pointer-events: none;
 
 	.is-menu-sidebar & {
 		visibility: visible;
 		opacity: 1;
-		pointer-events: unset;
 	}
 }
 
 //</editor-fold>
 
+.hfg-pe {
+	pointer-events: none;
+
+	.is-menu-sidebar & {
+		pointer-events: unset;
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
With v3.4.8, that #3729 issue came again as a regression.

In this PR, that issue was fixed again.

the regression was causing; the mobile menu (opening behavior: Full Canvas and if some other conditions are met) was overlapping with some other HTML elements (such as WC Product Tabs). Therefore, when you click somewhere, the browser redirects you to a menu URL in the mobile menu even though the mobile menu is closed and you're in a desktop browser.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- The issue defined on https://github.com/Codeinwp/neve/issues/3729 should be fixed.
- No regression should occur Neve Mobile Menu feature overall

<!-- Issues that this pull request closes. -->
Closes #3729.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
