### PR TITLE
Menu item not aligned with caret

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -33,6 +33,8 @@
 		color: var(--color);
 		position: relative;
 		width: 100%;
+		display: flex;
+		align-items: center;
 	}
 
 	li:hover > .wrap > a,


### PR DESCRIPTION
### Summary
This is a regression caused by 3.5.2 update. The elements had "display: flex" and "align-items: center" before, I'm not sure why we removed them. 

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->
<img width="678" alt="Screenshot 2023-02-15 at 14 59 53" src="https://user-images.githubusercontent.com/9929553/219034108-b5699c50-84d2-43af-83b5-d575841ecd48.png">


### Test instructions
- Go to the customizer and add a primary menu.
- Inside the Layout tab, add a min-height for elements, let's say 100
- For that primary menu location, set a menu. When you create the menu, make sure you add child items.
- Check how the menu looks on the frontend
- Please check that no other issues appear in the mega menu

### Time
45min

<!-- Issues that this pull request closes. -->
Closes #3832.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
