### PR TITLE
chore: run potfile generation on build files instead of source

### DIFF
--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -20,7 +20,9 @@ jobs:
         run: |
          cd neve-head
          ls languages/
-         npm run makepot
+         composer install --no-dev --prefer-dist --no-progress --no-suggest
+         yarn install --frozen-lockfile
+         yarn run build
          ls languages/
       - name: Checkout Ref Head
         uses: actions/checkout@v2
@@ -31,7 +33,9 @@ jobs:
         run: |
          cd neve-base
          ls languages/
-         npm run makepot
+         composer install --no-dev --prefer-dist --no-progress --no-suggest
+         yarn install --frozen-lockfile
+         yarn run build
          ls languages/
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/.github/workflows/diff-translations.yml
+++ b/.github/workflows/diff-translations.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
          cd neve-head
          ls languages/
-         npm run build:makepot
+         npm run makepot
          ls languages/
       - name: Checkout Ref Head
         uses: actions/checkout@v2
@@ -31,7 +31,7 @@ jobs:
         run: |
          cd neve-base
          ls languages/
-         npm run build:makepot
+         npm run makepot
          ls languages/
       - name: Find Comment
         uses: peter-evans/find-comment@v1

--- a/bin/makepot.sh
+++ b/bin/makepot.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+docker run \
+  --user root \
+  --rm \
+  --volume  "$(pwd):/var/www/html/neve" \
+  wordpress:cli bash -c 'php -d memory_limit=1024M "$(which wp)" i18n make-pot ./neve/ ./neve/languages/neve.pot --headers={\"Last-Translator\":\"friends@themeisle.com\"\,\"Project-Id-Version\":\"Neve\"\,\"Report-Msgid-Bugs-To\":\"https://github.com/Codeinwp/neve/issues\"\} --allow-root --exclude=dist,src,e2e-tests '

--- a/bin/makepot.sh
+++ b/bin/makepot.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
+yarn dist
+
 docker run \
   --user root \
   --rm \
   --volume  "$(pwd):/var/www/html/neve" \
-  wordpress:cli bash -c 'php -d memory_limit=1024M "$(which wp)" i18n make-pot ./neve/ ./neve/languages/neve.pot --headers={\"Last-Translator\":\"friends@themeisle.com\"\,\"Project-Id-Version\":\"Neve\"\,\"Report-Msgid-Bugs-To\":\"https://github.com/Codeinwp/neve/issues\"\} --allow-root --exclude=dist,src,e2e-tests '
+  wordpress:cli bash -c 'php -d memory_limit=1024M "$(which wp)" i18n make-pot ./neve/dist ./neve/languages/neve.pot --headers={\"Last-Translator\":\"friends@themeisle.com\"\,\"Project-Id-Version\":\"Neve\"\,\"Report-Msgid-Bugs-To\":\"https://github.com/Codeinwp/neve/issues\"\} --allow-root '

--- a/languages/README.md
+++ b/languages/README.md
@@ -6,4 +6,4 @@ You can help getting Neve translated by using the [WordPress.org](https://transl
 
 You can run the following commands to build the translation file: 
 * `yarn install --frozen-lockfile`
-* `yarn run makepot`
+* `yarn run build:makepot`

--- a/languages/README.md
+++ b/languages/README.md
@@ -6,4 +6,4 @@ You can help getting Neve translated by using the [WordPress.org](https://transl
 
 You can run the following commands to build the translation file: 
 * `yarn install --frozen-lockfile`
-* `yarn run build:makepot`
+* `yarn run makepot`

--- a/package.json
+++ b/package.json
@@ -156,8 +156,7 @@
 		"webpack-cli": "^4.9.0"
 	},
 	"scripts": {
-		"build": "npm-run-all build:* && npm run makepot",
-		"makepot": "bash ./bin/makepot.sh",
+		"build": "npm-run-all build:*",
 		"build:ui-components": "wp-scripts build assets/apps/components/src/components.js --output-path=assets/apps/components/build --env=nevePackage",
 		"build:customizer": "wp-scripts build assets/apps/customizer-controls/src/controls.js --output-path=assets/apps/customizer-controls/build",
 		"build:ss-notice": "wp-scripts build assets/apps/starter-sites/src/notice.js --output-path=assets/apps/starter-sites/build",
@@ -165,7 +164,8 @@
 		"build:metabox": "wp-scripts build assets/apps/metabox/src/index.js --output-path=assets/apps/metabox/build",
 		"build:rollup": "rollup -c ./rollup.config.js",
 		"build:grunt": "grunt build",
-	    "test:e2e:playwright": "playwright test --config e2e-tests/playwright.config.ts --reporter=list",
+	  	"build:makepot": "bash ./bin/makepot.sh",
+	  	"test:e2e:playwright": "playwright test --config e2e-tests/playwright.config.ts --reporter=list",
 	    "phpcbf": "composer run-script format || true ",
 		"phpcs": "composer run-script phpcs",
 		"git:add": "git add *.css assets/**/*.css assets/**/*.js",

--- a/package.json
+++ b/package.json
@@ -156,8 +156,8 @@
 		"webpack-cli": "^4.9.0"
 	},
 	"scripts": {
-		"build": "npm-run-all build:*",
-		"build:makepot": "docker run --user root --rm --volume  \"$(pwd):/var/www/html/neve\" wordpress:cli bash -c 'php -d memory_limit=1024M \"$(which wp)\" i18n make-pot ./neve/ ./neve/languages/neve.pot --headers={\\\"Last-Translator\\\":\\\"friends@themeisle.com\\\"\\,\\\"Project-Id-Version\\\":\\\"Neve\\\"\\,\\\"Report-Msgid-Bugs-To\\\":\\\"https://github.com/Codeinwp/neve/issues\\\"\\} --allow-root --exclude=dist,build,bundle,e2e-tests '",
+		"build": "npm-run-all build:* && npm run makepot",
+		"makepot": "bash ./bin/makepot.sh",
 		"build:ui-components": "wp-scripts build assets/apps/components/src/components.js --output-path=assets/apps/components/build --env=nevePackage",
 		"build:customizer": "wp-scripts build assets/apps/customizer-controls/src/controls.js --output-path=assets/apps/customizer-controls/build",
 		"build:ss-notice": "wp-scripts build assets/apps/starter-sites/src/notice.js --output-path=assets/apps/starter-sites/build",


### PR DESCRIPTION
### Summary
Runs the POT generation and POT diff on JS build files instead of using the source files, mirroring wp.org behavior.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

Closes #3774
