### PR TITLE
fix: cloudflare supecache install [#3769]

### DIFF
--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -52,6 +52,8 @@ class Plugin_Helper {
 				return $slug . '/adblock-notify.php';
 			case 'feedzy-rss-feeds':
 				return $slug . '/feedzy-rss-feed.php';
+			case 'wp-cloudflare-page-cache':
+				return $slug . '/wp-cloudflare-super-page-cache.php';
 			default:
 				return $slug . '/' . $slug . '.php';
 		}


### PR DESCRIPTION
### Summary
Updated the plugin path since for wp-cloudflare-page-cache it's not the expected pattern `$slug / $slug.php`

### Will affect visual aspect of the product
/NO


### Test instructions
- Go to Neve dashboard, plugins tab and install cloudflare supercache

<!-- Issues that this pull request closes. -->
Closes #3769.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
