### PR TITLE
Do not render heading title multiple in WooCommerce pages.

### DIFF
--- a/inc/views/page_header.php
+++ b/inc/views/page_header.php
@@ -57,7 +57,7 @@ class Page_Header extends Base_View {
 			return;
 		}
 		$header_layout = get_theme_mod( 'neve_page_header_layout', 'normal' );
-		if ( $header_layout !== 'normal' && in_array( $context, [ 'single-page', 'woo-page' ] ) ) {
+		if ( $header_layout !== 'normal' && in_array( $context, [ 'single-page', 'woo-page' ], true ) ) {
 			return;
 		}
 

--- a/inc/views/page_header.php
+++ b/inc/views/page_header.php
@@ -57,7 +57,7 @@ class Page_Header extends Base_View {
 			return;
 		}
 		$header_layout = get_theme_mod( 'neve_page_header_layout', 'normal' );
-		if ( $header_layout !== 'normal' && $context === 'single-page' ) {
+		if ( $header_layout !== 'normal' ) {
 			return;
 		}
 

--- a/inc/views/page_header.php
+++ b/inc/views/page_header.php
@@ -57,7 +57,7 @@ class Page_Header extends Base_View {
 			return;
 		}
 		$header_layout = get_theme_mod( 'neve_page_header_layout', 'normal' );
-		if ( $header_layout !== 'normal' ) {
+		if ( $header_layout !== 'normal' && in_array( $context, [ 'single-page', 'woo-page' ] ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
If the heading layout is "cover", WooCommerce pages seem to have a double title. That's fixed.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Note: The issue is completely related to the Neve Free.

- Install WooCommerce
- Visit Customizer->Layout->Page then choose **Cover** for **Header Layout**
- Make sure the double title issue was fixed in WooCommerce pages such as a cart, checkout, etc. Normal pages and WooCommerce pages behave the same regarding the page header (the title is located only in the header cover.)
- Make sure there is no regression on the page header/title mechanism overall Neve
- ⚠️  Make sure that PR doesn't cause "#3450" issue again.

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2408.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
