### PR TITLE
chore: rollback menu changes

### DIFF
--- a/assets/js/src/frontend/hgf.js
+++ b/assets/js/src/frontend/hgf.js
@@ -5,15 +5,9 @@ import {
 	addClass,
 	removeClass,
 	NV_FOCUS_TRAP_START,
-	NV_FOCUS_TRAP_END,
 } from '../utils.js';
 
 const closeNavSelector = '.close-sidebar-panel .navbar-toggle';
-const sidebarClasses = [
-	'is-menu-sidebar',
-	'hiding-header-menu-sidebar',
-	'is-active',
-];
 
 export const HFG = function () {
 	this.options = {
@@ -76,7 +70,7 @@ HFG.prototype.init = function (skipSidebar = false) {
 HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
 	const TOGGLE_CLASS_CONTAINER = '.menu-mobile-toggle';
 	const buttonsContainer = document.querySelectorAll(TOGGLE_CLASS_CONTAINER);
-	removeClass(document.body, sidebarClasses[1]);
+	removeClass(document.body, 'hiding-header-menu-sidebar');
 
 	/**
 	 * Elements to apply aria-hidden on
@@ -90,20 +84,20 @@ HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
 
 	if (
 		(!NeveProperties.isCustomize &&
-			document.body.classList.contains(sidebarClasses[0])) ||
+			document.body.classList.contains('is-menu-sidebar')) ||
 		toggle === false
 	) {
 		const navClickaway = document.querySelector('.nav-clickaway-overlay');
 		if (navClickaway !== null) {
 			navClickaway.parentNode.removeChild(navClickaway);
 		}
-		addClass(document.body, sidebarClasses[1]);
-		removeClass(document.body, sidebarClasses[0]);
-		removeClass(buttonsContainer, sidebarClasses[2]);
+		addClass(document.body, 'hiding-header-menu-sidebar');
+		removeClass(document.body, 'is-menu-sidebar');
+		removeClass(buttonsContainer, 'is-active');
 		// Remove the hiding class after 1 second.
 		setTimeout(
 			function () {
-				removeClass(document.body, sidebarClasses[1]);
+				removeClass(document.body, 'hiding-header-menu-sidebar');
 			}.bind(this),
 			1000
 		);
@@ -113,11 +107,9 @@ HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
 		 */
 		toggleAria(ariaHideOnToggle, false);
 		toggleAria(ariaShowOnToggle);
-		// Remove focus trap when closing.
-		document.dispatchEvent(new CustomEvent(NV_FOCUS_TRAP_END));
 	} else {
-		addClass(document.body, sidebarClasses[0]);
-		addClass(buttonsContainer, sidebarClasses[2]);
+		addClass(document.body, 'is-menu-sidebar');
+		addClass(buttonsContainer, 'is-active');
 		if (target) {
 			document.dispatchEvent(
 				new CustomEvent(NV_FOCUS_TRAP_START, {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -85,34 +85,15 @@ function openCarrets(e, caret) {
 	createNavOverlay(document.querySelectorAll(`.${strings[0]}`), strings[0]);
 }
 
-/**
- * Check that element is visible.
- *
- * @param {Element} el
- * @return {boolean} If element is visible or not.
- */
-const vis = (el) => {
-	if (el === document) {
-		return true;
-	}
-
-	if (window.getComputedStyle(el, null).display === 'none') {
-		return false;
-	}
-	return vis(el.parentNode);
-};
-
 function getKeyboardFocusableElements(element = document) {
-	return [
+	focusTrapDetails.elements = [
 		...element.querySelectorAll(
 			'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'
 		),
 	].filter(
-		(el) =>
-			!el.hasAttribute('disabled') &&
-			!el.getAttribute('aria-hidden') &&
-			vis(el)
+		(el) => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden')
 	);
+	return focusTrapDetails.elements;
 }
 
 /**
@@ -139,7 +120,9 @@ document.addEventListener(NV_FOCUS_TRAP_END, function () {
 });
 
 function startFocusTrap(event) {
-	const elements = getKeyboardFocusableElements(focusTrapDetails.container);
+	const elements =
+		focusTrapDetails.elements ||
+		getKeyboardFocusableElements(focusTrapDetails.container);
 	const tabKey = event.keyCode === 9;
 	const shiftKey = event.shiftKey;
 	const escKey = event.keyCode === 27;

--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -8,7 +8,6 @@
 
 	.sub-menu .sub-menu {
 		max-height: none;
-		width: 100%;
 	}
 
 	.neve-mm-col {
@@ -78,7 +77,8 @@
 		}
 
 		.neve-mega-menu:hover,
-		.neve-mega-menu:focus {
+		.neve-mega-menu:focus,
+		.neve-mega-menu:focus-within {
 
 			> .sub-menu {
 				display: flex;

--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -23,20 +23,15 @@
 	margin-right: calc(var(--spacing) / 2 * -1);
 	margin-left: calc(var(--spacing) / 2 * -1);
 
-	li > .wrap {
+	li > a {
 		display: flex;
 		align-items: center;
-	}
-
-	li a {
 		min-height: var(--height);
 		color: var(--color);
 		position: relative;
-		width: 100%;
 	}
 
-	> li:hover > a,
-	> li:hover > .caret {
+	a:hover {
 		color: var(--hovercolor);
 	}
 
@@ -52,14 +47,22 @@
 			color: var(--activecolor);
 		}
 
-		&:hover > .sub-menu {
+		&:hover > .sub-menu,
+		&:focus-within > .sub-menu {
 
 			@extend %show-dropdown;
 		}
 	}
 
-	li .caret {
-		line-height: 0;
+	.caret {
+		display: flex;
+		justify-content: center;
+
+		svg {
+			fill: currentColor;
+			width: 0.5em;
+			height: 0.5em;
+		}
 	}
 
 	.sub-menu {
@@ -74,10 +77,8 @@
 
 		li {
 			min-width: 150px;
-			width: 100%;
 		}
 
-		li > .wrap,
 		li > a {
 			padding: $spacing-xs $spacing-md;
 			white-space: nowrap;

--- a/assets/scss/components/elements/navigation/_nav-styles.scss
+++ b/assets/scss/components/elements/navigation/_nav-styles.scss
@@ -1,7 +1,6 @@
 .style-border-bottom > ul > li >,
 .sm-style-border-bottom .sub-menu {
 
-	.wrap::after,
 	a::after {
 		bottom: 0;
 	}
@@ -11,7 +10,6 @@
 .style-border-top > ul > li >,
 .sm-style-border-top .sub-menu {
 
-	.wrap::after,
 	a::after {
 		top: 0;
 	}
@@ -20,7 +18,6 @@
 .sm-style .sub-menu,
 .m-style > ul > li > {
 
-	.wrap:hover,
 	a:hover {
 
 		&::after {
@@ -28,7 +25,6 @@
 		}
 	}
 
-	.wrap::after,
 	a::after {
 		position: absolute;
 		content: "";
@@ -47,26 +43,13 @@
 .style-full-height > ul > li >,
 .sm-style-full-height .sub-menu {
 
-	.wrap {
-		z-index: 1;
-
-		&::after {
-			top: 0;
-			bottom: 0;
-			left: calc(var(--spacing) / 2 * -1);
-			right: calc(var(--spacing) / 2 * -1);
-			height: 100%;
-			z-index: -1;
-		}
-	}
-
 	a:hover {
 		color: currentColor;
 
 		&,
 		span,
 		i {
-			color: var(--hovertextcolor, var(--color));
+			color: var(--hovertextcolor, var(--color)) !important;
 		}
 
 		&::after {
@@ -89,12 +72,6 @@
 }
 
 .sm-style-full-height .sub-menu a:hover {
-
-	+ .caret svg {
-		color: var(--hovertextcolor);
-		position: relative;
-		z-index: 1;
-	}
 
 	&::after {
 		width: 100%;

--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -139,6 +139,57 @@
 	}
 }
 
+/* Showing Menu Sidebar animation. */
+.is-menu-sidebar {
+
+	.header-menu-sidebar {
+		visibility: visible;
+	}
+
+	&.menu_sidebar_slide_left {
+
+		.header-menu-sidebar {
+			transform: translate3d(0, 0, 0);
+			left: 0;
+		}
+	}
+
+	&.menu_sidebar_slide_right {
+
+		.header-menu-sidebar {
+			transform: translate3d(0, 0, 0);
+			right: 0;
+		}
+	}
+
+	&.menu_sidebar_pull_right,
+	&.menu_sidebar_pull_left {
+
+		.header-menu-sidebar {
+			transform: translateX(0);
+		}
+	}
+
+	&.menu_sidebar_dropdown {
+
+		.header-menu-sidebar {
+			height: auto;
+		}
+
+		.header-menu-sidebar-inner {
+			max-height: 400px;
+			padding: 20px 0;
+		}
+	}
+
+	&.menu_sidebar_full_canvas {
+
+		.header-menu-sidebar {
+			opacity: 1;
+		}
+	}
+}
+
 .header-menu-sidebar .menu-item-nav-search {
 	display: flex;
 	align-items: center;
@@ -157,14 +208,19 @@
 	transition: all 0.3s linear;
 	visibility: hidden;
 	opacity: 0;
-	pointer-events: none;
 
 	.is-menu-sidebar & {
 		visibility: visible;
 		opacity: 1;
-		pointer-events: unset;
 	}
 }
 
 //</editor-fold>
 
+.hfg-pe {
+	pointer-events: none;
+
+	.is-menu-sidebar & {
+		pointer-events: unset;
+	}
+}

--- a/assets/scss/elements/_mega-menu.scss
+++ b/assets/scss/elements/_mega-menu.scss
@@ -173,7 +173,8 @@
 		}
 
 		.neve-mega-menu:hover > .sub-menu,
-		.neve-mega-menu:focus > .sub-menu {
+		.neve-mega-menu:focus > .sub-menu,
+		.neve-mega-menu:focus-within > .sub-menu {
 			opacity: 1;
 			visibility: visible;
 			pointer-events: all;

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
 	"format": "phpcbf --standard=phpcs.xml --report-summary --report-source -s  --runtime-set testVersion 7.0- ",
-	"format-fix-exit": "\"vendor/bin/phpcbf-fix-exit-0\" --standard=phpcs.xml --report-summary --report-source -s  --runtime-set testVersion 7.0- ",
+	"format-fix-exit": "phpcbf-fix-exit-0 --standard=phpcs.xml --report-summary --report-source -s  --runtime-set testVersion 7.0- ",
 	"phpcs": "phpcs --standard=phpcs.xml -s  --runtime-set testVersion 7.0-",
 	"lint": "composer run-script phpcs",
 	"phpcs-i": "phpcs -i",


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This PR will revert accessibility changes and should revert the menu functionality to how it worked prior to the 3.4.8 release.
Rollback changes from https://github.com/Codeinwp/neve/pull/3696

Works with changes for pro from here: https://github.com/Codeinwp/neve-pro-addon/pull/2291

Will reopen:
https://github.com/Codeinwp/neve/issues/2935.
https://github.com/Codeinwp/neve/issues/3731.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- 
- 

<!-- Issues that this pull request closes. -->
Closes #3750.
Closes #3752.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
