### PR TITLE
Typekit fonts when loading them locally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
 	"codeinwp/themeisle-sdk": "^3.2",
-    "wptt/webfont-loader": "dev-main"
+    "wptt/webfont-loader": "master"
   },
   "repositories": [
 	{
@@ -64,7 +64,7 @@
 	"installer-disable": "true"
   },
   "require-dev": {
-    "codeinwp/phpcs-ruleset": "master",
+    "codeinwp/phpcs-ruleset": "dev-main",
     "phpstan/phpstan": "0.12.90",
     "szepeviktor/phpstan-wordpress": "^0.7.6",
     "php-stubs/woocommerce-stubs": "^5.4"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
 	"codeinwp/themeisle-sdk": "^3.2",
-    "wptt/webfont-loader": "master"
+    "wptt/webfont-loader": "dev-main"
   },
   "repositories": [
 	{

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   },
   "require": {
 	"codeinwp/themeisle-sdk": "^3.2",
-    "wptt/webfont-loader": "master"
+    "wptt/webfont-loader": "dev-master"
   },
   "repositories": [
 	{

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
 	  "homepage": "https://themeisle.com"
 	}
   ],
-	
+
   "type": "wordpress-theme",
   "support": {
 	"issues": "https://github.com/Codeinwp/neve/issues",
@@ -18,8 +18,14 @@
   },
   "require": {
 	"codeinwp/themeisle-sdk": "^3.2",
-    "wptt/webfont-loader": "^1.1"
+    "wptt/webfont-loader": "master"
   },
+  "repositories": [
+	{
+	  "type": "vcs",
+	  "url": "https://github.com/cristian-ungureanu/webfont-loader"
+	}
+  ],
   "autoload": {
 	"psr-4": {
 	  "HFG\\": "header-footer-grid/"

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,7 @@
 	"installer-disable": "true"
   },
   "require-dev": {
-    "codeinwp/phpcs-ruleset": "dev-main",
+    "codeinwp/phpcs-ruleset": "master",
     "phpstan/phpstan": "0.12.90",
     "szepeviktor/phpstan-wordpress": "^0.7.6",
     "php-stubs/woocommerce-stubs": "^5.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f0f3b0ba1a788bb29a4ddaa7cb5dd8d",
+    "content-hash": "15c9395b002e54b77b5fa9fb33bb5fc0",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.32",
+            "version": "3.2.34",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "76c09a05d01b83f620db230146e264bdb9a38af6"
+                "reference": "f8d3a16d65a77d4f31dbfa1ffcb5ca3ac5c9979b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/76c09a05d01b83f620db230146e264bdb9a38af6",
-                "reference": "76c09a05d01b83f620db230146e264bdb9a38af6",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/f8d3a16d65a77d4f31dbfa1ffcb5ca3ac5c9979b",
+                "reference": "f8d3a16d65a77d4f31dbfa1ffcb5ca3ac5c9979b",
                 "shasum": ""
             },
             "require-dev": {
@@ -42,22 +42,22 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.32"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.34"
             },
-            "time": "2022-11-30T20:49:33+00:00"
+            "time": "2023-01-31T08:26:01+00:00"
         },
         {
             "name": "wptt/webfont-loader",
-            "version": "v1.1.3",
+            "version": "dev-master",
             "source": {
                 "type": "git",
-                "url": "https://github.com/WPTT/webfont-loader.git",
-                "reference": "19fa29ba8d82bed018fb8c6f949799739c61356c"
+                "url": "https://github.com/cristian-ungureanu/webfont-loader.git",
+                "reference": "0294f21a20549f0c5e79700399946583dfa496b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WPTT/webfont-loader/zipball/19fa29ba8d82bed018fb8c6f949799739c61356c",
-                "reference": "19fa29ba8d82bed018fb8c6f949799739c61356c",
+                "url": "https://api.github.com/repos/cristian-ungureanu/webfont-loader/zipball/0294f21a20549f0c5e79700399946583dfa496b0",
+                "reference": "0294f21a20549f0c5e79700399946583dfa496b0",
                 "shasum": ""
             },
             "require": {
@@ -69,8 +69,19 @@
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "wptrt/wpthemereview": "^0.2.1"
             },
+            "default-branch": true,
             "type": "package",
-            "notification-url": "https://packagist.org/downloads/",
+            "scripts": {
+                "standards:check": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcs"
+                ],
+                "standards:fix": [
+                    "@php ./vendor/squizlabs/php_codesniffer/bin/phpcbf"
+                ],
+                "lint": [
+                    "@php ./vendor/bin/parallel-lint --exclude .git --exclude vendor ."
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -83,13 +94,13 @@
             "description": "Locally host webfonts.",
             "homepage": "https://github.com/WPTT/font-loader",
             "keywords": [
-                "wordpress"
+                "WordPress"
             ],
             "support": {
                 "issues": "https://github.com/WPTT/font-loader/issues",
                 "source": "https://github.com/WPTT/font-loader"
             },
-            "time": "2022-10-21T07:56:48+00:00"
+            "time": "2023-02-03T11:14:21+00:00"
         }
     ],
     "packages-dev": [
@@ -182,27 +193,27 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.1",
+            "version": "v0.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
-                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "*",
-                "phpcompatibility/php-compatibility": "^9.0",
-                "sensiolabs/security-checker": "^4.1.0"
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -223,6 +234,10 @@
                     "email": "franck.nijhof@dealerdirect.com",
                     "homepage": "http://www.frenck.nl",
                     "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
@@ -234,6 +249,7 @@
                 "codesniffer",
                 "composer",
                 "installer",
+                "phpcbf",
                 "phpcs",
                 "plugin",
                 "qa",
@@ -248,28 +264,28 @@
                 "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
                 "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
             },
-            "time": "2020-12-07T18:04:37+00:00"
+            "time": "2022-02-04T12:51:07+00:00"
         },
         {
             "name": "php-stubs/woocommerce-stubs",
-            "version": "v5.8.0",
+            "version": "v5.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "e3978c519fb1e51585e8c86b489b802aa0c64cee"
+                "reference": "486ccff117badfab94c404065d37a77d632d7db5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/e3978c519fb1e51585e8c86b489b802aa0c64cee",
-                "reference": "e3978c519fb1e51585e8c86b489b802aa0c64cee",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/486ccff117badfab94c404065d37a77d632d7db5",
+                "reference": "486ccff117badfab94c404065d37a77d632d7db5",
                 "shasum": ""
             },
             "require": {
                 "php-stubs/wordpress-stubs": "^5.3.0"
             },
             "require-dev": {
-                "giacocorsiglia/stubs-generator": "^0.5.0",
-                "php": "~7.1"
+                "php": "~7.1",
+                "php-stubs/generator": "^0.8.0"
             },
             "suggest": {
                 "symfony/polyfill-php73": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
@@ -290,30 +306,33 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v5.8.0"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v5.9.1"
             },
-            "time": "2021-10-15T14:13:09+00:00"
+            "time": "2022-04-30T06:35:48+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v5.8.1",
+            "version": "v5.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "8b333464d3183bccde2fdbb814e3cae592434943"
+                "reference": "13ecf204a7e6d215a7c0d23e2aa27940fe617717"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/8b333464d3183bccde2fdbb814e3cae592434943",
-                "reference": "8b333464d3183bccde2fdbb814e3cae592434943",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/13ecf204a7e6d215a7c0d23e2aa27940fe617717",
+                "reference": "13ecf204a7e6d215a7c0d23e2aa27940fe617717",
                 "shasum": ""
             },
             "replace": {
                 "giacocorsiglia/wordpress-stubs": "*"
             },
             "require-dev": {
-                "giacocorsiglia/stubs-generator": "^0.5.0",
-                "php": "~7.1"
+                "nikic/php-parser": "< 4.12.0",
+                "php": "~7.3 || ~8.0",
+                "php-stubs/generator": "^0.8.1",
+                "phpdocumentor/reflection-docblock": "^5.3",
+                "phpstan/phpstan": "^1.2"
             },
             "suggest": {
                 "paragonie/sodium_compat": "Pure PHP implementation of libsodium",
@@ -334,9 +353,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.8.1"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v5.9.5"
             },
-            "time": "2021-09-09T22:10:19+00:00"
+            "time": "2022-11-09T05:32:14+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -402,16 +421,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-paragonie",
-            "version": "1.3.1",
+            "version": "1.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie.git",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43"
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/ddabec839cc003651f2ce695c938686d1086cf43",
-                "reference": "ddabec839cc003651f2ce695c938686d1086cf43",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityParagonie/zipball/bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
+                "reference": "bba5a9dfec7fcfbd679cfaf611d86b4d3759da26",
                 "shasum": ""
             },
             "require": {
@@ -448,26 +467,27 @@
                 "paragonie",
                 "phpcs",
                 "polyfill",
-                "standards"
+                "standards",
+                "static analysis"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityParagonie"
             },
-            "time": "2021-02-15T10:24:51+00:00"
+            "time": "2022-10-25T01:46:02+00:00"
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.2",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
-                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
+                "reference": "b6c1e3ee1c35de6c41a511d5eb9bd03e447480a5",
                 "shasum": ""
             },
             "require": {
@@ -502,13 +522,14 @@
                 "compatibility",
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-07-21T11:09:57+00:00"
+            "time": "2022-10-24T09:00:36+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -576,28 +597,29 @@
         },
         {
             "name": "sirbrillig/phpcs-variable-analysis",
-            "version": "v2.11.2",
+            "version": "v2.11.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sirbrillig/phpcs-variable-analysis.git",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e"
+                "reference": "0f25a3766f26df91d6bdda0c8931303fc85499d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
-                "reference": "3fad28475bfbdbf8aa5c440f8a8f89824983d85e",
+                "url": "https://api.github.com/repos/sirbrillig/phpcs-variable-analysis/zipball/0f25a3766f26df91d6bdda0c8931303fc85499d7",
+                "reference": "0f25a3766f26df91d6bdda0c8931303fc85499d7",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
-                "squizlabs/php_codesniffer": "^3.5"
+                "squizlabs/php_codesniffer": "^3.5.6"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "limedeck/phpunit-detailed-printer": "^3.1 || ^4.0 || ^5.0",
-                "phpstan/phpstan": "^0.11.8",
-                "phpunit/phpunit": "^5.0 || ^6.5 || ^7.0 || ^8.0",
-                "sirbrillig/phpcs-import-detection": "^1.1"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.0",
+                "phpcsstandards/phpcsdevcs": "^1.1",
+                "phpstan/phpstan": "^1.7",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.21 || ^6.5 || ^7.0 || ^8.0 || ^9.0",
+                "sirbrillig/phpcs-import-detection": "^1.1",
+                "vimeo/psalm": "^0.2 || ^0.3 || ^1.1 || ^4.24 || ^5.0@beta"
             },
             "type": "phpcodesniffer-standard",
             "autoload": {
@@ -620,25 +642,29 @@
                 }
             ],
             "description": "A PHPCS sniff to detect problems with variables.",
+            "keywords": [
+                "phpcs",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/sirbrillig/phpcs-variable-analysis/issues",
                 "source": "https://github.com/sirbrillig/phpcs-variable-analysis",
                 "wiki": "https://github.com/sirbrillig/phpcs-variable-analysis/wiki"
             },
-            "time": "2021-07-06T23:45:17+00:00"
+            "time": "2023-01-05T18:45:16+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.6.1",
+            "version": "3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
-                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/1359e176e9307e906dc3d890bcc9603ff6d90619",
+                "reference": "1359e176e9307e906dc3d890bcc9603ff6d90619",
                 "shasum": ""
             },
             "require": {
@@ -681,20 +707,20 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2021-10-11T04:00:11+00:00"
+            "time": "2022-06-18T07:21:10+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.23.0",
+            "version": "v1.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010"
+                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/fba8933c384d6476ab14fb7b8526e5287ca7e010",
-                "reference": "fba8933c384d6476ab14fb7b8526e5287ca7e010",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
+                "reference": "9e8ecb5f92152187c4799efd3c96b78ccab18ff9",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +729,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.23-dev"
+                    "dev-main": "1.27-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -711,12 +737,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php73\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -744,7 +770,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.27.0"
             },
             "funding": [
                 {
@@ -760,7 +786,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
+            "time": "2022-11-03T14:55:06+00:00"
         },
         {
             "name": "szepeviktor/phpstan-wordpress",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15c9395b002e54b77b5fa9fb33bb5fc0",
+    "content-hash": "c666878551c8e649d4d6db2656724b77",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
@@ -981,6 +981,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "wptt/webfont-loader": 20,
         "codeinwp/phpcs-ruleset": 20
     },
     "prefer-stable": true,

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,6 +36,6 @@ parameters:
     ignoreErrors:
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
         - '#Parameter \#2 \$default of function get_theme_mod expects#'
-        - '#Parameter \#2 \$args of method WP_Customize_Manager::add_setting() expects#'
+        - '#Parameter \#2 \$args of method WP_Customize_Manager::add_setting\(\) expects#'
 includes:
     - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,42 +1,42 @@
 parameters:
-    level: 5
-    paths:
-        - %currentWorkingDirectory%/functions.php
-        - %currentWorkingDirectory%/globals
-        - %currentWorkingDirectory%/inc
-        - %currentWorkingDirectory%/header-footer-grid/Core
-        - %currentWorkingDirectory%/header-footer-grid/loader.php
-        - %currentWorkingDirectory%/header-footer-grid/Main.php
-        - %currentWorkingDirectory%/header-footer-grid/functions-migration.php
-        - %currentWorkingDirectory%/header-footer-grid/functions-template.php
-    bootstrapFiles:
-        - %currentWorkingDirectory%/inc/core/styles/generator.php
-        - %currentWorkingDirectory%/inc/core/theme_info.php
-        - %currentWorkingDirectory%/vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/config.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/header-footer-elementor.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/yoast-wordpress-seo.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/rankmath.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/neve-pro.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/legacy-wp-core.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/breadcrumb-navxt.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/seopress.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/pwa.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/web-stories-wp.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/lifter-lms.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/bb-header-footer.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/elementor.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/elementor-pro.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/amp-wp.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/vip-go-mu-plugins.php
-        - %currentWorkingDirectory%/tests/php/static-analysis-stubs/easy-digital-downloads.php
-        - %currentWorkingDirectory%/vendor/wptt/webfont-loader/wptt-webfont-loader.php
-    dynamicConstantNames:
-        - NEVE_DEBUG
+	level: 5
+	paths:
+		- %currentWorkingDirectory%/functions.php
+		- %currentWorkingDirectory%/globals
+		- %currentWorkingDirectory%/inc
+		- %currentWorkingDirectory%/header-footer-grid/Core
+		- %currentWorkingDirectory%/header-footer-grid/loader.php
+		- %currentWorkingDirectory%/header-footer-grid/Main.php
+		- %currentWorkingDirectory%/header-footer-grid/functions-migration.php
+		- %currentWorkingDirectory%/header-footer-grid/functions-template.php
+	bootstrapFiles:
+		- %currentWorkingDirectory%/inc/core/styles/generator.php
+		- %currentWorkingDirectory%/inc/core/theme_info.php
+		- %currentWorkingDirectory%/vendor/php-stubs/woocommerce-stubs/woocommerce-stubs.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/config.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/header-footer-elementor.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/yoast-wordpress-seo.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/rankmath.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/neve-pro.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/legacy-wp-core.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/breadcrumb-navxt.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/seopress.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/pwa.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/web-stories-wp.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/lifter-lms.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/bb-header-footer.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/elementor.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/elementor-pro.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/amp-wp.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/vip-go-mu-plugins.php
+		- %currentWorkingDirectory%/tests/php/static-analysis-stubs/easy-digital-downloads.php
+		- %currentWorkingDirectory%/vendor/wptt/webfont-loader/wptt-webfont-loader.php
+	dynamicConstantNames:
+		- NEVE_DEBUG
 	reportUnmatchedIgnoredErrors: false
-    ignoreErrors:
-        - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
-        - '#Parameter \#2 \$default of function get_theme_mod expects#'
-        - '#Parameter \#2 \$args of method WP_Customize_Manager::add_setting\(\) expects#'
+	ignoreErrors:
+		- '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
+		- '#Parameter \#2 \$default of function get_theme_mod expects#'
+		- '#Parameter \#2 \$args of method WP_Customize_Manager::add_setting\(\) expects#'
 includes:
-    - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon
+	- %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -36,5 +36,6 @@ parameters:
     ignoreErrors:
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
         - '#Parameter \#2 \$default of function get_theme_mod expects#'
+        - '#Parameter \#2 \$args of method WP_Customize_Manager::add_setting() expects#'
 includes:
     - %currentWorkingDirectory%/vendor/szepeviktor/phpstan-wordpress/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,6 +33,7 @@ parameters:
         - %currentWorkingDirectory%/vendor/wptt/webfont-loader/wptt-webfont-loader.php
     dynamicConstantNames:
         - NEVE_DEBUG
+	reportUnmatchedIgnoredErrors: false
     ignoreErrors:
         - '#^Function apply_filters(_ref_array)? invoked with [34567] parameters, 2 required\.$#'
         - '#Parameter \#2 \$default of function get_theme_mod expects#'


### PR DESCRIPTION
### Summary
In this PR I changed webfont-loader to point to my fork where I fixed the issue.

The issue was that when downloading a font with multiple font weights from Typekit, the file name was the same resulting in one font weight overwriting another's file.

### Will affect visual aspect of the product
NO

### Notes for the reviewer:
Please have a look over this PR: https://github.com/WPTT/webfont-loader/pull/21

### Test instructions
- Use the following Typekit project Id to replicate the issue and see if it's fixed: set1ymb
- Enable local loading of fonts.
- Choose Sofia-pro for the body font.
- Check on the front end if the issue is the same as in the customizer.
- After you test with that project id, you can do another round of tests with this one: vds6kqq, since it adds more options.
- Please also test if Google fonts loading locally are affected in any way.

### Time
~ 4h 30min

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2350.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
