### PR TITLE
fix: solve header cart icon 

### DIFF
--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -175,7 +175,7 @@ class CartIcon extends Abstract_Component {
 				'transport'             => 'postMessage',
 				'sanitize_callback'     => 'neve_sanitize_colors',
 				'label'                 => __( 'Color', 'neve' ),
-				'type'                  => 'neve_color_control',
+				'type'                  => '\Neve\Customizer\Controls\React\Color',
 				'section'               => $this->section,
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
@@ -194,6 +194,7 @@ class CartIcon extends Abstract_Component {
 						'fallback' => 'inherit',
 					],
 				],
+				'conditional_header'    => true,
 			]
 		);
 
@@ -205,7 +206,7 @@ class CartIcon extends Abstract_Component {
 				'transport'             => 'postMessage',
 				'sanitize_callback'     => 'neve_sanitize_colors',
 				'label'                 => __( 'Hover Color', 'neve' ),
-				'type'                  => 'neve_color_control',
+				'type'                  => '\Neve\Customizer\Controls\React\Color',
 				'section'               => $this->section,
 				'live_refresh_selector' => true,
 				'live_refresh_css_prop' => [
@@ -224,6 +225,7 @@ class CartIcon extends Abstract_Component {
 						'fallback' => 'inherit',
 					],
 				],
+				'conditional_header'    => true,
 			]
 		);
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The header cart icon was not using the conditional headers flag and the color setting would not save for each header.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
    <summary>Default Header</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/fdd19630-bb88-4cbf-ab9c-6631b19cf207)
</details>

<details open>
    <summary>Shop Header</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/a88aade5-012c-4873-bb27-a68a333a86aa)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Use a Shop Starter Site as a starting point
2. Disable `Show This Header Site-wide` from Global Header Settings
3. Change the colors for the Responsive Search and Cart Icons from the default Header
4. Change the colors for the Responsive Search and Cart Icons from the Shop Header and make sure it is enabled for the products Archive Type
5. Check that the colors are displayed correctly for each Header when used.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2524.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
