### PR TITLE
fix: logo accessibility issue [#3934]

### DIFF
--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -44,11 +44,11 @@ if ( $show_desc ) {
 $title_tagline .= '</div>';
 
 if ( $is_not_link ) {
-	$start_tag = '<span class="brand" title="' . get_bloginfo( 'name' ) . '" aria-label="' . get_bloginfo( 'name' ) . '">';
+	$start_tag = '<span class="brand" title="← ' . get_bloginfo( 'name' ) . '" aria-label="' . get_bloginfo( 'name' ) . '">';
 	$end_tag   = '</span>';
 } else {
-	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" title="' . get_bloginfo( 'name' ) . '"
-			aria-label="' . get_bloginfo( 'name' ) . '">';
+	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" title="← ' . get_bloginfo( 'name' ) . '"
+			aria-label="' . get_bloginfo( 'name' ) . '" rel="home">';
 	$end_tag   = '</a>';
 }
 
@@ -105,4 +105,3 @@ do_action( 'hfg_after_wp_get_attachment_image', $custom_logo_id, $image );
 	echo ( $end_tag ); //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	?>
 </div>
-


### PR DESCRIPTION
### Summary
- Change the title attribute of the logo wrap to be different than the content
- Add `rel="home"` on the link

### Will affect the visual aspect of the product
NO

### Test instructions
- Add this version on an online instance of your choice ( TasteWP / InstaWP etc. )
- Check it on https://accessmonitor.acessibilidade.gov.pt/. You should not get "Links with the same text in content and `title` attribute" error.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3934.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
