### PR TITLE
Fix/color picker control

### DIFF
--- a/assets/apps/components/src/Controls/ColorControl.js
+++ b/assets/apps/components/src/Controls/ColorControl.js
@@ -83,6 +83,11 @@ const ColorControl = ({
 			)}
 			{children}
 			<Dropdown
+				contentClassName={
+					'gradient' !== activePanel
+						? ''
+						: 'neve-color-picker-dropdown'
+				}
 				renderToggle={({ isOpen, onToggle }) => {
 					toggle = onToggle;
 					return (

--- a/assets/apps/components/src/Style/_color.scss
+++ b/assets/apps/components/src/Style/_color.scss
@@ -17,9 +17,14 @@
 	}
 
 	.clear {
-		width: 100%;
+		width: calc(100% + 2px);
 		justify-content: center;
-		border-radius: 0;
+		position: fixed;
+		bottom: -18px;
+		left: -1px;
+		border-radius: 0 0 4px 4px;
+		box-shadow: 0 0 0 1px #ccc, 0 0.7px 1px rgba(0,0,0,.1), 0 1.2px 1.7px -0.2px rgba(0,0,0,.1), 0 2.3px 3.3px -0.5px rgba(0,0,0,.1);
+		z-index: 2;
 	}
 
 	> div {

--- a/assets/apps/components/src/Style/_color.scss
+++ b/assets/apps/components/src/Style/_color.scss
@@ -20,7 +20,7 @@
 		width: calc(100% + 2px);
 		justify-content: center;
 		position: fixed;
-		bottom: -18px;
+		bottom: -8px;
 		left: -1px;
 		border-radius: 0 0 4px 4px;
 		box-shadow: 0 0 0 1px #ccc, 0 0.7px 1px rgba(0,0,0,.1), 0 1.2px 1.7px -0.2px rgba(0,0,0,.1), 0 2.3px 3.3px -0.5px rgba(0,0,0,.1);

--- a/assets/apps/components/src/Style/_global-color-picker.scss
+++ b/assets/apps/components/src/Style/_global-color-picker.scss
@@ -51,7 +51,6 @@
   .components-popover__content {
 	border: none;
 	border-radius: 5px !important;
-	max-height: 430px!important;
   }
 }
 .global-color-picker {

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -9,8 +9,21 @@
 		}
 	}
 
-	.components-popover:not(.global-colors-selector) .components-popover__content {
+	.neve-color-picker-dropdown > .components-popover__content {
 		overflow: unset !important;
+	    .components-popover__content {
+		  max-height: 450px!important;
+		}
+		> .components-spacer {
+		  position: sticky;
+		  z-index: 3;
+		  .components-angle-picker-control {
+			gap: calc(8px) !important;
+		  }
+		  .components-custom-gradient-picker > .components-custom-gradient-picker__ui-line {
+			gap: calc(8px) !important;
+		  }
+		}
 	}
 
 	.components-custom-gradient-picker__gradient-bar {
@@ -30,7 +43,7 @@
 #nv-mm-app {
   .modal {
 	.components-popover__content {
-	  max-height: 430px!important;
+	  max-height: 450px!important;
 	}
 
 	.components-color-picker {

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -54,6 +54,9 @@
 	}
 	.components-popover:not(.global-colors-selector) .components-popover__content {
 	  max-height: 520px!important;
+	  .components-base-control {
+		padding: 4px 0;
+	  }
 	}
 
 	.components-color-picker {

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -9,8 +9,15 @@
 		}
 	}
 
+    .components-popover:not(.neve-color-picker-dropdown) {
+	  .components-base-control {
+		padding: 8px 0;
+	  }
+	}
+
 	.neve-color-picker-dropdown > .components-popover__content {
 		overflow: unset !important;
+		min-height: 420px;
 	    .components-popover__content {
 		  max-height: 450px!important;
 		}

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -63,3 +63,10 @@
 	}
   }
 }
+@media screen and (max-height: 900px) {
+  #nv-mm-app {
+	.modal .components-popover:not(.global-colors-selector) .components-popover__content {
+	  max-height: 420px!important;
+	}
+  }
+}

--- a/assets/apps/components/src/Style/_gradient-component.scss
+++ b/assets/apps/components/src/Style/_gradient-component.scss
@@ -42,8 +42,11 @@
  */
 #nv-mm-app {
   .modal {
-	.components-popover__content {
-	  max-height: 450px!important;
+	.components-popover.global-colors-selector .components-popover__content {
+	  max-height: 420px!important;
+	}
+	.components-popover:not(.global-colors-selector) .components-popover__content {
+	  max-height: 520px!important;
 	}
 
 	.components-color-picker {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
What changed:
I moved the Clear Button to a fixed position at the bottom of the modal so that it should always be visible.
Changed the way the modal displays the content so that if there is not enough space it will use the scroll for the content inside, this also allows the modal to position better when it is opened and the elements on the page will change position like on the sidebar from the Customizer.
Ensured the minimum and maximum heights for all the modal instances so that it can open and remain in view inside the Customizer, when the Gradient Picker is enabled, or when used inside the Mega Menu.

In the future I believe it would be better to redesign the Control for usage inside the Customizer, the Gutenberg Control does not seem to handle very well the various scenarios with the pop-over that it is using.


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Go to **Appearance** > **Customize** > **Colors and Background**
2. Add 3 or more Custom Colors.
3. Check how the Color Picker is opening and is being displayed on resolutions from 720px height to 1080px you can go higher but it should not matter when the height is very big as there will be enough real estate to display the modal. Toggle between Hex, HSL, and RGB modes.
    <img width="617" alt="image" src="https://user-images.githubusercontent.com/23024731/231419059-5a984e43-c02c-4bd1-8fce-db9553d6527c.png">
   <img width="618" alt="image" src="https://user-images.githubusercontent.com/23024731/231419395-04689230-b34e-418a-bf54-7a6bf4e6cf66.png">
4. Check that on smaller screens the controls are visible and if not enough space the clear button, if required, is always visible you can scroll through the content and all controls are accessible by scrolling inside the modal.
    <img width="379" alt="image" src="https://user-images.githubusercontent.com/23024731/231423049-55c7f086-f911-4b0c-bee4-6940f20fe5dc.png">
5. Go to **Appearance** > **Customize** > **Buttons** > **Primary Button Appearance**
6. Check the Background color where the Gradient Option is also enabled, Check that the gradient can open when adding new points or editing existing ones and that controls can be accessible. (Note here, there might be cases where if you scroll you can hide some of the gradient controls since the modal will always open top or bottom and maintain the origin point of the color that opened it, but as long as they can be accessible by scrolling and most of the controls are visible it should be ok.) Here is an example of partially hidden controls:
    <img width="406" alt="image" src="https://user-images.githubusercontent.com/23024731/231435682-4ca50e73-faab-4f70-a60d-4269993138b7.png">
    Scrolling to a new position inside the sidebar will reveal the full control that is behind and once the active selection is closed everything will be visible
    <img width="404" alt="image" src="https://user-images.githubusercontent.com/23024731/231436258-d1e630ff-d432-44fb-a34d-97e15706120f.png">
7. Once the Gradient Picker was checked the next thing to check is the Mega Menu Colors, check that the Mega Menu feature is enabled inside Neve Pro
8. Go to  **Appearance** > **Menus**, create a menu, or use the one that is already created if available. Enable Mega Menu for one of the menu items and co to the Tab Style of the Mega Menu
    <img width="631" alt="image" src="https://user-images.githubusercontent.com/23024731/231437123-91a59dc9-1758-407f-97b9-d6ff1e797dd5.png">
9. First check that the Global colors and Custom Colors can be accessed and set  using the scroll if the real estate is too small and that all the Colour Modals will open in view:
    <img width="629" alt="image" src="https://user-images.githubusercontent.com/23024731/231437414-76be4b15-258f-4db9-8e28-4a62d59210c4.png">
10. Check that the Color Picker is opening in view and that the Controls are accessible:
    <img width="573" alt="image" src="https://user-images.githubusercontent.com/23024731/231441393-16222ea8-0d24-452e-884f-22d464bb13cc.png">







## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3927, #3871.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
