### PR TITLE
fix: about page display when using whitelabel …

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -83,14 +83,30 @@ class Main {
 		add_action( 'admin_menu', [ $this, 'register' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 		add_action( 'init', array( $this, 'register_settings' ) );
+		add_action( 'init', array( $this, 'register_about_page' ), 1 );
+	}
 
-		$theme = wp_get_theme();
-		if ( $theme['name'] !== 'Neve' ) {
+	/**
+	 * Add the about page with respect to the white label settings.
+	 *
+	 * @return void
+	 */
+	public function register_about_page() {
+		$theme         = wp_get_theme();
+		$filtered_name = apply_filters( 'ti_wl_theme_name', $theme->__get( 'Name' ) );
+		$slug          = $theme->__get( 'stylesheet' );
+
+		if ( empty( $slug ) || empty( $filtered_name ) ) {
 			return;
 		}
+
+		if ( $filtered_name !== 'Neve' ) {
+			return;
+		}
+
 		add_filter(
 			'neve_about_us_metadata',
-			function () {
+			function () use ( $filtered_name ) {
 				return [
 					// Top-level page in the dashboard sidebar
 					'location'         => 'neve-welcome',
@@ -105,11 +121,10 @@ class Main {
 					'has_upgrade_menu' => ! defined( 'NEVE_PRO_VERSION' ),
 					// Upgrade menu item link & text
 					'upgrade_link'     => tsdk_utmify( esc_url( 'https://themeisle.com/themes/neve/upgrade/' ), 'aboutfilter', 'nevedashboard' ),
-					'upgrade_text'     => __( 'Upgrade', 'neve' ) . ' ' . $this->theme_args['name'],
+					'upgrade_text'     => __( 'Upgrade', 'neve' ) . ' ' . $filtered_name,
 				];
 			}
 		);
-
 	}
 
 	/**

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -84,6 +84,10 @@ class Main {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 		add_action( 'init', array( $this, 'register_settings' ) );
 
+		$theme = wp_get_theme();
+		if ( $theme['name'] !== 'Neve' ) {
+			return;
+		}
 		add_filter(
 			'neve_about_us_metadata',
 			function () {

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -100,7 +100,10 @@ class Main {
 			return;
 		}
 
-		if ( $filtered_name !== 'Neve' ) {
+		// We check if the name is different from the filtered name,
+		// if it is, the whitelabel is in use and we should not add the about page.
+		// this check allows for child themes to use the about page.
+		if ( $filtered_name !== $theme->__get( 'Name' ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Hide the About page when the WhiteLabel theme name is changed.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://github.com/Codeinwp/neve/assets/23024731/c39e9f0c-6fb2-432e-ade0-a5d358c86322)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Enable the WhiteLabel module
2. Change the theme name
3. Check that the about page is not being displayed anymore.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2539.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
