### PR TITLE
fix: move transparent header min height control

### DIFF
--- a/header-footer-grid/Core/Builder/Header.php
+++ b/header-footer-grid/Core/Builder/Header.php
@@ -186,6 +186,11 @@ class Header extends Abstract_Builder {
 			$global_settings_tabs->controls['style']['neve_transparent_header'] = [];
 		}
 
+		if ( $wp_customize->get_control( 'neve_transparent_min_height' ) !== null ) {
+			$wp_customize->get_control( 'neve_transparent_min_height' )->priority   = 10;
+			$global_settings_tabs->controls['style']['neve_transparent_min_height'] = [];
+		}
+
 		if ( $wp_customize->get_control( 'neve_transparent_only_on_home' ) !== null ) {
 			$wp_customize->get_control( 'neve_transparent_only_on_home' )->priority   = 10;
 			$global_settings_tabs->controls['style']['neve_transparent_only_on_home'] = [];


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Supporting change for [PRO_PR_LINK]

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Test instructions on [PRO_PR_LINK]

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2455.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
