### PR TITLE
fix: issue with woo taxonomy not respecting container setting

### DIFF
--- a/inc/views/layouts/layout_container.php
+++ b/inc/views/layouts/layout_container.php
@@ -48,7 +48,7 @@ class Layout_Container extends Base_View {
 				return ( $this->get_container_class( 'neve_single_product_container_style' ) );
 			}
 
-			if ( is_shop() ) {
+			if ( is_shop() || is_product_category() ) {
 				return ( $this->get_container_class( 'neve_shop_archive_container_style' ) );
 			}
 		}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixed the container style not applying for WooCommerce taxonomy pages. The same container style should apply as the shop page.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Change the Layout Container Style from Customizer for the Shop/Archive the container style should also apply to the Product Categories pages. Previously it only applied to the Shop page.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2203.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
