### PR TITLE
Alternating layout control is missing

### DIFF
--- a/inc/customizer/options/layout_blog.php
+++ b/inc/customizer/options/layout_blog.php
@@ -236,8 +236,8 @@ class Layout_Blog extends Base_Customizer {
 					'active_callback' => function () {
 						$is_list_layout = get_theme_mod( $this->section ) === 'default';
 						$has_image      = true;
-						if ( $is_list_layout ) {
-							$has_image = defined( 'NEVE_PRO_VERSION' ) ? get_theme_mod( 'neve_blog_list_image_position', 'left' ) !== 'no' : false;
+						if ( $is_list_layout && defined( 'NEVE_PRO_VERSION' ) ) {
+							$has_image = get_theme_mod( 'neve_blog_list_image_position', 'left' ) !== 'no';
 						}
 						return $is_list_layout && $has_image;
 					},


### PR DESCRIPTION
### Summary
The sanitization function was changed to hide the toggle if the Image Position control was set to "No image". While this worked well in Neve Pro, in Neve, the control just disappeared.

### Will affect the visual aspect of the product
NO

### Test instructions
- Just with Neve free installed, no PRO, check the customizer -> layout -> blog /archive panel. You should see the toggle there
- Activate Neve Pro and check the presence of the control again
- Switch to Image Position => "No Image"
- Check if the toggle disappears. The condition for the toggle to be present are list layout + image position not "no image"


### Time
21 min

<!-- Issues that this pull request closes. -->
Closes #3831.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
