### PR TITLE
Missing padding for button appearance control

### DIFF
--- a/assets/apps/components/src/Controls/ButtonAppearance.js
+++ b/assets/apps/components/src/Controls/ButtonAppearance.js
@@ -336,7 +336,11 @@ const ButtonAppearance = ({
 	return (
 		<div className="neve-button-appearance-control">
 			{label && <span className="customize-control-title">{label}</span>}
-			<div className="neve-white-background-control">
+			<div
+				className={`neve-white-background-control ${
+					type ? 'has-type' : ''
+				}`}
+			>
 				<span className="customize-control-title">
 					{__('Style', 'neve')}
 				</span>

--- a/assets/apps/components/src/Style/_button-appearance.scss
+++ b/assets/apps/components/src/Style/_button-appearance.scss
@@ -14,7 +14,7 @@
 	}
   }
 
-  .neve-white-background-control {
+  .neve-white-background-control.has-type {
     padding-bottom: 0;
   }
 


### PR DESCRIPTION
### Summary
- The control was missing the padding because we previously added [this CSS ](https://github.com/Codeinwp/neve/blob/master/assets/apps/components/src/Style/_button-appearance.scss#L17-L19)
- We added that CSS to fix another issue: https://vertis.d.pr/i/ejZGVj, but we didn't take into consideration when the style is not set on filled or outlined. This PR should fix both cases.

### Will affect the visual aspect of the product
NO

### Test instructions
- Go to customizer, add a button inside the header
- Edit that button and check the appearance control inside the style tab
- Check the Primary / Secondary button controls from Customizer -> Buttons

### Time
26 min

<!-- Issues that this pull request closes. -->
Closes #3809.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
