### PR TITLE
fix: solve issue with customizer sidebar flicker #3942

### DIFF
--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -335,9 +335,14 @@ class Metabox_Settings {
 		$container       = $this->get_current_layout();
 		$container_class = $container === 'contained' ? ' .container ' : ' .container-fluid ';
 		// Add the `!important` if in customizer, so that the live refresh doesn't affect this.
-		$important = '';
+		$important    = '';
+		$hide_sidebar = '';
 		if ( is_customize_preview() ) {
 			$important = '!important';
+
+			if ( $sidebar_width === 0 ) {
+				$hide_sidebar = 'display: none;';
+			}
 		}
 		$max_width = Mods::to_json( Config::MODS_CONTAINER_WIDTH );
 		$extra_css = '';
@@ -370,7 +375,7 @@ class Metabox_Settings {
 			}
 			#content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .col{ max-width: ' . absint( $meta_value ) . '%' . esc_attr( $important ) . '; }
 			body:not(.neve-off-canvas) #content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap,
-			body:not(.neve-off-canvas) #content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap.shop-sidebar { max-width: ' . absint( $sidebar_width ) . '%' . esc_attr( $important ) . '; }
+			body:not(.neve-off-canvas) #content.neve-main > ' . esc_attr( $container_class ) . ' > .row > .nv-sidebar-wrap.shop-sidebar { max-width: ' . absint( $sidebar_width ) . '%' . esc_attr( $important ) . '; ' . esc_attr( $hide_sidebar ) . ' }
 		}
 		';
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Enforce the sidebar to not display inside the customizer if the width is 0.
Previously because the with would change and get overridden inside the Customizer via the live refresh it would flicker becoming visible. 
I added a `display: none` only for the Customizer context if the sidebar width is 0.


### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import the Web Agecy demo
2. Go to Customizer -> Layout -> Content/ Sidebar
3. Disable the advanced mode
4. Change the customizer settings for the sitewide width. There should be no flickering. Previously it would flicker even though the settings are overridden by the individual post-meta settings. 


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3942.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
