### PR TITLE
fix: solves issue with specific customizer settings imported and spar…

### DIFF
--- a/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
+++ b/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
@@ -100,8 +100,11 @@ const TypefaceComponent = ({ control }) => {
 		},
 	};
 
-	if (!setVal || typeof setVal === 'string') {
+	if (!setVal) {
 		setVal = emptyValue;
+	}
+	if (typeof setVal === 'string') {
+		setVal = defaultParams;
 	}
 
 	const controlParams = control.params.input_attrs

--- a/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
+++ b/assets/apps/customizer-controls/src/typeface/TypefaceComponent.js
@@ -100,7 +100,7 @@ const TypefaceComponent = ({ control }) => {
 		},
 	};
 
-	if (!setVal) {
+	if (!setVal || typeof setVal === 'string') {
 		setVal = emptyValue;
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added an additional check if setting is not of correct type to be set to the default as to not break JS.
This was not related to Sparks, it will only use those controls if WooBooster is active, and WooBooster is only active if a version of Sparks is present.

Note: I suspect the settings were exported from a version of Neve where some Typography controls held a different value type or the id of the controls changed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Use the instructions provided here: https://github.com/Codeinwp/sparks-for-woocommerce/issues/148
2. Check that the Customizer does not break and no errors are thrown.

<!-- Issues that this pull request closes. -->
Closes Codeinwp/sparks-for-woocommerce#148.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
