### PR TITLE
fix: improve compatibility with WPML and Neve #3870

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ logs.log
 /test-results/
 /playwright-report/
 /playwright/.cache/
+.phpunit.result.cache
 

--- a/inc/compatibility/wpml.php
+++ b/inc/compatibility/wpml.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Holds the compatibility logic for WPML plugin.
+ *
+ * Author:          Bogdan Preda <friends@themeisle.com>
+ * Created on:      17/03/2023
+ *
+ * @package Neve\Compatibility
+ */
+
+namespace Neve\Compatibility;
+
+/**
+ * Class WPML
+ *
+ * @package Neve\Compatibility
+ */
+class WPML {
+
+	/**
+	 * Init function.
+	 *
+	 * @return bool
+	 */
+	public function init() {
+		if ( ! $this->should_load() ) {
+			return false;
+		}
+		$this->load_hooks();
+
+		return true;
+	}
+
+	/**
+	 * Load hooks.
+	 */
+	public function load_hooks() {
+		add_filter( 'neve_filter_featured_posts', array( $this, 'filter_posts_and_return_original' ), 10, 1 );
+	}
+
+	/**
+	 * Decide if this class should load.
+	 *
+	 * @return bool
+	 */
+	private function should_load() {
+		return defined( 'WPML_PLUGIN_PATH' );
+	}
+
+	/**
+	 * This will return the original language posts.
+	 * This hooks into `neve_filter_featured_posts` filter.
+	 * We ensure that returned posts are in the original language.
+	 *
+	 * @param array $posts The posts to filter.
+	 *
+	 * @return array
+	 */
+	final public function filter_posts_and_return_original( $posts ) {
+		$original_post_ids = array();
+		$current_language  = apply_filters( 'wpml_current_language', null );
+		foreach ( $posts as $post ) {
+			$original_post_id = apply_filters( 'wpml_object_id', $post['ID'], $post['post_type'], true, $current_language );
+			if ( $original_post_id !== $post['ID'] ) {
+				$original_post_ids[] = $original_post_id;
+				continue;
+			}
+			$original_post_ids[] = $post['ID'];
+		}
+
+		return $original_post_ids;
+	}
+}

--- a/inc/compatibility/wpml.php
+++ b/inc/compatibility/wpml.php
@@ -62,12 +62,27 @@ class WPML {
 		foreach ( $posts as $post ) {
 			$original_post_id = apply_filters( 'wpml_object_id', $post['ID'], $post['post_type'], true, $current_language );
 			if ( $original_post_id !== $post['ID'] ) {
-				$original_post_ids[] = $original_post_id;
+				$original_post_ids = $this->add_to_array_unique( $original_post_ids, $original_post_id );
 				continue;
 			}
-			$original_post_ids[] = $post['ID'];
+			$original_post_ids = $this->add_to_array_unique( $original_post_ids, $post['ID'] );
 		}
 
 		return $original_post_ids;
+	}
+
+	/**
+	 * Add to array unique values.
+	 *
+	 * @param array $array The array to add to.
+	 * @param mixed $value The value to add.
+	 *
+	 * @return array
+	 */
+	private function add_to_array_unique( $array, $value ) {
+		if ( ! in_array( $value, $array, true ) ) {
+			$array[] = $value;
+		}
+		return $array;
 	}
 }

--- a/inc/core/core_loader.php
+++ b/inc/core/core_loader.php
@@ -123,6 +123,7 @@ class Core_Loader {
 			'Compatibility\PWA',
 			'Compatibility\Web_Stories',
 			'Compatibility\Easy_Digital_Downloads',
+			'Compatibility\WPML',
 
 			'Admin\Metabox\Manager',
 			'Admin\Troubleshoot\Main',

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -8,6 +8,7 @@
 
 namespace Neve\Views;
 
+use Neve\Compatibility\WPML;
 use Neve\Customizer\Defaults\Layout;
 
 /**
@@ -107,6 +108,15 @@ class Template_Parts extends Base_View {
 					'post_status' => 'publish',
 				)
 			);
+
+			/**
+			 * Filters the featured posts.
+			 *
+			 * @since 3.5.0
+			 *
+			 * @param array $posts Array of posts.
+			 */
+			$posts = apply_filters( 'neve_filter_featured_posts', $posts );
 		}
 
 		if ( $target === 'sticky' ) {

--- a/tests/test-wpml-compatibility.php
+++ b/tests/test-wpml-compatibility.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Description Test WPML compatibility
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  17-03-{2023}
+ *
+ * @package neve
+ */
+
+/**
+ * Class TestNeveWpDebug
+ */
+class TestWPMLCompatibility extends WP_UnitTestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+		// We create 2 mock posts to use in the tests.
+		$this->factory->post->create_many( 2 );
+	}
+
+	public function test_wpml_compatibility_featured_post() {
+		$neve_wpml = new \Neve\Compatibility\WPML();
+		$this->assertEquals( 'Neve\Compatibility\WPML', get_class( $neve_wpml ), 'Incorrect class type' );
+		$this->assertTrue( false === $neve_wpml->init(), 'WPML compatibility should not load load' );
+
+		define( 'WPML_PLUGIN_PATH', '_test_path_to_wpml_' );
+		$this->assertTrue( $neve_wpml->init(), 'WPML compatibility should load' );
+
+		$posts = wp_get_recent_posts(
+			array(
+				'numberposts' => 2,
+				'post_status' => 'publish',
+			)
+		);
+		$filtered_posts = apply_filters( 'neve_filter_featured_posts', $posts );
+		$containsAllValues = ! array_diff( array_column( $posts, 'iD' ), $filtered_posts );
+		$this->assertTrue( $containsAllValues, 'WPML compatibility should not filter posts' );
+
+		$original_post_id = $posts[0]['ID'];
+		add_filter( 'wpml_object_id', function( $post_id, $post_type, $return_original_if_missing, $current_language ) use ( $original_post_id ) {
+			return $original_post_id;
+		}, 10, 4 );
+
+		$filtered_posts = apply_filters( 'neve_filter_featured_posts', $posts );
+		$this->assertEquals( $original_post_id, reset($filtered_posts ), 'WPML compatibility should filter posts' );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
What changed:
I added a new filter for the recent featured posts.
Added a compatibility class for WPML that hooks into the new filter to ensure correct language posts are being used.

Why the change:
I chose to filter the posts using a compatibility class as opposed to using `'suppress_filters' => false` because of a few considerations:
1. We can also use this class for future compatibility requirements of WPML
2. The default value form WP is `'suppress_filters' => true` changing this seems like a catch-all patch, I opted instead to specifically address the issue of returning the proper post ID if WPML is active, which should be easier to debug and maintain in the future.
3. Having a filter for this will allow future changes to the posts, compatibility reasons or other requirements.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install the Neve theme and WPML
2. Configure 2 languages for WPML or more if required.
3. Create a post and translate it into all languages
4. Have a page set as Blog to display the posts if not already set.
5. Go to Appearance > Customize > Layout > Blog / Archive > Featured post
6. Enable the option and select "Latest Post"
7. Check if the Featured Post is displayed correctly for each language, it should be properly translated for the active language.
8. Check how the Featured Post behaves with the "Sticky Post" option selected instead of "Latest Post"
9. Same behavior should be maintained.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3870.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
