### PR TITLE
fix: make body_class hook signature similar to WP's

### DIFF
--- a/inc/customizer/defaults/layout.php
+++ b/inc/customizer/defaults/layout.php
@@ -85,7 +85,7 @@ trait Layout {
 			return false;
 		}
 
-		$body_classes = apply_filters( 'body_class', [] );
+		$body_classes = apply_filters( 'body_class', [], [] ); // @see https://developer.wordpress.org/reference/hooks/body_class/
 		return is_array( $body_classes ) && in_array( 'neve-off-canvas', $body_classes );
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

## body_class hook in Neve Theme
```
File: inc/customizer/defaults/layout.php
87: 
88: 		$body_classes = apply_filters( 'body_class', [] );
```
## body_class hook in WP
https://developer.wordpress.org/reference/hooks/body_class/

The `body_class` created in neve theme is made similar to the WP `body_class` hook. The `body_class` hook in neve theme has only 1 parameter passed which is different from the WP `body_class` where two parameters are used. This has resulted in a fatal error where third-party plugins and themes relied on `body_class` with two parameters.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

-  Use the `body_class` hook with two parameters in `functions.php` for now, which should result in a fatal error.
- 

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
