### PR TITLE
fix: sidebar logic change Codeinwp/neve-pro-addon#2335

### DIFF
--- a/inc/views/layouts/layout_sidebar.php
+++ b/inc/views/layouts/layout_sidebar.php
@@ -126,7 +126,7 @@ class Layout_Sidebar extends Base_View {
 			$sidebar_setup['content_width'] = 'neve_sitewide_content_width';
 			$sidebar_setup['has_widgets']   = is_active_sidebar( $sidebar_setup['sidebar_slug'] );
 
-			return apply_filters( 'neve_sidebar_setup_filter', $sidebar_setup );
+			return apply_filters( 'neve_before_returning_sidebar_setup', $sidebar_setup );
 		}
 
 		switch ( $context ) {
@@ -165,7 +165,7 @@ class Layout_Sidebar extends Base_View {
 
 		$sidebar_setup['has_widgets'] = is_active_sidebar( $sidebar_setup['sidebar_slug'] );
 
-		$sidebar_setup = apply_filters( 'neve_sidebar_setup_filter', $sidebar_setup );
+		$sidebar_setup = apply_filters( 'neve_before_returning_sidebar_setup', apply_filters( 'neve_sidebar_setup_filter', $sidebar_setup ) );
 
 		add_filter(
 			'neve_' . $context . '_sidebar_setup',


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The issue was that we added the `neve_sidebar_setup_filter` before returning the defaults if the **Enable Advanced Options** was disabled.

The Custom Post Types module uses the filter to add the required theme mods if the feature is enabled. However, by invoking it here, we short-circuited the check and made the toggle redundant. This would introduce a regression and would not return the expected defaults.

In order to maintain the functionality of the new sidebar module and not change existing logic and behavior I've added a new filter `neve_before_returning_sidebar_setup` that we can use to alter the sidebar data before returning from the `get_sidebar_setup()` function.

This has changes in PRO for the Sidebar Module to hook as before using the new filter.
Link: 

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/214865786-40735f1e-b494-46f2-91db-5485acac76d9.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that it solves the layout issues on staging.
2. Check that no regressions to the sidebar module are being introduced.

### 🕐 Worked Time:
~ 2h

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2335.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
