### PR TITLE
Secondary Menu Item Colors Fixed.

### DIFF
--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -30,6 +30,8 @@ $container_classes[] = 'nav-menu-secondary';
 				'container'      => 'ul',
 				'depth'          => - 1,
 				'fallback_cb'    => '__return_false',
+				'before'         => '<div class="wrap">',
+				'after'          => '</div>',
 			)
 		);
 		?>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
**active** and **hover** colors of the secondary menu items were not working; these were fixed with this PR.

**How?**
As I see, a wrapper element (`div.wrap`) was added to the primary menu items with v3.5.2 (via `nav_menu_item_title` add filter call, [reference](https://github.com/Codeinwp/neve/blob/master/inc/views/nav_walker.php#L139-L140)). But that is applied only to the primary menu however the CSS rules which manage hover/active style were restricted by .wrap element https://github.com/Codeinwp/neve/blob/master/assets/scss/components/elements/navigation/_nav-menu.scss#L42 https://github.com/Codeinwp/neve/blob/master/assets/scss/components/elements/navigation/_nav-menu.scss#L54 that was the problem. Therefore I thought the wrapper element (`div.wrap`) is missing on the secondary menu, and I added it.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
- Visit customizer and add a secondary header menu
- set menu colors with different colors (normal, active, hover)
- On the customizer and front side, all colors work fine.
- ⚠️ please make sure there is no regression on any capability of the submenu
- ⚠️ important notice: please make sure this PR doesn't cause any regression on the issues (4 issues https://vertis.d.pr/i/XpyScp, as I see) closed by https://github.com/Codeinwp/neve/pull/3754 PR.

<!-- Issues that this pull request closes. -->
Closes #3878.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
