### PR TITLE
fix: solve sidebar gradient

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -95,7 +95,7 @@ $desktop: map-get($gl-devices-list, desktop);
 [class*="row-inner"],
 .header-menu-sidebar-bg {
 	position: relative;
-	background-image: var(--bgimage, none);
+	background: var(--bgimage, var(--bgcolor, #fff));
 	background-position: var(--bgposition, center);
 	background-repeat: no-repeat;
 	background-size: cover;

--- a/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
+++ b/assets/scss/components/hfg/frontend/layout/_mobile_sidebar.scss
@@ -27,7 +27,7 @@
 }
 
 .header-menu-sidebar-bg {
-	background-color: var(--bgcolor);
+	background: var(--bgcolor);
 	color: var(--color);
 	position: relative;
 	display: flex;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Solve the order of rules that are being applied for the background to allow for gradient usage.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://github.com/Codeinwp/neve/assets/23024731/cbdf0b9e-154f-46b8-89e2-dc33992971fa)


### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Add a Gradient Color to the Header Sidebar
2. Check that is being used inside the Customizer and on the Frontend
3. Check that the image background works as before.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3960.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
