### PR TITLE
Vertical align for cover posts

### DIFF
--- a/assets/scss/components/elements/blog/_blogpost-covers.scss
+++ b/assets/scss/components/elements/blog/_blogpost-covers.scss
@@ -2,6 +2,7 @@
 $overlay: rgba(0, 0, 0, 0.75);
 
 .cover-post {
+	display: flex;
 	box-shadow: var(--boxshadow, none);
 	position: relative;
 	min-height: 300px;


### PR DESCRIPTION
### Summary
Added a display flex property on the parent of the inner class so the inner class can be aligned vertically.

### Will affect the visual aspect of the product
NO

### Test instructions
- Switch to cover layout
- Check if all controls from the customizer still work
- Try to add a featured post and see if it works properly

### Time
24 min

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2354.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
