### PR TITLE
Fix/footer menu styles

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -39,7 +39,7 @@
 
 	li:hover > .wrap > a,
 	li:hover > .wrap > .caret {
-		color: var(--hovercolor);
+		color: var(--hovercolor, var(--nv-primary-accent));
 	}
 
 	> li {

--- a/assets/scss/components/elements/navigation/_nav-styles.scss
+++ b/assets/scss/components/elements/navigation/_nav-styles.scss
@@ -35,7 +35,7 @@
 		right: 0;
 		left: 0;
 		pointer-events: none;
-		background-color: var(--hovercolor, currentColor);
+		background-color: var(--hovercolor, var(--nv-primary-accent, currentColor));
 	}
 }
 

--- a/e2e-tests/fixtures/customizer/hfg/footer-menu-setup.json
+++ b/e2e-tests/fixtures/customizer/hfg/footer-menu-setup.json
@@ -1,0 +1,8 @@
+{
+  "hfg_footer_layout_v2": "{\"desktop\":{\"top\":{\"left\":[{\"id\":\"footer-menu\"}],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"main\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"bottom\":{\"left\":[],\"c-left\":[{\"id\":\"footer_copyright\"}],\"center\":[],\"c-right\":[],\"right\":[]}}}",
+  "footer-menu_style": "style-border-bottom",
+  "footer-menu_hover_color": "#3a88b8",
+  "footer-menu_color": "#d3a600",
+  "nav_menu_locations[footer]": 177
+
+}

--- a/e2e-tests/specs/customizer/hfg/hfg-footer-menu-component.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-footer-menu-component.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import { setCustomizeSettings } from '../../../utils';
+import data from '../../../fixtures/customizer/hfg/footer-menu-setup.json';
+
+test.describe('Footer Menu component', function () {
+	let page: Page;
+	let footerElements: Locator, count: number;
+
+	test.beforeAll(async ({ browser, request, baseURL }) => {
+		page = await browser.newPage();
+		await setCustomizeSettings('hfgFooterMenu', data, {
+			request,
+			baseURL,
+		});
+
+		footerElements = await page.locator(
+			'.site-title, .menu-item, .palette-icon-wrapper'
+		);
+		count = await footerElements.count();
+	});
+
+	test('Check Footer Menu Style and Hover', async () => {
+		await page.goto('/?test_name=hfgFooterMenu');
+
+		await expect(page.locator('.nav-menu-footer')).toHaveClass(/style\-border\-bottom/);
+
+		const footerMenuItems = await page
+			.locator('.footer-menu.nav-ul li .wrap a')
+			.all();
+
+		for (const item of footerMenuItems) {
+			await expect(item).toHaveCSS('color', 'rgb(211, 166, 0)'); // #d3a600
+			await item.hover();
+			await expect(item).toHaveCSS('color', 'rgb(58, 136, 184)'); // #3a88b8
+		}
+	});
+});

--- a/header-footer-grid/templates/components/component-nav-footer.php
+++ b/header-footer-grid/templates/components/component-nav-footer.php
@@ -11,11 +11,13 @@ namespace HFG;
 
 use HFG\Core\Components\NavFooter;
 
-$style = component_setting( NavFooter::STYLE_ID );
+$style = component_setting( NavFooter::STYLE_ID, 'style-plain' );
 
-$container_classes = [ $style ];
-
-$container_classes[] = 'nav-menu-footer';
+$container_classes = [ 'nav-menu-footer' ];
+if ( $style !== 'style-plain' ) {
+	$container_classes[] = $style;
+	$container_classes[] = 'm-style';
+}
 
 ?>
 <div class="component-wrap">
@@ -30,6 +32,8 @@ $container_classes[] = 'nav-menu-footer';
 				'container'      => 'ul',
 				'menu_class'     => 'footer-menu nav-ul',
 				'menu_id'        => 'footer-menu',
+				'before'         => '<div class="wrap">',
+				'after'          => '</div>',
 			)
 		);
 		?>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added the menu styles back to the footer menu.
Adde an e2e test to check that the style classes are present and the colors are being applied.


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://user-images.githubusercontent.com/23024731/233155106-3555e4b1-2e09-487e-b313-dbab1f151711.png)

![image](https://user-images.githubusercontent.com/23024731/233155366-5de0e31b-3822-4602-855f-810f8878ea0c.png)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Add a footer menu
2. Change the hover color, this should apply on the front end and inside the Customizer.
3. Change the Hover Skin using the **Style** Tab
4. Check that the Hover Skin is being used and displayed correctly.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3948.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
