### PR TITLE
Feat/upsell banners hfg

### DIFF
--- a/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
+++ b/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react';
+import React, { useState } from 'react';
 import { __ } from '@wordpress/i18n';
 import { Button, Icon } from '@wordpress/components';
 import { WPCustomizeControl } from '../@types/customizer-control';
@@ -36,7 +36,7 @@ const BannerUpsell: React.FC<Props> = ({ control }) => {
 			{textContent && (
 				<div className="neve-customizer-heading">
 					{useLogo && logoPath && (
-						<img src={logoPath} alt="Logo" className="logo" />
+						<img src={logoPath} alt="Neve" className="logo" />
 					)}
 					<span className="accordion-heading">{textContent}</span>
 					{url && (

--- a/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
+++ b/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
@@ -1,0 +1,71 @@
+import React, {useState} from 'react';
+import { __ } from '@wordpress/i18n';
+import { Button, Icon } from '@wordpress/components';
+import { WPCustomizeControl } from '../@types/customizer-control';
+
+type Props = {
+	control: WPCustomizeControl;
+};
+
+const dismissUpsell = (id = '', nonce = '') => {
+	const formData = new FormData();
+	formData.append('action', 'neve_dismiss_customizer_upsell_notice');
+	formData.append('nonce', nonce);
+	formData.append('id', id);
+	fetch('/wp-admin/admin-ajax.php', {
+		method: 'POST',
+		body: formData,
+	}).then((resp) => resp.json());
+};
+const BannerUpsell: React.FC<Props> = ({ control }) => {
+	const { params } = control;
+	const { title, text, buttonText, logoPath, useLogo, url, nonce, id } =
+		params;
+
+	const textContent = title || text;
+	const buttonTextDisplay = buttonText || __('Learn More', 'neve');
+
+	const [hide, setHide] = useState(false);
+
+	if (hide) {
+		return null;
+	}
+
+	return (
+		<div className="upsell-inner">
+			{textContent && (
+				<div className="neve-customizer-heading">
+					{useLogo && logoPath && (
+						<img src={logoPath} alt="Logo" className="logo" />
+					)}
+					<span className="accordion-heading">{textContent}</span>
+					{url && (
+						<Button
+							target="_blank"
+							rel="external noreferrer noopener"
+							href={url}
+							isPrimary
+						>
+							{buttonTextDisplay}
+							<span className="components-visually-hidden">
+								{__('(opens in a new tab)', 'neve')}
+							</span>
+						</Button>
+					)}
+					<Button
+						className="nv-dismiss-upsell"
+						onClick={() => {
+							dismissUpsell(id, nonce);
+							setHide(true);
+						}}
+						style={{ padding: 3 }}
+					>
+						<Icon icon="no-alt" size={20} />
+					</Button>
+				</div>
+			)}
+		</div>
+	);
+};
+
+export default BannerUpsell;

--- a/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
+++ b/assets/apps/customizer-controls/src/builder-upsell/BannerUpsell.tsx
@@ -6,10 +6,6 @@ import { useEffect } from '@wordpress/element';
 
 type Props = {
 	control: WPCustomizeControl;
-	useHideBannerState: () => {
-		hide: boolean;
-		setHide: (hide: boolean) => void;
-	};
 };
 
 /**

--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -40,6 +40,7 @@ import './style.scss';
 import Documentation from './documentation-section/Documentation.tsx';
 import Instructions from './builder-instructions/Instructions.tsx';
 import Upsells from './builder-upsell/Upsells.tsx';
+import BannerUpsell from './builder-upsell/BannerUpsell.tsx';
 import { initLocalGoogleFonts } from './typography-extra/LocalGoogleFonts';
 
 import MainSearch from './customizer-search/MainSearch.tsx';
@@ -215,6 +216,34 @@ const initUpsellSection = () => {
 		}
 
 		render(<Upsells control={section} />, section.container[0]);
+	});
+
+	const upsellBannerSections = document.querySelectorAll(
+		'.control-section.neve-upsell-banner'
+	);
+	upsellBannerSections.forEach((node) => {
+		const slug = node.getAttribute('data-slug');
+		const section = wp.customize.section(slug);
+
+		if (!section) {
+			return;
+		}
+
+		render(<BannerUpsell control={section} />, section.container[0]);
+	});
+
+	const upsellBannerControls = document.querySelectorAll(
+		'.customize-control.neve-upsell-banner'
+	);
+	upsellBannerControls.forEach((node) => {
+		const slug = node.getAttribute('data-slug');
+		const control = wp.customize.control(slug);
+
+		if (!control) {
+			return;
+		}
+
+		render(<BannerUpsell control={control} />, control.container[0]);
 	});
 };
 

--- a/assets/apps/customizer-controls/src/scss/_upsell.scss
+++ b/assets/apps/customizer-controls/src/scss/_upsell.scss
@@ -34,3 +34,70 @@ $upsell_blue: #0065A6 !default;
 	  }
 	}
 }
+
+#acordion-section-neve_hfg_header_upsell_section,
+#acordion-section-neve_hfg_footer_upsell_section,
+ul[id^=sub-accordion-panel-hfg_] .control-subsection.neve-upsell-banner,
+ul[id^=sub-accordion-section-hfg_] .customize-control.neve-upsell-banner {
+  display: block !important;
+  &.control-section.neve-upsell-banner,
+  &.customize-control.neve-upsell-banner {
+	.upsell-inner {
+	  bottom: 240px;
+	  z-index: 100;
+	}
+  }
+}
+
+.control-section.neve-upsell-banner,
+.customize-control.neve-upsell-banner {
+  .upsell-inner {
+	position: fixed;
+	bottom: 0;
+	right: 0;
+	width: calc(100% - clamp(300px, 18%, 600px) - 12px);
+	border: none;
+	.neve-customizer-heading {
+	  border: none;
+	  background-color: $upsell_blue;
+	  color: #fff;
+	  padding: 2px 12px;
+	  display: flex;
+	  align-items: center;
+	  justify-content: start;
+	  gap: 12px;
+	  font-weight: normal;
+	  height: auto;
+
+	  .accordion-heading {
+		padding: 8px 2px;
+	  }
+
+	  .logo {
+		width: 24px;
+		filter: grayscale(1) invert(1) brightness(10);
+	  }
+
+	  .components-button.is-primary {
+		margin: 6px 6px 6px 24px;
+		background-color: #fff;
+		color: $upsell_blue;
+		font-weight: bold;
+		&:hover {
+		  background-color: #4f94d4cc;
+		  color: #fff;
+		}
+	  }
+
+	  .nv-dismiss-upsell {
+		color: #fff;
+		margin-left: auto;
+		margin-right: 12px;
+		&:hover {
+		  color: #000;
+		}
+	  }
+	}
+  }
+}
+

--- a/assets/apps/customizer-controls/src/scss/_upsell.scss
+++ b/assets/apps/customizer-controls/src/scss/_upsell.scss
@@ -44,8 +44,14 @@ ul[id^=sub-accordion-section-hfg_] .customize-control.neve-upsell-banner {
   &.customize-control.neve-upsell-banner {
 	.upsell-inner {
 	  bottom: 240px;
-	  z-index: 100;
+	  z-index: 10;
 	}
+  }
+}
+
+@media (max-width: 960px){
+  .control-section.neve-upsell-banner .upsell-inner {
+	bottom: calc(240px + 2vh + 0.8em) !important;
   }
 }
 

--- a/assets/customizer/js/upsell.js
+++ b/assets/customizer/js/upsell.js
@@ -1,6 +1,9 @@
 /* global upsellConfig */
 wp.customize.bind( 'ready', function () {
-	if ( typeof upsellConfig !== 'undefined' ) {
+	const hasBanner = document.getElementById(
+		'acordion-section-neve_hfg_header_upsell_section'
+	);
+	if (typeof upsellConfig !== 'undefined' && !hasBanner) {
 		const markup =
 			'<div class="nv-upsell"><div class="nv-upsell-content">' +
 			upsellConfig.text +

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -12,6 +12,7 @@ namespace Neve\Core;
 
 use Neve\Admin\Dashboard\Plugin_Helper;
 use Neve\Core\Settings\Mods_Migrator;
+use Neve\Core\Theme_Info;
 
 /**
  * Class Admin
@@ -19,6 +20,7 @@ use Neve\Core\Settings\Mods_Migrator;
  * @package Neve\Core
  */
 class Admin {
+	use Theme_Info;
 
 	/**
 	 * Dismiss notice key.
@@ -57,6 +59,17 @@ class Admin {
 		if ( get_option( $this->dismiss_notice_key ) !== 'yes' ) {
 			add_action( 'admin_notices', [ $this, 'admin_notice' ], 0 );
 			add_action( 'wp_ajax_neve_dismiss_welcome_notice', [ $this, 'remove_notice' ] );
+		}
+
+		// load upsell dismiss only if neve pro is not active or license is invalid.
+		if ( ! $this->has_valid_addons() ) {
+			add_action(
+				'wp_ajax_neve_dismiss_customizer_upsell_notice',
+				[
+					'Neve\Customizer\Options\Upsells',
+					'remove_customizer_upsell_notice',
+				] 
+			);
 		}
 
 		add_action( 'admin_menu', [ $this, 'remove_background_submenu' ], 110 );

--- a/inc/customizer/controls/react/upsell_banner.php
+++ b/inc/customizer/controls/react/upsell_banner.php
@@ -92,7 +92,7 @@ class Upsell_Banner extends \WP_Customize_Control {
 		?>
 		<li id="customize-control-<?php echo esc_attr( $this->id ); ?>"
 			data-slug="<?php echo esc_attr( $this->id ); ?>"
-			class="customize-control customize-control-<?php echo esc_attr( $this->id ); ?>-control neve-upsell-banner">
+			class="customize-control customize-control-<?php echo esc_attr( $this->id ); ?>-control neve-upsell-banner" style="background: none;">
 		</li>
 		<?php
 	}

--- a/inc/customizer/controls/react/upsell_banner.php
+++ b/inc/customizer/controls/react/upsell_banner.php
@@ -63,7 +63,7 @@ class Upsell_Banner extends \WP_Customize_Control {
 	/**
 	 * Upsell use logo.
 	 *
-	 * @var string
+	 * @var boolean
 	 */
 	public $use_logo = false;
 

--- a/inc/customizer/controls/react/upsell_banner.php
+++ b/inc/customizer/controls/react/upsell_banner.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Description Upsell Section
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  20-12-{2021}
+ *
+ * @package neve/neve-pro
+ */
+namespace Neve\Customizer\Controls\React;
+
+/**
+ * Customizer section.
+ *
+ * @package    WordPress
+ * @subpackage Customize
+ * @since      4.1.0
+ * @see        WP_Customize_Section
+ */
+class Upsell_Banner extends \WP_Customize_Control {
+	/**
+	 * Type of this section.
+	 *
+	 * @var string
+	 */
+	public $type = 'neve_upsell_banner';
+
+	/**
+	 * Upgrade URL.
+	 *
+	 * @var string
+	 */
+	public $url = '';
+
+	/**
+	 * Nonce.
+	 *
+	 * @var string
+	 */
+	public $nonce = '';
+
+	/**
+	 * Upsell text.
+	 *
+	 * @var string
+	 */
+	public $text = '';
+
+	/**
+	 * Upsell button text.
+	 *
+	 * @var string
+	 */
+	public $button_text = '';
+
+	/**
+	 * Upsell logo path.
+	 *
+	 * @var string
+	 */
+	public $logo_path = '';
+
+	/**
+	 * Upsell use logo.
+	 *
+	 * @var string
+	 */
+	public $use_logo = false;
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 * @since 4.1.0
+	 */
+	public function json() {
+		$json               = parent::json();
+		$json['url']        = $this->url;
+		$json['nonce']      = $this->nonce;
+		$json['text']       = $this->text;
+		$json['buttonText'] = $this->button_text;
+		$json['useLogo']    = $this->use_logo === true;
+		$json['id']         = $this->id;
+		$json['logoPath']   = ! empty( $this->logo_path ) ? $this->logo_path : get_template_directory_uri() . '/assets/img/dashboard/logo.svg';
+		return $json;
+	}
+
+	/**
+	 * Render template.
+	 */
+	protected function render() {
+		?>
+		<li id="customize-control-<?php echo esc_attr( $this->id ); ?>"
+			data-slug="<?php echo esc_attr( $this->id ); ?>"
+			class="customize-control customize-control-<?php echo esc_attr( $this->id ); ?>-control neve-upsell-banner">
+		</li>
+		<?php
+	}
+}

--- a/inc/customizer/controls/react/upsell_banner_section.php
+++ b/inc/customizer/controls/react/upsell_banner_section.php
@@ -63,7 +63,7 @@ class Upsell_Banner_Section extends \WP_Customize_Section {
 	/**
 	 * Upsell use logo.
 	 *
-	 * @var string
+	 * @var boolean
 	 */
 	public $use_logo = false;
 

--- a/inc/customizer/controls/react/upsell_banner_section.php
+++ b/inc/customizer/controls/react/upsell_banner_section.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Description Upsell Section
+ *
+ * Author:      Bogdan Preda <bogdan.preda@themeisle.com>
+ * Created on:  20-12-{2021}
+ *
+ * @package neve/neve-pro
+ */
+namespace Neve\Customizer\Controls\React;
+
+/**
+ * Customizer section.
+ *
+ * @package    WordPress
+ * @subpackage Customize
+ * @since      4.1.0
+ * @see        WP_Customize_Section
+ */
+class Upsell_Banner_Section extends \WP_Customize_Section {
+	/**
+	 * Type of this section.
+	 *
+	 * @var string
+	 */
+	public $type = 'neve_upsell_banner_section';
+
+	/**
+	 * Upgrade URL.
+	 *
+	 * @var string
+	 */
+	public $url = '';
+
+	/**
+	 * Nonce.
+	 *
+	 * @var string
+	 */
+	public $nonce = '';
+
+	/**
+	 * Upsell text.
+	 *
+	 * @var string
+	 */
+	public $text = '';
+
+	/**
+	 * Upsell button text.
+	 *
+	 * @var string
+	 */
+	public $button_text = '';
+
+	/**
+	 * Upsell logo path.
+	 *
+	 * @var string
+	 */
+	public $logo_path = '';
+
+	/**
+	 * Upsell use logo.
+	 *
+	 * @var string
+	 */
+	public $use_logo = false;
+
+	/**
+	 * Gather the parameters passed to client JavaScript via JSON.
+	 *
+	 * @return array The array to be exported to the client as JSON.
+	 * @since 4.1.0
+	 */
+	public function json() {
+		$json               = parent::json();
+		$json['url']        = $this->url;
+		$json['nonce']      = $this->nonce;
+		$json['text']       = $this->text;
+		$json['buttonText'] = $this->button_text;
+		$json['useLogo']    = $this->use_logo === true;
+		$json['logoPath']   = ! empty( $this->logo_path ) ? $this->logo_path : get_template_directory_uri() . '/assets/img/dashboard/logo.svg';
+		return $json;
+	}
+
+	/**
+	 * Render template.
+	 */
+	protected function render() {
+		?>
+		<li id="acordion-section-<?php echo esc_attr( $this->id ); ?>"
+			data-slug="<?php echo esc_attr( $this->id ); ?>"
+			class="control-section control-section-<?php echo esc_attr( $this->type ); ?> neve-upsell-banner">
+		</li>
+		<?php
+	}
+}

--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -46,6 +46,24 @@ class Upsells extends Base_Customizer {
 		add_filter( 'theme_mod_neve_checkout_page_layout', array( $this, 'override_neve_checkout_page_layout_theme_mod' ), 10, 1 );
 	}
 
+
+	/**
+	 * Dismiss the upsell banner for 7 days.
+	 *
+	 * @return void
+	 */
+	public static function remove_customizer_upsell_notice() {
+		check_ajax_referer( 'neve-upsell-banner-nonce', 'nonce' );
+
+		$id = isset( $_POST['id'] ) ? sanitize_text_field( $_POST['id'] ) : '';
+		if ( empty( $id ) ) {
+			wp_send_json( [] );
+		}
+
+		set_transient( 'upsell_dismiss_' . $id, true, 7 * DAY_IN_SECONDS );
+		wp_send_json( [] );
+	}
+
 	/**
 	 * Overrides neve_checkout_page_layout theme mod as 'standard' if Neve Pro addon is disabled or not activated.
 	 *
@@ -79,6 +97,8 @@ class Upsells extends Base_Customizer {
 	 */
 	public function add_controls() {
 		$this->wpc->register_section_type( '\Neve\Customizer\Controls\Simple_Upsell_Section' );
+		$this->wpc->register_section_type( '\Neve\Customizer\Controls\React\Upsell_Banner_Section' );
+		$this->wpc->register_control_type( '\Neve\Customizer\Controls\React\Upsell_Banner' );
 		$this->section_upsells();
 		$this->control_upsells();
 		$this->checkout_locked_layout();
@@ -423,18 +443,63 @@ class Upsells extends Base_Customizer {
 			)
 		);
 
-		$upsells = [
-			'blog_archive' => [
-				'text'        => __( 'More blog layout customization options available in PRO', 'neve' ),
-				'button_text' => __( 'Learn More', 'neve' ),
-				'section'     => 'neve_blog_archive_layout',
-			],
-			'single_post'  => [
-				'text'        => __( 'More single post components available in PRO', 'neve' ),
-				'button_text' => __( 'Learn More', 'neve' ),
-				'section'     => 'neve_single_post_layout',
-			],
+		$upsells         = [];
+		$upsells_banners = [];
+
+		$upsells_banners['blog_archive'] = [
+			'text'        => __( 'More blog layout customization options available in PRO', 'neve' ),
+			'button_text' => __( 'Learn More', 'neve' ),
+			'use_logo'    => true,
+			'section'     => 'neve_blog_archive_layout',
 		];
+		$upsells_banners['single_post']  = [
+			'text'        => __( 'More single post components available in PRO', 'neve' ),
+			'button_text' => __( 'Learn More', 'neve' ),
+			'use_logo'    => true,
+			'section'     => 'neve_single_post_layout',
+		];
+
+
+		$hfg_header                     = 'hfg_header';
+		$hfg_header_text                = __( 'Extend your header with more components and settings, build sticky/transparent headers or display them conditionally.', 'neve' );
+		$hfg_header_button              = __( 'Get the PRO version!', 'neve' );
+		$upsells_banners[ $hfg_header ] = [
+			'text'        => $hfg_header_text,
+			'button_text' => $hfg_header_button,
+			'use_logo'    => true,
+			'panel'       => $hfg_header,
+			'type'        => 'section',
+		];
+
+		foreach ( [ 'top', 'main', 'bottom', 'sidebar' ] as $section ) {
+			$section_id                     = $hfg_header . '_layout_' . $section;
+			$upsells_banners[ $section_id ] = [
+				'text'        => $hfg_header_text,
+				'button_text' => $hfg_header_button,
+				'use_logo'    => true,
+				'section'     => $section_id,
+			];
+		}
+
+		$hfg_footer                     = 'hfg_footer';
+		$hfg_footer_text                = __( 'Neve PRO Features', 'neve' );
+		$hfg_footer_button              = __( 'Get the PRO version!', 'neve' );
+		$upsells_banners[ $hfg_footer ] = [
+			'text'        => $hfg_footer_text,
+			'button_text' => $hfg_footer_button,
+			'use_logo'    => true,
+			'panel'       => $hfg_footer,
+			'type'        => 'section',
+		];
+		foreach ( [ 'top', 'main', 'bottom' ] as $section ) {
+			$section_id                     = $hfg_footer . '_layout_' . $section;
+			$upsells_banners[ $section_id ] = [
+				'text'        => $hfg_footer_text,
+				'button_text' => $hfg_footer_button,
+				'use_logo'    => true,
+				'section'     => $section_id,
+			];
+		}
 
 
 		if ( class_exists( 'WooCommerce', false ) ) {
@@ -459,6 +524,54 @@ class Upsells extends Base_Customizer {
 				'panel'       => 'neve_typography',
 				'type'        => 'section',
 			];
+		}
+
+		foreach ( $upsells_banners as $id => $args ) {
+			if ( isset( $args['type'] ) && $args['type'] === 'section' ) {
+				$section_id   = 'neve_' . $id . '_upsell_section';
+				$is_dismissed = get_transient( 'upsell_dismiss_' . $section_id );
+				if ( $is_dismissed !== false ) {
+					continue;
+				}
+				$this->add_section(
+					new Section(
+						$section_id,
+						array_merge(
+							$args,
+							[
+								'type'     => 'neve_upsell_banner_section',
+								'priority' => 10000,
+								'nonce'    => wp_create_nonce( 'neve-upsell-banner-nonce' ),
+								'url'      => tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', 'panel-' . $args['panel'] ),
+							]
+						),
+						'\Neve\Customizer\Controls\React\Upsell_Banner_Section'
+					)
+				);
+
+				continue;
+			}
+			$control_id   = 'neve_' . $id . '_upsell_banner_control';
+			$is_dismissed = get_transient( 'upsell_dismiss_' . $control_id );
+			if ( $is_dismissed !== false ) {
+				continue;
+			}
+			$this->add_control(
+				new Control(
+					$control_id,
+					[ 'sanitize_callback' => 'sanitize_text_field' ],
+					array_merge(
+						$args,
+						[
+							'type'     => 'neve_upsell_banner',
+							'priority' => 10000,
+							'nonce'    => wp_create_nonce( 'neve-upsell-banner-nonce' ),
+							'url'      => tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', 'upsell-banner-customizer-section-' . $args['section'] ),
+						]
+					),
+					'\Neve\Customizer\Controls\React\Upsell_Banner'
+				)
+			);
 		}
 
 		foreach ( $upsells as $id => $args ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Created a new Control and Section that will display an Upsell banner inside the Customizer.
These banners are used with the existing Upsell class to add the banners to Layout Single Post, Layout Archive, Header, and Footer.

To not introduce new strings inside the theme I reused the main upsell text for the Footer banner.

Once a banner is dismissed it will dismiss all banner instances, this was intended on my part as I think it would be a bad user experience to close multiple banners individually.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Single Post (pic. 1)
![image](https://user-images.githubusercontent.com/23024731/236176777-5485e2a6-3284-48b3-84f5-d280d182c887.png)

Archive (pic. 2)
![image](https://user-images.githubusercontent.com/23024731/236177177-4c896745-08c0-4723-8877-61bc26af4d2f.png)

Header (pic. 3)
![image](https://user-images.githubusercontent.com/23024731/236177394-8c81d59d-c8f2-4487-9beb-7b3d0009a701.png)

Footer (pic. 4)
![image](https://user-images.githubusercontent.com/23024731/236177498-66f89b34-10e7-49b6-865f-36b91317df25.png)



### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Use only Neve without PRO being active.
2. Go to Customizer to **Layout** > **Single Post** and check the upsell banner at the bottom of the page. See pic. 1
3. Go to Customizer to **Layout** > **Blog / Archive** and check the upsell banner at the bottom of the page. See pic. 2
4. Go to Customizer to **Header** and check the upsell banner. See pic. 3
5. Go to Customizer to **Footer** and check the upsell banner. See pic. 4
6. Check that when dismissed the banner will not appear anymore. The expiry time is set to 7 days. You can use Transient Manager to remove the transient and check that the banner is displayed again. The transient name is `upsell_dismiss_banner_customizer`

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3964.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
