### PR TITLE
Update tested up to Neve Pro version

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -113,7 +113,7 @@ add_filter(
 		$compatibilities['NevePro'] = [
 			'basefile'  => defined( 'NEVE_PRO_BASEFILE' ) ? NEVE_PRO_BASEFILE : '',
 			'required'  => '2.1',
-			'tested_up' => '2.4',
+			'tested_up' => '2.5',
 		];
 
 		return $compatibilities;


### PR DESCRIPTION
### Summary
- Change the tested up-to version of Neve Pro

### Will affect visual aspect of the product
NO

### Test instructions
- Update Neve and Neve Pro
- Check if the message is still displayed
- Check if this version works with Neve Pro 2.1 ( min required version ) ( eg: there are no fatal errors that break the website )

### Time
~ 2 minutes

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2343.
<!-- Should look like this: `Closes #1, #2, #3.` . -->