### PR TITLE
Add link to the support form in Neve dashboard

### DIFF
--- a/assets/apps/dashboard/src/Components/Sidebar.js
+++ b/assets/apps/dashboard/src/Components/Sidebar.js
@@ -1,5 +1,6 @@
 /* global neveDash */
 import { changeOption } from '../utils/rest';
+import SupportCard from './SupportCard';
 import LicenseCard from './LicenseCard';
 import { __ } from '@wordpress/i18n';
 import { ToggleControl, ExternalLink } from '@wordpress/components';
@@ -12,6 +13,9 @@ const Sidebar = ({ currentTab, setToast, loggerValue, setLogger }) => {
 
 	return (
 		<div className="sidebar-wrap">
+			{!neveDash.whiteLabel && neveDash.pro && (
+				<SupportCard isVisible={'pro' === currentTab} />
+			)}
 			{neveDash.pro && <LicenseCard isVisible={'pro' === currentTab} />}
 			{!neveDash.whiteLabel && (
 				<aside className="sidebar card">

--- a/assets/apps/dashboard/src/Components/Sidebar.js
+++ b/assets/apps/dashboard/src/Components/Sidebar.js
@@ -13,9 +13,7 @@ const Sidebar = ({ currentTab, setToast, loggerValue, setLogger }) => {
 
 	return (
 		<div className="sidebar-wrap">
-			{!neveDash.whiteLabel && neveDash.pro && (
-				<SupportCard isVisible={'pro' === currentTab} />
-			)}
+			{!neveDash.whiteLabel && neveDash.pro && <SupportCard />}
 			{neveDash.pro && <LicenseCard isVisible={'pro' === currentTab} />}
 			{!neveDash.whiteLabel && (
 				<aside className="sidebar card">

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -7,8 +7,6 @@ const SupportCard = ({ license }) => {
 	}
 	const { supportData } = license;
 
-	console.log( license );
-
 	if (!supportData || !supportData.text || !supportData.url) {
 		return null;
 	}

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -7,6 +7,8 @@ const SupportCard = ({ license }) => {
 	}
 	const { supportData } = license;
 
+	console.log( license );
+
 	if (!supportData || !supportData.text || !supportData.url) {
 		return null;
 	}

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -1,0 +1,48 @@
+/* global neveDash */
+
+import { withSelect } from '@wordpress/data';
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+const { proSupportURL } = neveDash;
+
+const SupportCard = ({ isVisible, license }) => {
+	if (!isVisible) {
+		return null;
+	}
+
+	if (!license || !license.valid || 'valid' !== license.valid) {
+		return null;
+	}
+
+	if (!proSupportURL) {
+		return null;
+	}
+
+	const buttonStyle = {
+		width: '100%',
+		justifyContent: 'center',
+		fontWeight: '700',
+		fontSize: '14px',
+		padding: '28px 0',
+		backgroundColor: '#ffffff',
+		marginBottom: '24px',
+	};
+
+	return (
+		<Button
+			style={buttonStyle}
+			variant="secondary"
+			href={proSupportURL}
+			target="_blank"
+		>
+			{__('Access our Premium Support', 'neve')}
+		</Button>
+	);
+};
+
+export default withSelect((select) => {
+	const { getLicense } = select('neve-dashboard');
+	return {
+		license: getLicense(),
+	};
+})(SupportCard);

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -3,7 +3,7 @@
 import { withSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-const { proSupportURL } = neveDash;
+const { proSupportURL, proSupportText } = neveDash;
 
 const SupportCard = ({ isVisible, license }) => {
 	if (!isVisible) {
@@ -14,7 +14,7 @@ const SupportCard = ({ isVisible, license }) => {
 		return null;
 	}
 
-	if (!proSupportURL) {
+	if (!proSupportURL || !proSupportText) {
 		return null;
 	}
 
@@ -35,7 +35,7 @@ const SupportCard = ({ isVisible, license }) => {
 			href={proSupportURL}
 			target="_blank"
 		>
-			{__('Access our Premium Support', 'neve')}
+			{proSupportText}
 		</Button>
 	);
 };

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -2,14 +2,9 @@
 
 import { withSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
 const { proSupportURL, proSupportText } = neveDash;
 
-const SupportCard = ({ isVisible, license }) => {
-	if (!isVisible) {
-		return null;
-	}
-
+const SupportCard = ({ license }) => {
 	if (!license || !license.valid || 'valid' !== license.valid) {
 		return null;
 	}

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -7,7 +7,7 @@ const SupportCard = ({ license }) => {
 	}
 	const { supportData } = license;
 
-	if (!supportData.text || !supportData.url) {
+	if (!supportData || !supportData.text || !supportData.url) {
 		return null;
 	}
 

--- a/assets/apps/dashboard/src/Components/SupportCard.js
+++ b/assets/apps/dashboard/src/Components/SupportCard.js
@@ -1,15 +1,13 @@
-/* global neveDash */
-
 import { withSelect } from '@wordpress/data';
 import { Button } from '@wordpress/components';
-const { proSupportURL, proSupportText } = neveDash;
 
 const SupportCard = ({ license }) => {
 	if (!license || !license.valid || 'valid' !== license.valid) {
 		return null;
 	}
+	const { supportData } = license;
 
-	if (!proSupportURL || !proSupportText) {
+	if (!supportData.text || !supportData.url) {
 		return null;
 	}
 
@@ -27,10 +25,10 @@ const SupportCard = ({ license }) => {
 		<Button
 			style={buttonStyle}
 			variant="secondary"
-			href={proSupportURL}
+			href={supportData.url}
 			target="_blank"
 		>
-			{proSupportText}
+			{supportData.text}
 		</Button>
 	);
 };

--- a/composer-dev.lock
+++ b/composer-dev.lock
@@ -8,16 +8,16 @@
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
-            "version": "3.2.35",
+            "version": "3.2.40",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/themeisle-sdk.git",
-                "reference": "e9e15f96cfbb9b2bbcad465599f0b766b5899023"
+                "reference": "d719fff89cb6643e555f5e3daa4ebd627ccb4fd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/e9e15f96cfbb9b2bbcad465599f0b766b5899023",
-                "reference": "e9e15f96cfbb9b2bbcad465599f0b766b5899023",
+                "url": "https://api.github.com/repos/Codeinwp/themeisle-sdk/zipball/d719fff89cb6643e555f5e3daa4ebd627ccb4fd7",
+                "reference": "d719fff89cb6643e555f5e3daa4ebd627ccb4fd7",
                 "shasum": ""
             },
             "require-dev": {
@@ -42,9 +42,9 @@
             ],
             "support": {
                 "issues": "https://github.com/Codeinwp/themeisle-sdk/issues",
-                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.35"
+                "source": "https://github.com/Codeinwp/themeisle-sdk/tree/v3.2.40"
             },
-            "time": "2023-02-22T12:12:05+00:00"
+            "time": "2023-03-30T09:29:30+00:00"
         },
         {
             "name": "wptt/webfont-loader",
@@ -989,5 +989,5 @@
     "platform-overrides": {
         "php": "7.2"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
### Summary
- I've added the support link inside the dashboard

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->
<img width="1488" alt="Screenshot 2023-04-10 at 13 17 15" src="https://user-images.githubusercontent.com/9929553/230882896-22717840-3bee-475b-a26c-f68634bc23b6.png">

### Test instructions
- Test with [this PR](https://github.com/Codeinwp/neve-pro-addon/pull/2463) from Neve PRO, otherwise, you won't see the change. The PR from Neve PRO adds the actual link and the button text to avoid adding new strings
- Activate a license and test that the link points where it should
- Check that the link appears in any tab
- Check that the link disappears when you deactivate the license 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2428.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
