### PR TITLE
fix: solves one click install

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -152,4 +152,4 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
-        run: yarn run test:e2e:playwright specs/tpc/tpc-notice-install.spec.ts
+        run: yarn run test:e2e:playwright

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -152,4 +152,4 @@ jobs:
       - name: Install Playwright Browsers
         run: npx playwright install --with-deps chromium
       - name: Run Playwright tests
-        run: yarn run test:e2e:playwright
+        run: yarn run test:e2e:playwright specs/tpc/tpc-notice-install.spec.ts

--- a/bin/envs/sample-data/start.sh
+++ b/bin/envs/sample-data/start.sh
@@ -1,4 +1,5 @@
 wp --allow-root plugin is-installed wordpress-importer && wp --allow-root plugin update wordpress-importer ||  wp --allow-root plugin install wordpress-importer
+wp --allow-root plugin install templates-patterns-collection
 ##Setup core content.
 wp --allow-root plugin activate wordpress-importer
 curl -O https://wpcom-themes.svn.automattic.com/demo/theme-unit-test-data.xml

--- a/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
+++ b/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
@@ -5,7 +5,10 @@ test('test', async ({ page }) => {
 	await loginWithRequest('/wp-admin/index.php', page);
 
 	if (page.url().includes('wp-login.php')) {
-		throw new Error('Not logged in');
+		//throw new Error('Not logged in');
+		await page.getByLabel('Username or Email Address').fill('admin');
+		await page.getByLabel('Password').fill('admin');
+		await page.getByRole('button', { name: 'Log In' }).click();
 	}
 
 	await expect(page).toHaveURL(/wp-admin\/index.php/);

--- a/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
+++ b/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '@playwright/test';
+import { loginWithRequest } from '../../utils';
+
+test('test', async ({ page }) => {
+	await loginWithRequest('/wp-admin/index.php', page);
+
+	if (page.url().includes('wp-login.php')) {
+		throw new Error('Not logged in');
+	}
+
+	await expect(page).toHaveURL(/wp-admin\/index.php/);
+
+	await expect(page.locator('button.install-now')).toContainText(
+		'Try one of our ready to use Starter Sites'
+	);
+	await expect(page.locator('button.install-now')).toBeVisible();
+	await page.locator('button.install-now').click();
+
+	await expect(page.locator('button.install-now')).toContainText(
+		/(Activating|Installing)/
+	);
+
+	await page.waitForNavigation();
+
+	await expect(page).toHaveURL(
+		/wp-admin\/themes.php\?page=tiob-starter-sites&onboarding=yes/
+	);
+
+	await expect(page.locator('a.tab')).toContainText([
+		'All Categories',
+		'Free',
+		'Business',
+		'Portfolio',
+		'WooCommerce',
+		'Blog',
+		'Personal',
+		'Other',
+	]);
+
+	await page.goto('/wp-admin/index.php');
+
+	await expect(page).toHaveURL(/wp-admin\/index.php/);
+
+	await expect(page.locator('button.install-now')).not.toBeVisible();
+});

--- a/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
+++ b/e2e-tests/specs/tpc/tpc-notice-install.spec.ts
@@ -1,48 +1,55 @@
 import { test, expect } from '@playwright/test';
 import { loginWithRequest } from '../../utils';
 
-test('test', async ({ page }) => {
-	await loginWithRequest('/wp-admin/index.php', page);
+test.describe('Dashboard Notice', () => {
+	test('Starter Sites Plugin install from Dashboard Notice', async ({
+		page,
+	}) => {
+		await loginWithRequest('/wp-admin/index.php', page);
 
-	if (page.url().includes('wp-login.php')) {
-		//throw new Error('Not logged in');
-		await page.getByLabel('Username or Email Address').fill('admin');
-		await page.getByLabel('Password').fill('admin');
-		await page.getByRole('button', { name: 'Log In' }).click();
-	}
+		if (page.url().includes('wp-login.php')) {
+			//throw new Error('Not logged in');
+			await page.getByLabel('Username or Email Address').fill('admin');
+			await page.getByLabel('Password').fill('admin');
+			await page.getByRole('button', { name: 'Log In' }).click();
+		}
 
-	await expect(page).toHaveURL(/wp-admin\/index.php/);
+		await expect(page).toHaveURL(/wp-admin\/index.php/);
 
-	await expect(page.locator('button.install-now')).toContainText(
-		'Try one of our ready to use Starter Sites'
-	);
-	await expect(page.locator('button.install-now')).toBeVisible();
-	await page.locator('button.install-now').click();
+		await expect(page.locator('button.install-now')).toContainText(
+			'Try one of our ready to use Starter Sites'
+		);
+		await expect(page.locator('button.install-now')).toBeVisible();
 
-	await expect(page.locator('button.install-now')).toContainText(
-		/(Activating|Installing)/
-	);
+		await Promise.all([
+			page.waitForNavigation({
+				url: /wp-admin\/themes.php\?page=tiob-starter-sites&onboarding=yes/,
+			}),
+			page.locator('button.install-now').click(),
+			expect(page.locator('button.install-now')).toContainText(
+				/(Activating|Installing)/
+			),
+		]);
 
-	await page.waitForNavigation();
+		await expect(page).toHaveURL(
+			/wp-admin\/themes.php\?page=tiob-starter-sites&onboarding=yes/
+		);
 
-	await expect(page).toHaveURL(
-		/wp-admin\/themes.php\?page=tiob-starter-sites&onboarding=yes/
-	);
+		await expect(page.locator('a.tab')).toContainText([
+			'All Categories',
+			'Free',
+			'Business',
+			'Portfolio',
+			'WooCommerce',
+			'Blog',
+			'Personal',
+			'Other',
+		]);
 
-	await expect(page.locator('a.tab')).toContainText([
-		'All Categories',
-		'Free',
-		'Business',
-		'Portfolio',
-		'WooCommerce',
-		'Blog',
-		'Personal',
-		'Other',
-	]);
+		await page.goto('/wp-admin/index.php');
 
-	await page.goto('/wp-admin/index.php');
+		await expect(page).toHaveURL(/wp-admin\/index.php/);
 
-	await expect(page).toHaveURL(/wp-admin\/index.php/);
-
-	await expect(page.locator('button.install-now')).not.toBeVisible();
+		await expect(page.locator('button.install-now')).not.toBeVisible();
+	});
 });

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -22,7 +22,7 @@ class Plugin_Helper {
 	 */
 	public function get_plugin_state( $slug ) {
 		$plugin_link_suffix = $this->get_plugin_path( $slug );
-		if ( file_exists( NEVE_PLUGINS_DIR . $plugin_link_suffix ) ) {
+		if ( file_exists( WP_PLUGIN_DIR . '/' . $plugin_link_suffix ) ) {
 			return is_plugin_active( $plugin_link_suffix ) ? 'deactivate' : 'activate';
 		}
 
@@ -129,7 +129,7 @@ class Plugin_Helper {
 			return $default;
 		}
 
-		$plugin_data = get_plugin_data( NEVE_PLUGINS_DIR . $plugin_file );
+		$plugin_data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin_file );
 		if ( ! empty( $plugin_data ) && array_key_exists( 'Version', $plugin_data ) ) {
 			return $plugin_data['Version'];
 		}

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -117,7 +117,7 @@ class Admin {
 		if ( empty( $screen ) ) {
 			return;
 		}
-		if ( $screen->id !== 'dashboard' ) {
+		if ( ! in_array( $screen->id, [ 'dashboard', 'themes' ], true ) ) {
 			return;
 		}
 
@@ -656,7 +656,7 @@ class Admin {
 		?>
 		<script type="text/javascript">
 			function handleNoticeActions($) {
-				var actions = $('.nv-welcome-notice').find('.notice-dismiss,  .ti-return-dashboard, .install-now, .options-page-btn')
+				var actions = $('.nv-welcome-notice').find('.notice-dismiss, .ti-return-dashboard, .options-page-btn')
 				$.each(actions, function (index, actionButton) {
 					$(actionButton).on('click', function (e) {
 						e.preventDefault()

--- a/tests/php/static-analysis-stubs/config.php
+++ b/tests/php/static-analysis-stubs/config.php
@@ -4,3 +4,4 @@
  */
 
 define( 'WP_DEFAULT_THEME', 'neve' );
+define( 'WP_PLUGIN_DIR', '/plugins' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixes one click install not working anymore.
The plugin state was active even if the plugin was not present in environments where files use symbolic links.
I think this was introduced by the changes here: https://github.com/Codeinwp/neve/pull/3693

I took the liberty to use `WP_PLUGIN_DIR` constant witch seam to work more consistent inside Beadrock and also on other environments.

I've also tweaked the button behavior as it had a conflict with other JS actions that were closing the notice to early.

ToDo:
+ [x] Add playwright tests
(For the playwright tests to work I had to install TPC via wp-cli as permissions did not allow for folder creation.)

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
You can use:
```sh
wp option update neve_notice_dismissed no && wp plugin deactivate templates-patterns-collection && wp plugin delete templates-patterns-collection
```
between tests to reset the instance and test a new case.

1. Check that the TPC is installed and you are redirected properly
    + When TPC is not installed
    + When TPC is installed but not active
    + When TPC is installed and active 
2. Check that on Beadrock there are no errors.

<!-- Issues that this pull request closes. -->
Closes #3760.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
