### PR TITLE
fix: elementor checkout [#3610]

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -484,6 +484,8 @@ class Elementor extends Page_Builder_Base {
 
 	/**
 	 * Detect if a page is using the checkout widget.
+	 *
+	 * @return bool
 	 */
 	public static function is_elementor_checkout() {
 		if ( ! class_exists( 'WooCommerce' ) ) {

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -457,6 +457,24 @@ class Elementor extends Page_Builder_Base {
 	}
 
 	/**
+	 * Detect if the a page is using the checkout widget.
+	 */
+	public static function is_elementor_checkout() {
+		if ( ! class_exists( '\ElementorPro\Plugin', false ) ) {
+			return false;
+		}
+
+		$is_elementor_checkout = false;
+		$page_id               = get_the_ID();
+		$elementor_data        = get_post_meta( $page_id, '_elementor_data', true );
+		if ( ! empty( $elementor_data ) && is_string( $elementor_data ) && strpos( $elementor_data, 'woocommerce-checkout-page' ) ) {
+			$is_elementor_checkout = true;
+		}
+
+		return $is_elementor_checkout;
+	}
+
+	/**
 	 * Conditionally suspense Woocommerce moditifications by Neve Pro if Elementor template applies to current page.
 	 *
 	 * @param  bool   $should_load Current loading status.

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -483,21 +483,32 @@ class Elementor extends Page_Builder_Base {
 	}
 
 	/**
-	 * Detect if the a page is using the checkout widget.
+	 * Detect if a page is using the checkout widget.
 	 */
 	public static function is_elementor_checkout() {
+		if ( ! class_exists( 'WooCommerce' ) ) {
+			return false;
+		}
+		if ( ! function_exists( 'is_checkout' ) && ! is_checkout() ) {
+			return false;
+		}
 		if ( ! class_exists( '\ElementorPro\Plugin', false ) ) {
 			return false;
+		}
+		if ( array_key_exists( 'checkout', self::$cache_cp_has_template ) ) {
+			return self::$cache_cp_has_template['checkout'];
 		}
 
 		$is_elementor_checkout = false;
 		$page_id               = get_the_ID();
 		$elementor_data        = get_post_meta( $page_id, '_elementor_data', true );
-		if ( ! empty( $elementor_data ) && is_string( $elementor_data ) && strpos( $elementor_data, 'woocommerce-checkout-page' ) ) {
+		if ( ! empty( $elementor_data ) && is_string( $elementor_data ) && ( strpos( $elementor_data, 'woocommerce-checkout-page' ) !== false ) ) {
 			$is_elementor_checkout = true;
 		}
 
-		return $is_elementor_checkout;
+		self::$cache_cp_has_template['checkout'] = $is_elementor_checkout;
+
+		return self::$cache_cp_has_template['checkout'];
 	}
 
 	/**

--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -249,10 +249,23 @@ class Woocommerce {
 	 * @return bool
 	 */
 	private function is_current_page_elementor_template() {
-		$is_shop_template    = Elementor::is_elementor_template( 'product_archive' );
+		/**
+		 * Detect if there is a template in Elementor for the shop page.
+		 */
+		$is_shop_template = Elementor::is_elementor_template( 'product_archive' );
+
+		/**
+		 * Detect if there is a template in Elementor for the single product page.
+		 */
 		$is_product_template = Elementor::is_elementor_template( 'single_product' );
 
-		return ( $is_shop_template || $is_product_template );
+		/**
+		 * Detect if a page is using the checkout widget.
+		 */
+		$is_elementor_checkout = Elementor::is_elementor_checkout();
+
+		// Prevent any modifications if any condition above are true.
+		return ( $is_shop_template || $is_product_template || $is_elementor_checkout );
 	}
 
 	/**

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -10,6 +10,7 @@
 
 namespace Neve\Core;
 
+use Neve\Compatibility\Elementor;
 use Neve\Compatibility\Starter_Content;
 use Neve\Core\Settings\Config;
 use Neve\Core\Settings\Mods;
@@ -312,7 +313,9 @@ class Front_End {
 			wp_register_style( 'neve-woocommerce', NEVE_ASSETS_URL . $style_path . ( ( NEVE_DEBUG ) ? '' : '.min' ) . '.css', array(), apply_filters( 'neve_version_filter', NEVE_VERSION ) );
 			wp_style_add_data( 'neve-woocommerce', 'rtl', 'replace' );
 			wp_style_add_data( 'neve-woocommerce', 'suffix', '.min' );
-			wp_enqueue_style( 'neve-woocommerce' );
+			if ( ! Elementor::is_elementor_checkout() ) {
+				wp_enqueue_style( 'neve-woocommerce' );
+			}
 		}
 
 		if ( class_exists( 'Easy_Digital_Downloads' ) ) {


### PR DESCRIPTION
### Summary
Prevent any modification for WooCommerce if the current page is the checkout one and the page is edited with Elementor and it has the Checkout widget on it

### Will affect the visual aspect of the product
NO

### Test instructions
- Check if the issue described **[here](https://github.com/Codeinwp/neve/issues/3610)** is fixed 
- Should be tested with https://github.com/Codeinwp/neve-pro-addon/pull/2308

<!-- Issues that this pull request closes. -->
Closes #3610.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
