### PR TITLE
fix: solve erros reported for non-admins #4004

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -219,15 +219,22 @@ class Main {
 	 */
 	private function copy_customizer_page( $theme_page, $capability ) {
 		global $submenu;
-		$customize_pos = array_search( 'customize', array_column( $submenu['themes.php'], 1 ) );
+		if ( ! isset( $submenu['themes.php'] ) ) {
+			return;
+		}
+		$themes_menu = $submenu['themes.php'];
+		if ( empty( $themes_menu ) ) {
+			return;
+		}
+		$customize_pos = array_search( 'customize', array_column( $themes_menu, 1 ) );
 		if ( false === $customize_pos ) {
 			return;
 		}
-		$themes_page_keys = array_keys( $submenu['themes.php'] );
+		$themes_page_keys = array_keys( $themes_menu );
 		if ( ! isset( $themes_page_keys[ $customize_pos ] ) ) {
 			return;
 		}
-		$themes_menu          = $submenu['themes.php'];
+
 		$customizer_menu_item = array_splice( $themes_menu, $customize_pos, 1 );
 		$customizer_menu_item = reset( $customizer_menu_item );
 		if ( empty( $customizer_menu_item ) ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
For non-admin users the Appearance menu is removed, the new theme page should also be removed if the user does not have the capability and no errors should be thrown. 

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check that non-admin users don't experience any errors with the new changes
2. Previously for Editors it would throw an error as the changes we introduced did not check if the appearance menu was present or not. Check other user types as well.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4004.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
