### PR TITLE
fix: added spacing to the default starter_content

### DIFF
--- a/inc/compatibility/starter-content/about.php
+++ b/inc/compatibility/starter-content/about.php
@@ -101,9 +101,14 @@ return [
 
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column {"className":"ticss-4ce656f1"} -->
-<div class="wp-block-column ticss-4ce656f1"><!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
+<div class="wp-block-column ticss-4ce656f1">
+<!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
 <figure class="wp-block-image icon-style is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-03.svg" alt="" width="48" height="48"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"left","level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-left has-text-align-center has-neve-text-color-color has-text-color">Super Efficient</h3>
@@ -119,9 +124,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {"className":"ticss-f6fc7494"} -->
-<div class="wp-block-column ticss-f6fc7494"><!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
+<div class="wp-block-column ticss-f6fc7494">
+<!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
 <figure class="wp-block-image icon-style is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-03.svg" alt="" width="48" height="48"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"left","level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-left has-text-align-center has-neve-text-color-color has-text-color">Deeply Committed</h3>
@@ -137,9 +147,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {"className":"ticss-a5b4df29"} -->
-<div class="wp-block-column ticss-a5b4df29"><!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
+<div class="wp-block-column ticss-a5b4df29">
+<!-- wp:image {"width":48,"height":48,"className":"icon-style is-style-rounded"} -->
 <figure class="wp-block-image icon-style is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-03.svg" alt="" width="48" height="48"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"left","level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-left has-text-align-center has-neve-text-color-color has-text-color">Highly Skilled</h3>
@@ -168,9 +183,14 @@ return [
 
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"align":"center","className":"is-style-default"} -->
+<div class="wp-block-column">
+<!-- wp:image {"align":"center","className":"is-style-default"} -->
 <div class="wp-block-image is-style-default"><figure class="aligncenter"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-01.jpg" alt="" /></figure></div>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Keith Marshall</h3>
@@ -194,9 +214,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"align":"center","className":"is-style-default"} -->
+<div class="wp-block-column">
+<!-- wp:image {"align":"center","className":"is-style-default"} -->
 <div class="wp-block-image is-style-default"><figure class="aligncenter "><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-02.jpg" alt=""/></figure></div>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">George Williams</h3>
@@ -220,9 +245,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"align":"center","className":"is-style-default"} -->
+<div class="wp-block-column">
+<!-- wp:image {"align":"center","className":"is-style-default"} -->
 <div class="wp-block-image is-style-default"><figure class="aligncenter "><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-03.jpg" alt="" /></figure></div>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"align":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Julia Castillo</h3>

--- a/inc/compatibility/starter-content/home.php
+++ b/inc/compatibility/starter-content/home.php
@@ -55,6 +55,10 @@ return [
 <div class="wp-block-image icon-style is-style-default"><figure class="aligncenter is-resized"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-03.svg" alt="" width="48" height="48"/></figure></div>
 <!-- /wp:image -->
 
+<!-- wp:spacer {"height":20} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:heading {"level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Fixed Price Projects</h3>
 <!-- /wp:heading -->
@@ -69,9 +73,15 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"align":"center","width":48,"height":48,"className":"icon-style is-style-default"} -->
+<div class="wp-block-column">
+
+<!-- wp:image {"align":"center","width":48,"height":48,"className":"icon-style is-style-default"} -->
 <div class="wp-block-image icon-style is-style-default"><figure class="aligncenter is-resized"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-02.svg" alt="" width="48" height="48"/></figure></div>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":20} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Receive on time</h3>
@@ -87,9 +97,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:image {"align":"center","width":48,"height":48,"className":"icon-style is-style-rounded"} -->
+<div class="wp-block-column">
+<!-- wp:image {"align":"center","width":48,"height":48,"className":"icon-style is-style-rounded"} -->
 <div class="wp-block-image icon-style is-style-rounded"><figure class="aligncenter is-resized"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/icon-01.svg" alt="" width="48" height="48"/></figure></div>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":20} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"level":3,"className":"has-text-align-center","textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Fast work turnaround</h3>
@@ -282,9 +297,14 @@ return [
 
 <!-- wp:columns -->
 <div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column "><!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
+<div class="wp-block-column ">
+<!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
 <figure class="wp-block-image is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-03.jpg" alt=""  width="80" height="80"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:paragraph {"align":"left","textColor":"neve-text-color","fontSize":"normal"} -->
 <p class="has-text-align-left has-neve-text-color-color has-text-color has-normal-font-size">“What is the point of being alive if you don’t at least try to do something remarkable?”</p>
@@ -300,9 +320,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {} -->
-<div class="wp-block-column "><!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
+<div class="wp-block-column ">
+<!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
 <figure class="wp-block-image  is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-01.jpg" alt="" width="80" height="80"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:paragraph {"align":"left","textColor":"neve-text-color","fontSize":"normal"} -->
 <p class="has-text-align-left has-neve-text-color-color has-text-color has-normal-font-size">“What is the point of being alive if you don’t at least try to do something remarkable?”</p>
@@ -318,9 +343,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {} -->
-<div class="wp-block-column"><!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
+<div class="wp-block-column">
+<!-- wp:image {"className":"is-style-rounded", "width":80,"height":80} -->
 <figure class="wp-block-image  is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-02.jpg" alt=""  width="80" height="80"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:paragraph {"align":"left","textColor":"neve-text-color","fontSize":"normal"} -->
 <p class="has-text-align-left has-neve-text-color-color has-text-color has-normal-font-size">“What is the point of being alive if you don’t at least try to do something remarkable?”</p>

--- a/inc/compatibility/starter-content/portofolio.php
+++ b/inc/compatibility/starter-content/portofolio.php
@@ -24,9 +24,14 @@ return [
 
 <!-- wp:columns {"verticalAlignment":"center"} -->
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"linkDestination":"none"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+<!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image "><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/card-05.jpg" alt="" /></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"textAlign":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Buzz Website</h3>
@@ -48,9 +53,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"linkDestination":"none"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+<!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/card-01.jpg" alt="" /></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"textAlign":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Branding for Chatoue</h3>
@@ -86,9 +96,14 @@ return [
 
 <!-- wp:columns {"verticalAlignment":"center"} -->
 <div class="wp-block-columns are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"linkDestination":"none"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+<!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/card-06.jpg" alt="" /></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"textAlign":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">IMB Internal Website</h3>
@@ -110,9 +125,14 @@ return [
 <!-- /wp:column -->
 
 <!-- wp:column {"verticalAlignment":"center","width":"50%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%"><!-- wp:image {"linkDestination":"none"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:50%">
+<!-- wp:image {"linkDestination":"none"} -->
 <figure class="wp-block-image"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/card-04.jpg" alt=""/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:heading {"textAlign":"center","level":3,"textColor":"neve-text-color"} -->
 <h3 class="has-text-align-center has-neve-text-color-color has-text-color">Social App</h3>
@@ -148,6 +168,9 @@ return [
 <div class="wp-block-image is-style-rounded"><figure class="aligncenter is-resized"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-03.jpg" alt="" width="80" height="80"/></figure></div>
 <!-- /wp:image -->
 
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:paragraph {"align":"center","textColor":"nv-text-dark-bg"} -->
 <p class="has-text-align-center has-nv-text-dark-bg-color has-text-color">“What is the point of being alive if you don’t at least <br>try to do something remarkable?”</p>

--- a/inc/compatibility/starter-content/project-details.php
+++ b/inc/compatibility/starter-content/project-details.php
@@ -60,13 +60,17 @@ return [
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 
-<!-- wp:separator {"className":"is-style-wide"} -->
-<hr class="wp-block-separator is-style-wide"/>
+<!-- wp:separator {"className":"has-text-color has-neve-text-color-color has-css-opacity has-neve-text-color-background-color has-background is-style-default"} -->
+<hr class="wp-block-separator has-text-color has-neve-text-color-color has-css-opacity has-neve-text-color-background-color has-background is-style-default"/>
 <!-- /wp:separator -->
 
 <!-- wp:image {"width":80,"height":80,"linkDestination":"none","className":"is-style-rounded"} -->
 <figure class="wp-block-image  is-style-rounded"><img src="' . trailingslashit( get_template_directory_uri() ) . 'assets/img/starter-content/team-03.jpg" alt="" width="80" height="80"/></figure>
 <!-- /wp:image -->
+
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
 
 <!-- wp:paragraph {"textColor":"neve-text-color"} -->
 <p class="has-neve-text-color-color has-text-color">“What is the point of being alive if you don’t at least try to do something remarkable?”</p>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Added the missing spacing to the default starter content.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. have two instances of Neve, one where you import the Web Agency Starter Site via TPC, and one where you just open the Customizer so that the Starter Content is displayed.
2. Check the spacing for elements on the following pages: Home, About, Portfolio, and Project Details. The elements' spacing should be the same.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3938.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
