### PR TITLE
Fix/social icons sanitization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ logs.log
 /playwright-report/
 /playwright/.cache/
 /playwright/.auth/
+.phpunit.result.cache

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -90,43 +90,11 @@ trait Core {
 			if ( isset( $filtered[ $key ] ) && is_numeric( $value ) ) {
 				$filtered[ $key ] = (int) $value;
 			}
-		}
 
-		return wp_json_encode( $filtered );
-	}
-
-	/**
-	 * Sanitize responsive control with units
-	 *
-	 * @param string $input Input.
-	 * @return string
-	 */
-	public function sanitize_responsive_int_w_units_json( $input ) {
-		$inputs   = json_decode( $input, true );
-		$filtered = array(
-			'mobile'  => 0,
-			'tablet'  => 0,
-			'desktop' => 0,
-			'suffix'  => array(
-				'mobile'  => 'px',
-				'tablet'  => 'px',
-				'desktop' => 'px',
-			),
-		);
-
-		if ( ! is_array( $inputs ) || empty( $inputs ) ) {
-			return wp_json_encode( $filtered );
-		}
-
-		foreach ( $inputs as $key => $value ) {
-			if ( isset( $filtered[ $key ] ) && is_numeric( $value ) ) {
-				$filtered[ $key ] = (int) $value;
-			}
-			if ( 'suffix' === $key ) {
+			// Optional if a suffix is present. We sanitize the array of suffixes below.
+			if ( 'suffix' === $key && is_array( $value ) ) {
 				foreach ( $value as $device => $suffix ) {
-					if ( isset( $filtered['suffix'][ $device ] ) ) {
-						$filtered['suffix'][ $device ] = in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ? $suffix : 'px';
-					}
+					$filtered['suffix'][ $device ] = in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ? $suffix : 'px';
 				}
 			}
 		}

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -96,6 +96,45 @@ trait Core {
 	}
 
 	/**
+	 * Sanitize responsive control with units
+	 *
+	 * @param string $input Input.
+	 * @return string
+	 */
+	public function sanitize_responsive_int_w_units_json( $input ) {
+		$inputs   = json_decode( $input, true );
+		$filtered = array(
+			'mobile'  => 0,
+			'tablet'  => 0,
+			'desktop' => 0,
+			'suffix'  => array(
+				'mobile'  => 'px',
+				'tablet'  => 'px',
+				'desktop' => 'px',
+			),
+		);
+
+		if ( ! is_array( $inputs ) || empty( $inputs ) ) {
+			return wp_json_encode( $filtered );
+		}
+
+		foreach ( $inputs as $key => $value ) {
+			if ( isset( $filtered[ $key ] ) && is_numeric( $value ) ) {
+				$filtered[ $key ] = (int) $value;
+			}
+			if ( 'suffix' === $key ) {
+				foreach ( $value as $device => $suffix ) {
+					if ( isset( $filtered['suffix'][ $device ] ) ) {
+						$filtered['suffix'][ $device ] = in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ? $suffix : 'px';
+					}
+				}
+			}
+		}
+
+		return wp_json_encode( $filtered );
+	}
+
+	/**
 	 * Sanitize regular json.
 	 *
 	 * @param string $input Input.

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -93,19 +93,22 @@ trait Core {
 
 			// Optional if a suffix is present. We sanitize the array of suffixes below.
 			if ( 'suffix' === $key && is_array( $value ) ) {
-				$default_suffix    = array(
+				$filtered['suffix'] = array(
 					'mobile'  => 'px',
 					'tablet'  => 'px',
 					'desktop' => 'px',
 				);
-				$sanitized_devices = array();
 				foreach ( $value as $device => $suffix ) {
-					$filtered['suffix'][ $device ] = in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ? $suffix : 'px';
-					$sanitized_devices[]           = $device;
-				}
+					if ( ! in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ) {
+						continue;
+					}
 
-				if ( array_diff( array_keys( $default_suffix ), $sanitized_devices ) ) {
-					$filtered['suffix'] = array_merge( $default_suffix, $filtered['suffix'] );
+					// Additionally; device check was added. (for key check I think we can leverage expected keys from $filtered since we expect 1-1 match for devices between suffix and input devices)
+					if ( ! array_key_exists( $device, $filtered ) ) {
+						continue;
+					}
+
+					$filtered['suffix'][ $device ] = $suffix;
 				}
 			}
 		}

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -93,8 +93,19 @@ trait Core {
 
 			// Optional if a suffix is present. We sanitize the array of suffixes below.
 			if ( 'suffix' === $key && is_array( $value ) ) {
+				$default_suffix    = array(
+					'mobile'  => 'px',
+					'tablet'  => 'px',
+					'desktop' => 'px',
+				);
+				$sanitized_devices = array();
 				foreach ( $value as $device => $suffix ) {
 					$filtered['suffix'][ $device ] = in_array( $suffix, array( 'px', 'em', 'rem', '%' ), true ) ? $suffix : 'px';
+					$sanitized_devices[]           = $device;
+				}
+
+				if ( array_diff( array_keys( $default_suffix ), $sanitized_devices ) ) {
+					$filtered['suffix'] = array_merge( $default_suffix, $filtered['suffix'] );
 				}
 			}
 		}

--- a/header-footer-grid/Traits/Core.php
+++ b/header-footer-grid/Traits/Core.php
@@ -103,7 +103,6 @@ trait Core {
 						continue;
 					}
 
-					// Additionally; device check was added. (for key check I think we can leverage expected keys from $filtered since we expect 1-1 match for devices between suffix and input devices)
 					if ( ! array_key_exists( $device, $filtered ) ) {
 						continue;
 					}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,14 +7,11 @@
         convertWarningsToExceptions="true"
 >
 
-    <testsuites name="General Unit tests ( Requires PHP 5.4) ">
-        <testsuite >
+    <testsuites>
+        <testsuite name="General Unit tests ( Requires PHP 5.4) ">
             <directory phpVersion="5.4.0" phpVersionOperator=">=" prefix="test-"  suffix=".php">./tests/</directory>
         </testsuite>
-    </testsuites>
-
-    <testsuites name="Bail lower php versions( For PHP lower than 5.4) ">
-        <testsuite>
+        <testsuite name="Bail lower php versions( For PHP lower than 5.4) ">
             <directory phpVersion="5.4.0" phpVersionOperator="lt" prefix="old-"  suffix=".php">./tests/old/</directory>
         </testsuite>
     </testsuites>

--- a/tests/test-neve-sanitization.php
+++ b/tests/test-neve-sanitization.php
@@ -122,6 +122,16 @@ class TestSanitization extends WP_UnitTestCase {
 			],
 		];
 		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_value );
+
+		// Test Invalid devices input with suffix.
+		$input_value = [
+			'mobile'  => 1,
+			'suffix'  => [
+				'mobile'  => 'rem',
+				'car'     => 'rem',
+			],
+		];
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_value );
 	}
 
 	/**

--- a/tests/test-neve-sanitization.php
+++ b/tests/test-neve-sanitization.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Description test-neve-sanitization.php
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  30-03-{2023}
+ *
+ * @package neve
+ */
+
+use HFG\Traits\Core;
+
+/**
+ * Class SanitizationWrapperTraitClass
+ */
+class SanitizationWrapperTraitClass {
+	use Core;
+}
+
+/**
+ * Class TestSanitization
+ */
+class TestSanitization extends WP_UnitTestCase {
+
+	/**
+	 * Sanitization wrapper trait class.
+	 *
+	 * @var SanitizationWrapperTraitClass
+	 */
+	private $sanitization;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->sanitization = new SanitizationWrapperTraitClass();
+	}
+
+	/**
+	 * Test sanitize responsive int json.
+	 */
+	public function test_sanitize_responsive_int_json() {
+		// Test value responsive int json. w/o. suffix.
+		$input_value  = [
+			'mobile'  => 1,
+			'tablet'  => 2,
+			'desktop' => 3,
+		];
+
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value );
+
+		// Test value responsive int json. w. suffix.
+		$input_value['suffix'] = [
+			'mobile'  => 'px',
+			'tablet'  => 'em',
+			'desktop' => 'rem',
+		];
+
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value );
+
+		// Test sanitization with string values.
+		$input_value  = [
+			'mobile'  => '1',
+			'tablet'  => '2',
+			'desktop' => '3',
+		];
+		$expected_value = [
+			'mobile'  => 1,
+			'tablet'  => 2,
+			'desktop' => 3,
+		];
+
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, wp_json_encode( $expected_value ) );
+
+		// Test sanitization with string values and suffix.
+		$input_value  = [
+			'mobile'  => '1',
+			'tablet'  => '2',
+			'desktop' => '3',
+			'suffix'  => [
+				'mobile'  => 'px',
+				'tablet'  => 'em',
+				'desktop' => 'rem',
+			],
+		];
+		$expected_value = [
+			'mobile'  => 1,
+			'tablet'  => 2,
+			'desktop' => 3,
+			'suffix'  => [
+				'mobile'  => 'px',
+				'tablet'  => 'em',
+				'desktop' => 'rem',
+			],
+		];
+
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, wp_json_encode( $expected_value ) );
+
+		// Test that for invalid input or failed sanitization the default value is returned.
+		$expected_default = '{"mobile":0,"tablet":0,"desktop":0}';
+		$input_value = 'invalid';
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_default );
+
+		$input_value = [];
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_default );
+
+		// Test partial valid input.
+		$expected_value = '{"mobile":1,"tablet":0,"desktop":0}';
+		$input_value = [
+			'mobile'  => 1,
+		];
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_value );
+
+		// Test partial valid input with suffix.
+		$expected_value = '{"mobile":1,"tablet":0,"desktop":0,"suffix":{"mobile":"rem","tablet":"px","desktop":"px"}}';
+		$input_value = [
+			'mobile'  => 1,
+			'suffix'  => [
+				'mobile'  => 'rem',
+			],
+		];
+		$this->do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_value );
+	}
+
+	/**
+	 * Private reusable function for the assertion of sanitize responsive int json.
+	 *
+	 * @param array  $input_value Input value.
+	 * @param string $expected_value Expected value.
+	 */
+	private function do_assertion_for_sanitize_responsive_int_json( $input_value, $expected_value = null ) {
+		$inout_json = wp_json_encode( $input_value );
+		$sanitized_value = $this->sanitization->sanitize_responsive_int_json( $inout_json );
+
+		if ( $expected_value === null ) {
+			$expected_value = $inout_json;
+		}
+
+		$this->assertEquals( $expected_value, $sanitized_value );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
What was changed:
The `sanitize_responsive_int_json` was changed as it was not allowing for inputs with a `suffix` key.
Recently we introduced new units for Responsive Range controls and they also have a `suffix` key holding the responsive suffixes.

I've checked all the usages and found out that this is only used to sanitize the Responsive Range controls values.

Further details are included here: Codeinwp/neve-pro-addon/pull/2450


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Add the Social Icons component in the Footer
2. Change the measurement unit for the Icon Size and Icon Padding
3. Check that the change is visible in the Customizer and on the front end.
4. Then change the unit for the Icon Padding as well and check that the update is reflected in both places.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2427.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
