### PR TITLE
fix: exclude draft pr and update_dependencies branch #3935

### DIFF
--- a/.github/workflows/pr-checklist.yml
+++ b/.github/workflows/pr-checklist.yml
@@ -5,6 +5,7 @@ on:
     types: [ opened, edited, synchronize, labeled, unlabeled ]
     branches-ignore:
       - 'master'
+      - 'update_dependencies'
 
 permissions: write-all
 
@@ -12,6 +13,7 @@ jobs:
   add-labels:
     runs-on: ubuntu-latest
     name: Label PR based on checklist
+    if: github.event.pull_request.draft == false && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - name: Check if checklist items are completed
         uses: Codeinwp/gha-pr-check-helper@master


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Excluded `update_dependencies` branch to not run on Dependabot PRs
Excluded Draft PRs

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Action should not run on Dependabot PRs
2. Action should not run on Draft PRs

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3935.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
