### PR TITLE
fix: display featured post only on first page #3779

### DIFF
--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -58,6 +58,11 @@ class Template_Parts extends Base_View {
 			return;
 		}
 
+		// If the query is for a paged result and not for the first page don't display featured post.
+		if ( is_paged() ) {
+			return;
+		}
+
 		/**
 		 * Filters the content parts.
 		 *


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added an additional check to not display featured post on other pages than the first one of the blog post when using pagination.

When pagination is used the featured post should display only on the first page.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Enable featured post
2. Have enough posts to have pagination, and use the numbered pagination.
3. Check that the featured post is only visible on the first page.

<!-- Issues that this pull request closes. -->
Closes #3779.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
