### PR TITLE
fix: popup for colors in mega menu not appearing [#2286]

### DIFF
--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -1,23 +1,16 @@
 .neve-color-component {
-  .components-popover {
-	position: fixed !important;
-	.components-popover {
-	  position: absolute !important;
-	}
-  }
-  .components-popover .components-popover__content {
-	overflow: unset !important;
-  }
 
-  .components-custom-gradient-picker__gradient-bar {
-	position: relative;
-	border-radius: 24px;
-	z-index: 1;
-  }
-
-  .components-custom-gradient-picker__gradient-bar {
-	&:not(.has-gradient) {
-		opacity: 1;
+	.components-popover .components-popover__content {
+		overflow: unset !important;
 	}
-  }
+
+	.components-custom-gradient-picker__gradient-bar {
+		position: relative;
+		border-radius: 24px;
+		z-index: 1;
+
+		&:not(.has-gradient) {
+			opacity: 1;
+		}
+	}
 }


### PR DESCRIPTION
### Summary
Fixes the mega menu style settings not appearing

### Will affect the visual aspect of the product
NO


### Test instructions
- Bogdan was adding some style to fix a bug introduced by WP core 6.1. I removed that style since the issue seemed to be fixed. Please make sure that this fix doesn't break anything that was fixed before https://github.com/Codeinwp/neve-pro-addon/issues/2286#issuecomment-1369932584
- Check if the styles popups are appearing and working for the Mega menu ( see the issue's body )

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2286.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
