### PR TITLE
fix: polylang infinite scroll [#3803]

### DIFF
--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -65,7 +65,7 @@ class Pagination extends Base_View {
 
 		/**
 		 * If homepage is set to 'A static page', there will be a parameter inside the query named 'pagename'.
-		 * That parameter is the title of the blog page and because of ot  the WP_Query will return 0 posts.
+		 * That parameter is the title of the blog page and because of it the WP_Query will return 0 posts.
 		 * Here, we unset it. We can't reset the query because we can lose search parameters for example.
 		 */
 		if ( array_key_exists( 'pagename', $args ) ) {

--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -55,15 +55,9 @@ class Pagination extends Base_View {
 			return new \WP_REST_Response( '' );
 		}
 
-		$query_args = $request->get_body();
-		$args       = json_decode( $query_args, true );
-
-		$per_page = get_option( 'posts_per_page' );
-		if ( $per_page > 100 ) {
-			$per_page = 100;
-		}
-
-		$args['posts_per_page']      = $per_page;
+		$args                        = [];
+		$per_page                    = get_option( 'posts_per_page' );
+		$args['posts_per_page']      = $per_page > 100 ? 100 : $per_page;
 		$args['post_type']           = 'post';
 		$args['paged']               = $request['page_number'];
 		$args['ignore_sticky_posts'] = 1;

--- a/inc/views/pluggable/pagination.php
+++ b/inc/views/pluggable/pagination.php
@@ -55,9 +55,24 @@ class Pagination extends Base_View {
 			return new \WP_REST_Response( '' );
 		}
 
-		$args                        = [];
-		$per_page                    = get_option( 'posts_per_page' );
-		$args['posts_per_page']      = $per_page > 100 ? 100 : $per_page;
+		$query_args = $request->get_body();
+		$args       = json_decode( $query_args, true );
+
+		$per_page = get_option( 'posts_per_page' );
+		if ( $per_page > 100 ) {
+			$per_page = 100;
+		}
+
+		/**
+		 * If homepage is set to 'A static page', there will be a parameter inside the query named 'pagename'.
+		 * That parameter is the title of the blog page and because of ot  the WP_Query will return 0 posts.
+		 * Here, we unset it. We can't reset the query because we can lose search parameters for example.
+		 */
+		if ( array_key_exists( 'pagename', $args ) ) {
+			unset( $args['pagename'] );
+		}
+
+		$args['posts_per_page']      = $per_page;
 		$args['post_type']           = 'post';
 		$args['paged']               = $request['page_number'];
 		$args['ignore_sticky_posts'] = 1;


### PR DESCRIPTION
### Summary
Fix the issue with infinite scroll when Polylang is active. The problem was that `$args` came with a parameter named "pagename." This parameter makes WP_Query return an empty string.

### Will affect the visual aspect of the product
NO

### Test instructions
- Install Polylang
- Add two languages
- Add posts and translations for those posts
- Enable infinite scroll in the customizer
- Test the following steps for the "Your homepage displays" customizer option set both as " Your latest posts" and "A static page."
- Check that infinite scroll works in both languages.
- Check that infinite scroll works on the search page.

### Time
~ 1h 20min

<!-- Issues that this pull request closes. -->
Closes #3803.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
