### PR TITLE
Fix image margin bottom

### DIFF
--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -58,7 +58,7 @@ pre {
 .excerpt-wrap {
 	--listpad: 20px;
 	--liststyle: disc;
-	--contentimgmargin: 1em;
+	--contentimgmargin: 24px;
 
 	ul,
 	ol {

--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -67,6 +67,10 @@ pre {
 	li {
 		margin-top: $spacing-xs;
 	}
+
+	.wp-block-image {
+		margin-bottom: 1em;
+	}
 }
 
 // === Content Floating Alignments === //

--- a/assets/scss/components/elements/_content.scss
+++ b/assets/scss/components/elements/_content.scss
@@ -58,6 +58,7 @@ pre {
 .excerpt-wrap {
 	--listpad: 20px;
 	--liststyle: disc;
+	--contentimgmargin: 1em;
 
 	ul,
 	ol {
@@ -66,10 +67,6 @@ pre {
 
 	li {
 		margin-top: $spacing-xs;
-	}
-
-	.wp-block-image {
-		margin-bottom: 1em;
 	}
 }
 

--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -16,6 +16,10 @@
 	> div:not(:last-child) {
 		margin-bottom: var(--spacing, $spacing-aired);
 	}
+
+	.wp-block-image {
+		margin-bottom: var(--contentimgmargin);
+	}
 }
 
 .nv-page-title-wrap {


### PR DESCRIPTION
### Summary
- Added a margin-bottom for the image block. This margin would only apply inside the content ( .nv-content-wrap class )

### Will affect the visual aspect of the product
NO

### Screenshots <!-- if applicable -->
- https://vertis.d.pr/i/WUzvop

### Test instructions
- Edit a post and add an image block with caption and other image without caption
- Make sure they both have margin bottom

### Time
53 min

<!-- Issues that this pull request closes. -->
Closes #3762.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
