### PR TITLE
chore: supporting changes for 

### DIFF
--- a/assets/apps/dashboard/src/Components/ModuleCard.js
+++ b/assets/apps/dashboard/src/Components/ModuleCard.js
@@ -1,4 +1,4 @@
-/* global neveDash */
+/* global neveDash, CustomEvent */
 /*eslint camelcase: ["error", {allow: ["required_actions"]}]*/
 import Accordion from './Accordion';
 import InputForm from './Options/InputForm';

--- a/assets/apps/dashboard/src/Components/ModuleCard.js
+++ b/assets/apps/dashboard/src/Components/ModuleCard.js
@@ -16,9 +16,25 @@ import {
 	ExternalLink,
 } from '@wordpress/components';
 import { withSelect, withDispatch } from '@wordpress/data';
-import { Fragment, useState } from '@wordpress/element';
+import { Fragment, useState, useEffect } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+
+const ReactPlaceholder = ({ slug }) => {
+	useEffect(() => {
+		console.log('Dispatch Event');
+
+		window.dispatchEvent(
+			new CustomEvent('neve-dashboard-react-placeholder', {
+				detail: {
+					slug,
+				},
+			})
+		);
+	}, []);
+
+	return <div id={slug} />;
+};
 
 const ModuleCard = ({
 	slug,
@@ -72,6 +88,7 @@ const ModuleCard = ({
 									choices,
 									depends_on: dependsOn,
 								} = optionGroup[optionSlug];
+
 								return (
 									<Fragment key={indexGroup}>
 										{'text' === type && (
@@ -107,6 +124,16 @@ const ModuleCard = ({
 												label={labelGroup}
 												slug={optionSlug}
 												choices={choices}
+											/>
+										)}
+										{(('react' === type &&
+											undefined === dependsOn) ||
+											('react' === type &&
+												isToggleEnabled(
+													dependsOn
+												))) && (
+											<ReactPlaceholder
+												slug={optionSlug}
 											/>
 										)}
 									</Fragment>

--- a/assets/apps/dashboard/src/Components/ModuleCard.js
+++ b/assets/apps/dashboard/src/Components/ModuleCard.js
@@ -22,8 +22,6 @@ import { __ } from '@wordpress/i18n';
 
 const ReactPlaceholder = ({ slug }) => {
 	useEffect(() => {
-		console.log('Dispatch Event');
-
 		window.dispatchEvent(
 			new CustomEvent('neve-dashboard-react-placeholder', {
 				detail: {

--- a/start.php
+++ b/start.php
@@ -32,6 +32,7 @@ function neve_run() {
 			'submenu_style'             => true,
 			'blog_hover_effects'        => true,
 			'hfg_d_search_iconbutton'   => true, // Dynamic icon selection or a button for search components
+			'restrict_content'          => true,
 		]
 	);
 	$vendor_file = trailingslashit( get_template_directory() ) . 'vendor/autoload.php';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Allow a placeholder inside the dashboard controls so that logic from Neve Pro can be added as a component and for cases where specific control logic is used.

In this case, the Restrict content feature saves all the settings within a single option.
Extended the compatibility array to allow for Restrict content to be used only with versions of Neve that support this.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Testing instructions can be found on the main PR: Codeinwp/neve-pro-addon#2444

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#1703.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
