### PR TITLE
Fix the size limit issue in Neve

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -8,7 +8,6 @@
 	z-index: $menu_sidebar_active_z_index;
 	visibility: hidden;
 	display: flex;
-	transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
 	height: 100vh;
 
 	/* Close Button */
@@ -21,6 +20,10 @@
 			position: relative;
 		}
 	}
+}
+
+.tcb {
+	transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
 }
 
 .header-menu-sidebar-bg {
@@ -118,7 +121,6 @@
 	}
 
 	.header-menu-sidebar-inner {
-		transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
 		max-height: 0;
 		padding: 0;
 	}
@@ -131,7 +133,6 @@
 		bottom: 0;
 		right: 0;
 		opacity: 0;
-		transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);
 	}
 
 	.header-menu-sidebar-inner {

--- a/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
+++ b/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
@@ -4,9 +4,7 @@ import {
 	isIntersectingViewport,
 	savePost,
 	setCustomizeSettings,
-	visitAdminPage,
 } from '../../../utils';
-import { addQueryArgs } from '@wordpress/url';
 
 // Annotate entire file as serial.
 test.describe.configure({ mode: 'serial' });
@@ -30,15 +28,13 @@ test.describe('Custom Global Color Control', () => {
 			{ request, baseURL }
 		);
 
-		const query = addQueryArgs('', {
-			post: 1,
-			action: 'edit',
-			test_name: 'custom-global-colors',
-		}).slice(1);
-		await visitAdminPage(page, 'post.php', query);
+		await page.goto(
+			'/wp-admin/post.php?post=1&action=edit&test_name=custom-global-colors'
+		);
 		await clearWelcome(page);
 
 		await page.locator('.block-editor-rich-text__editable').first().click();
+		await page.locator('#tab-panel-0-styles').click();
 		await page
 			.locator('.block-editor-panel-color-gradient-settings__color-name')
 			.getByText('Text')

--- a/header-footer-grid/templates/row-wrapper-mobile.php
+++ b/header-footer-grid/templates/row-wrapper-mobile.php
@@ -15,10 +15,10 @@ use HFG\Core\Components\MenuIcon;
 
 $row_index        = current_row();
 $interaction_type = row_setting( Abstract_Builder::LAYOUT_SETTING );
-$classes          = [ 'header-menu-sidebar', 'menu-sidebar-panel', $interaction_type, 'hfg-pe' ];
+$classes          = [ 'header-menu-sidebar', 'tcb', 'menu-sidebar-panel', $interaction_type, 'hfg-pe' ];
 $is_contained     = in_array( $interaction_type, [ 'full_canvas', 'dropdown' ], true );
 $close_contained  = $interaction_type === 'dropdown';
-$inner_classes    = 'header-menu-sidebar-inner ' . ( $is_contained ? ' container' : '' );
+$inner_classes    = 'header-menu-sidebar-inner tcb ' . ( $is_contained ? ' container' : '' );
 $item_attributes  = apply_filters( 'neve_nav_toggle_data_attrs', '' );
 $close_classes    = 'close-sidebar-panel navbar-toggle-wrapper' . ( $close_contained ? ' container' : '' );
 $submenu_style    = row_setting( 'layout', 'slide_left' );


### PR DESCRIPTION
### Summary
- In this PR, I moved the `transition: all 0.3s cubic-bezier(0.79, 0.14, 0.15, 0.86);` CSS property to a separate class and added that class in PHP to be able to reduce the CSS size. Before this PR, the property was added to each class and it was taking lot of space ( kudos to @mskapusuz for noticing this )
- I also fixed an e2e test that was failing after the latest modifications in Otter.

### Will affect visual aspect of the product
NO


### Test instructions
The transition property was on menu sidebar on mobile so here's what you need to check:
- The menu sidebar still opens and closes in the same way with the same animation. Here's a video about what's the expected behaviour: https://vertis.d.pr/v/ABtsJM and how the header would open without that transition: https://vertis.d.pr/v/rL4PhB. It should be pretty easy to spot.
- Check if the sidebar opens like before when you change the opening behaviour of the menu sidebar https://vertis.d.pr/i/i2aVeP

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3924.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
