### PR TITLE
Fix possible null value for Footer section ID 

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_FooterWidget.php
+++ b/header-footer-grid/Core/Components/Abstract_FooterWidget.php
@@ -32,7 +32,7 @@ abstract class Abstract_FooterWidget extends Abstract_Component {
 	 * @access  public
 	 */
 	public function footer_widgets_show( $active, $section ) {
-		if ( strpos( $section->id, 'widgets-footer-' ) ) {
+		if ( isset( $section->id ) && strpos( $section->id, 'widgets-footer-' ) ) {
 			$active = true;
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

I added a null condition for checking the Footer section id.

ℹ️ I could not reproduce the bug. Thus, I suspect it was temporary regression caused by some issue that has been solved. Still, I added the condition to be sure of the feature.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Follow the instruction from the linked issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3982 .
<!-- Should look like this: `Closes #1, #2, #3.` . -->
