### PR TITLE
PHP 8.2 Support

### DIFF
--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -377,7 +377,7 @@ class Css_Prop {
 		if ( strpos( $value, ',' ) !== false ) {
 			$value = explode( ',', $value );
 
-			$value = array_map( 'self::quote_font_family', $value );
+			$value = array_map( 'Neve\Core\Styles\CSS_Prop::quote_font_family', $value );
 
 			return join( ',', $value );
 		}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
* Maintain support for a deprecated pattern (usage 'self' in callable argument) with PHP 8.2

ref: https://php.watch/versions/8.2/partially-supported-callable-deprecation#deprecated-patterns

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Make sure there is no PHP warning/error on PHP 8.2 on Neve Pro + Neve or only Neve

### Time
<!-- Describe how this pull request can be tested. -->
~ 1h 5min

<!-- Issues that this pull request closes. -->
Closes #3595 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
