### PR TITLE
chore: solve gradient issue for wp62rc 

### DIFF
--- a/assets/apps/components/src/Controls/ColorControl.js
+++ b/assets/apps/components/src/Controls/ColorControl.js
@@ -157,6 +157,7 @@ const ColorControl = ({
 									/>
 									<GradientPicker
 										value={gradient}
+										gradients={[]}
 										onChange={(currentGradient) => {
 											setGradient(currentGradient);
 											onChange(currentGradient);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
In WP 6.2 RC the Gradient component has `gradients` as required even if they are not used.
I'm passing an empty array to not break the component.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1.  Go to the header builder
2. Add a Button component
3. Edit the Style options for the Button
4. Change the Background color for the Button
5. Add a gradient for the background color
6. Check that the control does not break, and that no JS error is thrown.


## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3894.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
