### PR TITLE
Card content elements control - fix the behavior in customizer

### DIFF
--- a/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
+++ b/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
@@ -24,12 +24,6 @@ const OrderingComponent = ({ control }) => {
 		return [...enabledItems, ...disabledItems];
 	};
 
-	const [value, setValue] = useState(
-		normalizeValue(maybeParseJson(control.setting.get()))
-	);
-
-	const [isVisible, setVisible] = useState(false);
-
 	const updateValue = (newVal) => {
 		const dbValue = newVal
 			.filter((el) => el.visible === true)
@@ -38,6 +32,13 @@ const OrderingComponent = ({ control }) => {
 		setValue(newVal);
 		control.setting.set(JSON.stringify(dbValue));
 	};
+
+	// const [components, setComponents] = useState(control.params.components);
+	const [value, setValue] = useState(
+		normalizeValue(maybeParseJson(control.setting.get()))
+	);
+
+	const [isVisible, setVisible] = useState(false);
 
 	useEffect(() => {
 		window.wp.customize.bind('ready', () => {
@@ -56,6 +57,23 @@ const OrderingComponent = ({ control }) => {
 						setVisible(true);
 					}
 				});
+
+			if (control.id === 'neve_layout_product_elements_order') {
+				wp.customize('neve_product_content_alignment', (setting) => {
+					setting.bind((val) => {
+						const controlVal = maybeParseJson(
+							control.setting.get()
+						);
+						components.title = __('Title', 'neve');
+						components.price = __('Price', 'neve');
+						if (val === 'inline') {
+							components.title = __('Title + Price', 'neve');
+							delete components.price;
+						}
+						updateValue(normalizeValue(controlVal));
+					});
+				});
+			}
 		});
 	}, []);
 

--- a/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
+++ b/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
@@ -24,6 +24,12 @@ const OrderingComponent = ({ control }) => {
 		return [...enabledItems, ...disabledItems];
 	};
 
+	const [value, setValue] = useState(
+		normalizeValue(maybeParseJson(control.setting.get()))
+	);
+
+	const [isVisible, setVisible] = useState(false);
+
 	const updateValue = (newVal) => {
 		const dbValue = newVal
 			.filter((el) => el.visible === true)
@@ -32,13 +38,6 @@ const OrderingComponent = ({ control }) => {
 		setValue(newVal);
 		control.setting.set(JSON.stringify(dbValue));
 	};
-
-	// const [components, setComponents] = useState(control.params.components);
-	const [value, setValue] = useState(
-		normalizeValue(maybeParseJson(control.setting.get()))
-	);
-
-	const [isVisible, setVisible] = useState(false);
 
 	useEffect(() => {
 		window.wp.customize.bind('ready', () => {

--- a/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
+++ b/assets/apps/customizer-controls/src/ordering/OrderingComponent.js
@@ -64,9 +64,12 @@ const OrderingComponent = ({ control }) => {
 							control.setting.get()
 						);
 						components.title = __('Title', 'neve');
-						components.price = __('Price', 'neve');
+						components.price = __('Product Price', 'neve');
 						if (val === 'inline') {
-							components.title = __('Title + Price', 'neve');
+							components.title =
+								__('Title', 'neve') +
+								' + ' +
+								__('Product Price', 'neve');
 							delete components.price;
 						}
 						updateValue(normalizeValue(controlVal));


### PR DESCRIPTION
### Summary
- I removed the js script added in php from Neve Pro ( see https://github.com/Codeinwp/neve-pro-addon/pull/2484 )
- I added the functionality inside the Ordering control, as we do for other controls of this type ( eg. neve_layout_single_(.+)_elements_order )
- I updated the components label from "Price" to "Product Price" to avoid adding any new string

### Will affect visual aspect of the product
NO

### Screenshots <!-- if applicable -->

Before this fix:
https://vertis.d.pr/v/f2VboS

After this fix:
https://vertis.d.pr/v/dmXHcO

### Test instructions
- Test with this PR: https://github.com/Codeinwp/neve-pro-addon/pull/2484
- Import a WooCommerce starter site
- Install and activate Sparks
- Go to customizer => WooCommerce => Product catalog => Card Content 
- Switch to inline mode for title and price
- Disable title + price or any other elements
- Switch back to left/right/center, the price should still be available

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2371.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
