### PR TITLE
Button padding different when using EM unit

### DIFF
--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -334,12 +334,16 @@ class Css_Prop {
 
 		if ( count( array_unique( $filtered ) ) === 2 && $value['top'] === $value['bottom'] && $value['right'] === $value['left'] ) {
 
+			if ( str_contains( (string) $value['top'], 'calc' )  &&  str_contains( (string) $value['right'], 'calc' ) ) {
+				return $css_prop . ':' . $value['top'] . ' ' . $value['right'] . ';';
+			}
+
 			if ( neve_value_is_zero( $value['top'] ) && neve_value_is_zero( $value['right'] ) ) {
 				return '';
 			}
 
-			$top_suffix   = neve_value_is_zero( $value['top'] ) ? '' : $suffix;
-			$right_suffix = neve_value_is_zero( $value['right'] ) ? '' : $suffix;
+			$top_suffix   = neve_value_is_zero( $value['top'] ) || str_contains( (string) $value['top'], 'calc' ) ? '' : $suffix;
+			$right_suffix = neve_value_is_zero( $value['right'] ) || str_contains( (string) $value['right'], 'calc' ) ? '' : $suffix;
 
 			$template .= $value['top'] . $top_suffix . ' ' . $value['right'] . $right_suffix;
 
@@ -347,6 +351,11 @@ class Css_Prop {
 		}
 
 		foreach ( Config::$directional_keys as $direction ) {
+			if ( str_contains( (string) $value[$direction], 'calc' ) ) {
+				$template .= $value[$direction] . ' ';
+
+				continue;
+			}
 			if ( ! isset( $value[ $direction ] ) || neve_value_is_zero( $value[ $direction ] ) ) {
 				$template .= '0 ';
 

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -334,7 +334,7 @@ class Css_Prop {
 
 		if ( count( array_unique( $filtered ) ) === 2 && $value['top'] === $value['bottom'] && $value['right'] === $value['left'] ) {
 
-			if ( str_contains( (string) $value['top'], 'calc' )  &&  str_contains( (string) $value['right'], 'calc' ) ) {
+			if ( self::has_calc( $value['top'] )  &&  self::has_calc( $value['right'] ) ) {
 				return $css_prop . ':' . $value['top'] . ' ' . $value['right'] . ';';
 			}
 
@@ -342,8 +342,8 @@ class Css_Prop {
 				return '';
 			}
 
-			$top_suffix   = neve_value_is_zero( $value['top'] ) || str_contains( (string) $value['top'], 'calc' ) ? '' : $suffix;
-			$right_suffix = neve_value_is_zero( $value['right'] ) || str_contains( (string) $value['right'], 'calc' ) ? '' : $suffix;
+			$top_suffix   = neve_value_is_zero( $value['top'] ) || self::has_calc( $value['top'] ) ? '' : $suffix;
+			$right_suffix = neve_value_is_zero( $value['right'] ) || self::has_calc( $value['right'] )  ? '' : $suffix;
 
 			$template .= $value['top'] . $top_suffix . ' ' . $value['right'] . $right_suffix;
 
@@ -351,16 +351,16 @@ class Css_Prop {
 		}
 
 		foreach ( Config::$directional_keys as $direction ) {
-			if ( str_contains( (string) $value[$direction], 'calc' ) ) {
+			if ( self::has_calc( $value[$direction] ) ) {
 				$template .= $value[$direction] . ' ';
-
 				continue;
 			}
+
 			if ( ! isset( $value[ $direction ] ) || neve_value_is_zero( $value[ $direction ] ) ) {
 				$template .= '0 ';
-
 				continue;
 			}
+
 			$template .= $value[ $direction ] . $suffix . ' ';
 		}
 
@@ -371,6 +371,17 @@ class Css_Prop {
 		$template = trim( $template ) . ';';
 
 		return $css_prop . ':' . $template . ';';
+	}
+
+	/**
+	 * Check if a value has calc value.
+	 *
+	 * @param string $value The value.
+	 *
+	 * @return bool
+	 */
+	public static function has_calc( $value ) {
+		return strpos( (string) $value, 'calc' ) !== false;
 	}
 
 	/**

--- a/inc/core/styles/css_prop.php
+++ b/inc/core/styles/css_prop.php
@@ -334,7 +334,7 @@ class Css_Prop {
 
 		if ( count( array_unique( $filtered ) ) === 2 && $value['top'] === $value['bottom'] && $value['right'] === $value['left'] ) {
 
-			if ( self::has_calc( $value['top'] )  &&  self::has_calc( $value['right'] ) ) {
+			if ( isset( $value['is_outline_button_padding'] ) ) {
 				return $css_prop . ':' . $value['top'] . ' ' . $value['right'] . ';';
 			}
 
@@ -342,8 +342,8 @@ class Css_Prop {
 				return '';
 			}
 
-			$top_suffix   = neve_value_is_zero( $value['top'] ) || self::has_calc( $value['top'] ) ? '' : $suffix;
-			$right_suffix = neve_value_is_zero( $value['right'] ) || self::has_calc( $value['right'] )  ? '' : $suffix;
+			$top_suffix   = neve_value_is_zero( $value['top'] ) ? '' : $suffix;
+			$right_suffix = neve_value_is_zero( $value['right'] ) ? '' : $suffix;
 
 			$template .= $value['top'] . $top_suffix . ' ' . $value['right'] . $right_suffix;
 
@@ -351,7 +351,7 @@ class Css_Prop {
 		}
 
 		foreach ( Config::$directional_keys as $direction ) {
-			if ( self::has_calc( $value[$direction] ) ) {
+			if ( isset( $value['is_outline_button_padding'] ) ) {
 				$template .= $value[$direction] . ' ';
 				continue;
 			}
@@ -371,17 +371,6 @@ class Css_Prop {
 		$template = trim( $template ) . ';';
 
 		return $css_prop . ':' . $template . ';';
-	}
-
-	/**
-	 * Check if a value has calc value.
-	 *
-	 * @param string $value The value.
-	 *
-	 * @return bool
-	 */
-	public static function has_calc( $value ) {
-		return strpos( (string) $value, 'calc' ) !== false;
 	}
 
 	/**

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -181,6 +181,7 @@ trait Css_Vars {
 					'primary'   => $value,
 					'secondary' => $value,
 				];
+
 				foreach ( $values as $btn_type => $appearance_values ) {
 					if ( ! isset( $appearance_values['type'] ) || $appearance_values['type'] !== 'outline' ) {
 						continue;
@@ -197,7 +198,8 @@ trait Css_Vars {
 
 						$suffix_css_prop = $btn_type === 'primary' ? '--primarybtnpadding' : '--secondarybtnpadding';
 						$suffix =  Css_Prop::get_suffix( $meta, $device, $value, $suffix_css_prop );
-						$paddings[ $btn_type ][ $direction ] = 'calc(' . $padding_value . $suffix . ' - ' . $border_width[ $direction ] . 'px)';
+						$paddings[ $btn_type ][ 'is_outline_button_padding' ] = true;
+						$paddings[ $btn_type ][ $direction ]                  = 'calc(' . $padding_value . $suffix . ' - ' . $border_width[ $direction ] . 'px)';
 					}
 				}
 				$final_value_default   = Css_Prop::transform_directional_prop( $meta, $device, $value, '--btnpadding', Config::CSS_PROP_PADDING );

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -194,7 +194,10 @@ trait Css_Vars {
 						if(  ! is_numeric( $padding_value ) ){
 							continue;
 						}
-						$paddings[ $btn_type ][ $direction ] = $padding_value - $border_width[ $direction ];
+
+						$suffix_css_prop = $btn_type === 'primary' ? '--primarybtnpadding' : '--secondarybtnpadding';
+						$suffix =  Css_Prop::get_suffix( $meta, $device, $value, $suffix_css_prop );
+						$paddings[ $btn_type ][ $direction ] = 'calc(' . $padding_value . $suffix . ' - ' . $border_width[ $direction ] . 'px)';
 					}
 				}
 				$final_value_default   = Css_Prop::transform_directional_prop( $meta, $device, $value, '--btnpadding', Config::CSS_PROP_PADDING );


### PR DESCRIPTION
### Summary
The problem comes from [this line](https://github.com/Codeinwp/neve/blob/master/inc/core/styles/css_vars.php#L197). We're removing the border width from the padding to have the same button width, no matter the style.

Eg: you have two buttons, one with an outline, and another without an outline, right next to each other. In order for them to have the same size, you need to remove the border width size from the padding. That was working well when we didn't had other unit sizes for the padding control. If the padding is 10EM and we remove 2 from it, we end up with 8EM and not 10EM - 2px.

In this PR i changed what the CSS variable will return, instead of subtract button border width from padding, return `calc(padding.suffix - borderWidth.px)`

### Screenshots
https://vertis.d.pr/v/w9QQy5

### Will affect visual aspect of the product
NO

### Test instructions
- Import Neve Web Agecy
- Set the button padding in EM, make it a big value like 10 to be able to see it fast. Also try with having the same values, all different values and grouped values ( top = bottom, left = right ) for the directions
- Make sure you have one button set as outline
- Check if both buttons have the same value

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3941.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
