### PR TITLE
Re-add .comment-content class to fix the alignment issue

### DIFF
--- a/assets/scss/components/elements/blog/_comments.scss
+++ b/assets/scss/components/elements/blog/_comments.scss
@@ -28,7 +28,11 @@
 	.avatar {
 		border-radius: 100%;
 	}
-
+	
+	.comment-content {
+		flex-grow: 1;
+	}
+	
 	input:not([type="submit"]):not([type="checkbox"]) {
 		width: 100%;
 	}


### PR DESCRIPTION
The removal of the .comment-content class is miss-aligning the comment reply/edit button. Hence re-adding it is fixing cosmetic appearance.

### Summary
In the recent update, 3.5.4, there were some changes made to `_comments.scss` file that has broken the alignment of the reply and edit button in the comments section. I've re-added the removed class `.comment-content`, and the alignment is back to normal. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Miss-aligned command button: https://imgur.com/a/J9yS3yK
Aligned command button: https://imgur.com/a/HxT2FBJ

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Update the Neve theme to the latest 3.5.4
- Load any blog post with a nested comment in your test rig
- Add a two-word nested comment
- Check for the comment section command button: **Reply** and **Edit** button alignment
- Re-introduce the `.comment-content { flex-grow: 1; }` in Custom CSS or developer console
- Reload the same blog post and comment
- Check for the alignment of the comment command button
- It should fix the visual defect.

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
