### PR TITLE
Font-size for tagcloud

### DIFF
--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -77,8 +77,7 @@
 	margin-top: $spacing-md;
 }
 
-.nv-tags-list,
-.tagcloud {
+.nv-tags-list {
 
 	a {
 		margin: 0 $spacing-xs $spacing-xs 0;
@@ -89,22 +88,13 @@
 		border-radius: 4px;
 		background: var(--nv-primary-accent);
 		line-height: 1;
+		font-size: 0.75em !important;
 		display: inline-block;
 	}
 
 	span {
 		margin-right: $spacing-xs;
 	}
-}
-
-.nv-tags-list {
-	font-size: 0.75em;
-}
-
-.tagcloud {
-	display: flex;
-	flex-wrap: wrap;
-	align-items: center;
 }
 
 .page .nv-post-cover {

--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -89,7 +89,6 @@
 		border-radius: 4px;
 		background: var(--nv-primary-accent);
 		line-height: 1;
-		font-size: 0.75em !important;
 		display: inline-block;
 	}
 
@@ -98,9 +97,14 @@
 	}
 }
 
+.nv-tags-list {
+	font-size: 0.75em;
+}
+
 .tagcloud {
 	display: flex;
 	flex-wrap: wrap;
+	align-items: center;
 }
 
 .page .nv-post-cover {


### PR DESCRIPTION
### Summary
In this PR, I removed the style of post tags that was applied to the tag cloud widget. That style was only visible for users who disabled the widget editor and switched back to classic widgets. We removed the style that was applying to the gutenberg block tagcloud in Neve 3.1 when we fixed this issue: https://github.com/Codeinwp/neve/issues/3489.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="1680" alt="Screenshot 2023-04-12 at 11 50 33" src="https://user-images.githubusercontent.com/9929553/231405044-09b97e21-10e4-4294-b7bd-cac6427aaed4.png">

In the above screenshot, you see how the tag cloud appears when added as a block and then how it appears when you added with the widget editor disabled. That's the expected behavior.

### Test instructions

- Import the theme unit test data from [here](https://raw.githubusercontent.com/WPTT/theme-unit-test/master/themeunittestdata.wordpress.xml) to avoid adding tags manually
- Go to widgets and add the tag cloud block
- Install https://wordpress.org/plugins/disable-widget-block-editor/ 
- Go to widgets and add the tag cloud classic widget
- Check that the classic tag cloud looks like the one from Gutenberg and that the font size for its elements is not the same

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3902.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
