### PR TITLE
Fix breadcrumbs not available on frontend

### DIFF
--- a/inc/views/breadcrumbs.php
+++ b/inc/views/breadcrumbs.php
@@ -95,7 +95,7 @@ class Breadcrumbs extends Base_View {
 	 * @param string $html_tag Wrapper HTML tag.
 	 */
 	public function render_breadcrumbs( $html_tag, $context = '' ) {
-		if ( is_front_page() && $context !== 'hfg' ) {
+		if ( $context !== 'hfg' && is_front_page() ) {
 			return;
 		}
 		if ( empty( $html_tag ) ) {

--- a/inc/views/breadcrumbs.php
+++ b/inc/views/breadcrumbs.php
@@ -22,7 +22,7 @@ class Breadcrumbs extends Base_View {
 	 * Module init.
 	 */
 	public function init() {
-		add_action( 'neve_pro_hfg_breadcrumb', array( $this, 'render_breadcrumbs' ) );
+		add_action( 'neve_pro_hfg_breadcrumb', array( $this, 'render_breadcrumbs' ), 10, 2 );
 		$this->load_theme_breadcrumbs();
 	}
 
@@ -94,8 +94,8 @@ class Breadcrumbs extends Base_View {
 	 *
 	 * @param string $html_tag Wrapper HTML tag.
 	 */
-	public function render_breadcrumbs( $html_tag ) {
-		if ( is_front_page() ) {
+	public function render_breadcrumbs( $html_tag, $context = '' ) {
+		if ( is_front_page() && $context !== 'hfg' ) {
 			return;
 		}
 		if ( empty( $html_tag ) ) {


### PR DESCRIPTION
### Summary
- Added a way to show breadcrumbs on frontend if they are in HFG's context
This PR is made to support changes from Neve Pro https://github.com/Codeinwp/neve-pro-addon/pull/2490

### Will affect the visual aspect of the product
NO

### Test instructions
- Install SEO by Yoast
- Check that the breadcrumbs in lite are still working as before
- With this PR active, https://github.com/Codeinwp/neve-pro-addon/pull/2490, add the breadcrumbs component inside the header. It should show the breadcrumb on frontpage too


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2481.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
