### PR TITLE
Add filter for the author post meta

### DIFF
--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -250,6 +250,7 @@ class Post_Meta extends Base_View {
 	 * Get the author meta.
 	 *
 	 * @param int | null $post_id Post id.
+	 * @param bool       $show_before Show the 'by' sting before the author name.
 	 *
 	 * @return string | false
 	 */
@@ -298,7 +299,18 @@ class Post_Meta extends Base_View {
 
 		$markup .= wp_kses_post( $link ) . '</span>';
 
-		return $markup;
+		/**
+		 * Filters the author post meta markup.
+		 *
+		 * @since 3.5.0
+		 *
+		 * @param int | null $post_id Post id.
+		 * @param $show_before bool Show the 'by' sting before the author name.
+		 * @param bool $markup The HTML markup used to display the post meta author.
+		 *
+		 * @return string
+		 */
+		return apply_filters( 'neve_filter_author_meta_markup', $post_id, $show_before, $markup );
 	}
 
 	/**

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -250,7 +250,7 @@ class Post_Meta extends Base_View {
 	 * Get the author meta.
 	 *
 	 * @param int | null $post_id Post id.
-	 * @param bool       $show_before Show the 'by' sting before the author name.
+	 * @param bool       $show_before Show the 'by' string before the author name.
 	 *
 	 * @return string | false
 	 */

--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -302,15 +302,17 @@ class Post_Meta extends Base_View {
 		/**
 		 * Filters the author post meta markup.
 		 *
-		 * @since 3.5.0
+		 * @since 3.5.2
 		 *
+		 * @param string $markup The HTML markup used to display the post meta author.
 		 * @param int | null $post_id Post id.
-		 * @param $show_before bool Show the 'by' sting before the author name.
-		 * @param bool $markup The HTML markup used to display the post meta author.
+		 * @param bool $show_before Show the 'by' sting before the author name.
 		 *
 		 * @return string
 		 */
-		return apply_filters( 'neve_filter_author_meta_markup', $post_id, $show_before, $markup );
+		$markup = apply_filters( 'neve_filter_author_meta_markup', $markup, $post_id, $show_before );
+
+		return wp_kses_post( $markup );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
For this task I had 2 options:
- Make the function global and wrap it in `if ( ! function_exists() )` to make it pluggable
- Add a filter over the result of this function

I choose to add a filter since this function could be used in other products. So, in order for our user to edit it, he could add the following code inside a child-theme:

```php
function neve_get_author_meta( $markup, $post_id, $show_before ) {
	global $post;

	if ( ! function_exists( 'coauthors_posts_links' ) ) {
		return $markup;
	}
	$link = coauthors_posts_links( $between = null, $betweenLast = null, $before = null, $after = null, $echo = false);
	$link = apply_filters( 'the_author_posts_link', $link );

	return wp_kses_post( $link ) . '';
}
add_filter( 'neve_filter_author_meta_markup', 'neve_get_author_meta', 10, 3 );
```

Note that the function has 3 parameters, so one could use them to edit the existing markup or do something with the post id. I also passed the `$show_before` attribute in case someone would need to know if the 'by' string should be displayed or not

### Will affect visual aspect of the product
NO


### Test instructions
- Install a child theme
- Install the co-authors plugin
- Set a second author for a post ( Note: the user role needs to be at least "Author", it won't be displayed otherwise )
- Add the mentioned function in functions.php file in your child-theme
- Make sure the author is enabled inside the meta control from the customizer
- Check the result on frontend

### Time
~ 1h 02 minutes in total

<!-- Issues that this pull request closes. -->
Closes #3778.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
