### PR TITLE
fix: toggle the aria-pressed aria for the menu caret #3977

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -386,6 +386,9 @@ menuCarets.forEach( function (caretElem) {
 	caretElem.addEventListener( "keydown", (event) => {
 		if ( event.keyCode === 13 ) {
 			event.target.parentElement.classList.toggle('active');
+            if ( event.target.getAttribute('aria-pressed') ) {
+				event.target.setAttribute('aria-pressed', 'true' === event.target.getAttribute('aria-pressed') ? 'false' : 'true');
+			}
 		}
 	});
 	caretElem.parentElement.parentElement.addEventListener( "focusout", (event) => {
@@ -399,7 +402,7 @@ menuCarets.forEach( function (caretElem) {
 JS;
 
 		$script_min_js = <<<'JSMIN'
-var menuCarets=document.querySelectorAll(".nav-ul li > .wrap > .caret");menuCarets.forEach((function(e){e.addEventListener("keydown",(e=>{13===e.keyCode&&e.target.parentElement.classList.toggle("active")})),e.parentElement.parentElement.addEventListener("focusout",(t=>{e.parentElement.parentElement.contains(t.relatedTarget)||e.parentElement.classList.remove("active")}))}));
+var menuCarets=document.querySelectorAll(".nav-ul li > .wrap > .caret");menuCarets.forEach(function(e){e.addEventListener("keydown",e=>{13===e.keyCode&&(e.target.parentElement.classList.toggle("active"),e.target.getAttribute("aria-pressed")&&e.target.setAttribute("aria-pressed","true"===e.target.getAttribute("aria-pressed")?"false":"true"))}),e.parentElement.parentElement.addEventListener("focusout",t=>{!e.parentElement.parentElement.contains(t.relatedTarget)&&e.parentElement.classList.remove("active")})});
 JSMIN;
 
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Toggle the aria-pressed attribute on Enter key.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Make sure a menu item has a submenu
2. Open the Developer Tools and check the code for the caret (notice that the aria-pressed is false)
3. Press "tab" until the caret is selected
4. When the caret is selected, press "enter"
5. The submenu opens correctly, but the aria-pressed remains false when it should switch to true


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3977 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
