### PR TITLE
Cart-link magic tag not working correctly

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -94,10 +94,17 @@ class Magic_Tags {
 			return $input;
 		}
 
-		if ( strpos( $input, 'http://{current_single_url}' ) !== false || strpos( $input, 'https://{current_single_url}' ) !== false ) {
-			$input = str_replace( 'http://{current_single_url}', '{current_single_url}', $input );
-			$input = str_replace( 'https://{current_single_url}', '{current_single_url}', $input );
-		}
+		// Define the regular expression to match http/https links containing magic tags
+		$regex = '/(https?:\/\/\{[^}]+\})/';
+
+		// Replace any matches with just the magic tag name
+		$input = preg_replace_callback(
+			$regex,
+			function( $matches ) {
+				return str_replace( [ 'https://', 'http://' ], '', $matches[1] );
+			},
+			$input
+		);
 
 		return preg_replace_callback(
 			'/\\{\s?\b(?:' . self::$magic_tag_regex . ')\b\s?\\}/',

--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -95,16 +95,10 @@ class Magic_Tags {
 		}
 
 		// Define the regular expression to match http/https links containing magic tags
-		$regex = '/(https?:\/\/\{[^}]+\})/';
+		$regex = '/(https?:\/\/)(\{[^}]+\})/';
 
 		// Replace any matches with just the magic tag name
-		$input = preg_replace_callback(
-			$regex,
-			function( $matches ) {
-				return str_replace( [ 'https://', 'http://' ], '', $matches[1] );
-			},
-			$input
-		);
+		$input = preg_replace( $regex, '$2', $input );
 
 		return preg_replace_callback(
 			'/\\{\s?\b(?:' . self::$magic_tag_regex . ')\b\s?\\}/',


### PR DESCRIPTION
### Summary
- Properly replace magic tag in this format: `https://{magic_tag}` and `http://{magic_tag}`, no matter the magic tag.

### Will affect visual aspect of the product
NO

### Test instructions
- Install WC, Neve, Neve Pro
- Create a sample product
- Create a custom layout and choose a rule to restrict it with product post_type
- Try to use {cart_link} magic link in the editor, you'll see it works as a text etc.
- Try to add {cart_link} for link of the Button or Button Groups blocks, you'll see on the frontend;
- Try to use it like "Link Option" https://vertis.d.pr/i/oWfjBe
- Try and see if other magic tags that return URLs like `{current_single_url}` are still working fine 

### Time
1h

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2266.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
