### PR TITLE
fix: color picker issue on small screens

### DIFF
--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -1,6 +1,7 @@
 .customize-control .neve-color-component {
 	.components-popover {
 		position: fixed !important;
+		max-height: 430px;
 		.components-custom-gradient-picker__inserter{
 		  z-index: 1;
 		}
@@ -23,4 +24,21 @@
 			opacity: 1;
 		}
 	}
+}
+
+/*
+ * Style fixes for color picker inside mega-menu.
+ */
+#nv-mm-app {
+  .modal {
+	.components-popover {
+	  max-height: 430px;
+	}
+
+	.components-color-picker {
+	  .components-select-control .components-input-control__container {
+		max-width: 100%;
+	  }
+	}
+  }
 }

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -1,7 +1,17 @@
-.neve-color-component {
+.customize-control .neve-color-component {
+	.components-popover {
+		position: fixed !important;
+		.components-custom-gradient-picker__inserter{
+		  z-index: 1;
+		}
+		.components-popover {
+			position: absolute !important;
+		}
+	}
 
 	.components-popover .components-popover__content {
 		overflow: unset !important;
+		max-height: fit-content !important;
 	}
 
 	.components-custom-gradient-picker__gradient-bar {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Enforced the `max-height` for that container so that it does not produce the same visual defect.
Changed back the properties that were removed here: https://github.com/Codeinwp/neve-pro-addon/issues/2286
cc: @cristian-ungureanu did it work correctly inside Customizer for the gradient picker?

Better scoped the gradient style to apply only under Customizer controls so as to not apply to Mega Menu or other usages.


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
MM Color picker:
![image](https://user-images.githubusercontent.com/23024731/213682637-56d4fe0c-4c92-43ff-8a70-aea2de802d1d.png)

Customizer Color Picker small screen:
![image](https://user-images.githubusercontent.com/23024731/213682838-3ac9709c-e160-4b34-a47e-113236024136.png)


Customizer Color Picker small screen and Gradient popover:
![image](https://user-images.githubusercontent.com/23024731/213683014-47c8de08-843d-4d0b-bff9-b167a49856b4.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
Customizer:
1. Test the color picker with a screen height of < 800
2. Check that for Gradient Colors ( E.g. Buttons background ) the gradient selector does not completely block the parent pop-over
3. Check that inside MM the color picker opens as expected.

<!-- Issues that this pull request closes. -->
Closes #3783.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
