### PR TITLE
Duplicate menu icon

### DIFF
--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -29,7 +29,7 @@ $menu_icon_class  = apply_filters( 'neve_menu_icon_classes', 'hamburger is-activ
 		data-row-id="<?php echo esc_attr( $row_index ); ?>">
 	<div id="header-menu-sidebar-bg" class="header-menu-sidebar-bg">
 		<?php
-		if ( $open_behavior !== 'dropdown' ) { 
+		if ( $open_behavior !== 'dropdown' ) {
 			?>
 			<div class="<?php echo esc_attr( $close_classes ); ?>">
 				<button type="button" class="<?php echo esc_attr( $menu_icon_class ); ?> navbar-toggle active" <?php echo ( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
@@ -53,14 +53,12 @@ $menu_icon_class  = apply_filters( 'neve_menu_icon_classes', 'hamburger is-activ
 					}
 					?>
 					<span class="screen-reader-text">
-					<?php
-					esc_html_e( 'Navigation Menu', 'neve' );
-					?>
-						</span>
+					<?php esc_html_e( 'Navigation Menu', 'neve' ); ?>
+					</span>
 				</button>
 			</div>
 			<?php
-		} 
+		}
 		?>
 		<div id="header-menu-sidebar-inner" class="<?php echo esc_attr( $inner_classes ); ?>">
 			<?php

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -21,41 +21,47 @@ $close_contained  = $interaction_type === 'dropdown';
 $inner_classes    = 'header-menu-sidebar-inner ' . ( $is_contained ? ' container' : '' );
 $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 $close_classes    = 'close-sidebar-panel navbar-toggle-wrapper' . ( $close_contained ? ' container' : '' );
-
-$menu_icon_class = apply_filters( 'neve_menu_icon_classes', 'hamburger is-active ' );
+$open_behavior    = row_setting( 'layout', 'slide_left' );
+$menu_icon_class  = apply_filters( 'neve_menu_icon_classes', 'hamburger is-active ' );
 ?>
 <div
 		id="header-menu-sidebar" class="<?php echo esc_attr( join( ' ', $classes ) ); ?>"
 		data-row-id="<?php echo esc_attr( $row_index ); ?>">
 	<div id="header-menu-sidebar-bg" class="header-menu-sidebar-bg">
-		<div class="<?php echo esc_attr( $close_classes ); ?>">
-			<button type="button" class="<?php echo esc_attr( $menu_icon_class ); ?> navbar-toggle active" <?php echo ( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					value="<?php esc_attr_e( 'Navigation Menu', 'neve' ); ?>"
-					aria-label="<?php esc_attr_e( 'Navigation Menu', 'neve' ); ?> ">
-				<?php
-				if ( $menu_icon_class === 'hamburger is-active ' ) {
-					?>
-					<span class="bars">
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-						<span class="icon-bar"></span>
-					</span>
+		<?php
+		if ( $open_behavior !== 'dropdown' ) { 
+			?>
+			<div class="<?php echo esc_attr( $close_classes ); ?>">
+				<button type="button" class="<?php echo esc_attr( $menu_icon_class ); ?> navbar-toggle active" <?php echo ( $item_attributes );// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						value="<?php esc_attr_e( 'Navigation Menu', 'neve' ); ?>"
+						aria-label="<?php esc_attr_e( 'Navigation Menu', 'neve' ); ?> ">
 					<?php
-				} else {
+					if ( $menu_icon_class === 'hamburger is-active ' ) {
+						?>
+						<span class="bars">
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+							<span class="icon-bar"></span>
+						</span>
+						<?php
+					} else {
+						?>
+						<span class="hamburger-box">
+							<span class="hamburger-inner"></span>
+						</span>
+						<?php
+					}
 					?>
-					<span class="hamburger-box">
-						<span class="hamburger-inner"></span>
-					</span>
+					<span class="screen-reader-text">
 					<?php
-				}
-				?>
-				<span class="screen-reader-text">
-				<?php
-				esc_html_e( 'Navigation Menu', 'neve' );
-				?>
-					</span>
-			</button>
-		</div>
+					esc_html_e( 'Navigation Menu', 'neve' );
+					?>
+						</span>
+				</button>
+			</div>
+			<?php
+		} 
+		?>
 		<div id="header-menu-sidebar-inner" class="<?php echo esc_attr( $inner_classes ); ?>">
 			<?php
 			/**


### PR DESCRIPTION
### Summary
Hide the button on menu dropdown if effect is dropdown

### Will affect visual aspect of the product
NO

### Test instructions
1. Navigate to a Customizer>Header>Mobile Sidebar and change the Open behavior animation to Slide down.
2. Open the site on mobile view and tap the menu icon.
3. Observe that a duplicate menu icon appears on the screen.


### Time
25min

<!-- Issues that this pull request closes. -->
Closes #3844.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
