### PR TITLE
Fix Neve + PPOM Visual Compatibility on Single Product Page

### DIFF
--- a/inc/compatibility/ppom.php
+++ b/inc/compatibility/ppom.php
@@ -38,6 +38,11 @@ class PPOM {
 	 * Load hooks.
 	 */
 	private function load_hooks() {
+		/**
+		 * Neve has display:flex on the single product page, but PPOM has display:block on the same page. Prevent PPOM from overriding Neve's CSS.
+		 *
+		 * Issue: https://github.com/Codeinwp/woocommerce-product-addon/issues/106
+		*/
 		add_filter( 'ppom_sp_ac_force_css_display_block', '__return_false' );
 	}
 }

--- a/inc/compatibility/ppom.php
+++ b/inc/compatibility/ppom.php
@@ -39,7 +39,8 @@ class PPOM {
 	 */
 	private function load_hooks() {
 		/**
-		 * Neve has display:flex on the single product page, but PPOM has display:block on the same page. Prevent PPOM from overriding Neve's CSS.
+		 * Neve has display:flex on the single product page, but PPOM has display:block on the same page.
+		 * Prevent PPOM's override of Neve's CSS.
 		 *
 		 * Issue: https://github.com/Codeinwp/woocommerce-product-addon/issues/106
 		*/

--- a/inc/compatibility/ppom.php
+++ b/inc/compatibility/ppom.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * PPOM compatibility.
+ *
+ * @package Neve\Compatibility
+ */
+
+namespace Neve\Compatibility;
+
+/**
+ * Class PPOM
+ */
+class PPOM {
+
+	/**
+	 * Init function.
+	 *
+	 * @return bool
+	 */
+	public function init() {
+		if ( ! $this->should_load() ) {
+			return false;
+		}
+
+		$this->load_hooks();
+
+		return true;
+	}
+
+	/**
+	 * Is plugin available?.
+	 */
+	private function should_load() {
+		return defined( 'PPOM_VERSION' );
+	}
+
+	/**
+	 * Load hooks.
+	 */
+	private function load_hooks() {
+		add_filter( 'ppom_sp_ac_force_css_display_block', '__return_false' );
+	}
+}

--- a/inc/core/core_loader.php
+++ b/inc/core/core_loader.php
@@ -125,6 +125,7 @@ class Core_Loader {
 			'Compatibility\Lifter',
 			'Compatibility\Patterns',
 			'Compatibility\PWA',
+			'Compatibility\PPOM',
 			'Compatibility\Web_Stories',
 			'Compatibility\Easy_Digital_Downloads',
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Neve + PPOM had an visual issue on the single product page, that was causing 'add to cart button' was looking weird.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
This is the helper PR of an another PR on the PPOM repo. Please follow up the instructions on https://github.com/Codeinwp/woocommerce-product-addon/pull/108

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/woocommerce-product-addon/issues/106.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
