### PR TITLE
fix: updated font size for product tabs h2

### DIFF
--- a/assets/scss/components/compat/woocommerce/single/_reviews.scss
+++ b/assets/scss/components/compat/woocommerce/single/_reviews.scss
@@ -6,7 +6,7 @@
 }
 
 .woocommerce-Tabs-panel h2 {
-	font-size: var(--h4fontsize);
+	font-size: var(--h2fontsize);
 }
 
 .woocommerce {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Updated the font size for the product tabs section for the H2 tag.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
Pic 1
![image](https://user-images.githubusercontent.com/23024731/236181262-8d59ae3a-c246-4217-b644-472d26180cd1.png)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Import a Shop Template
2. Check the font size for the `h2` tag under the product tabs. See pic. 1

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3962.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
