### PR TITLE
fix: solve meta-sidebar error

### DIFF
--- a/assets/apps/metabox/src/components/Sidebar.js
+++ b/assets/apps/metabox/src/components/Sidebar.js
@@ -10,7 +10,7 @@ import { withDispatch, withSelect, select, dispatch } from '@wordpress/data';
 import MetaFieldsManager from './MetaFieldsManager';
 const Sidebar = compose(
 	withDispatch((dispatchHandler) => {
-		dispatchHandler('core/keyboard-shortcuts').registerShortcut({
+		return dispatchHandler('core/keyboard-shortcuts').registerShortcut({
 			name: 'neve/open-meta-sidebar',
 			category: 'block',
 			description: __('Open Neve meta sidebar', 'neve'),


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The function `withDispatch`  from  `Sidebar.js` used by the `meta-sidebar` should return a function.

I changed that so it conforms to this rule. No error should be thrown on Gutenberg  15.2 and above now.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install Guttenberg plugin 15.2 or higher
2. Use this version of Neve
3. Check on a new post that no error is being thrown.

<!-- Issues that this pull request closes. -->
Closes #3883.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
