### PR TITLE
fix: am reported issue #4000

### DIFF
--- a/header-footer-grid/Core/Components/MenuIcon.php
+++ b/header-footer-grid/Core/Components/MenuIcon.php
@@ -675,6 +675,9 @@ CSS;
 	 * @return string
 	 */
 	public static function aria_expanded_behaviour( $only_click_attribute = false ) {
+		if ( neve_is_amp() ) {
+			return $only_click_attribute ? '' : 'aria-expanded="false"';
+		}
 		return ( $only_click_attribute ? '' : 'aria-expanded="false" ' ) . 'onclick="if(\'undefined\' !== typeof toggleAriaClick ) { toggleAriaClick() }"';
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Conditioned the JS `onClick` attribute to not be added if the webpage is in AMP mode.
Previously it was added and caused AMP to report issues with the compatibility.

The other reported issues originate from Otter and Feedzy for the linked issue.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
    <summary>Pic. 1</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/ad25230e-88f2-434d-a1fe-b043f11c210e)
</details>

<details>
    <summary>Pic. 2</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/f39d7fea-3d30-43cd-ba7e-7e83886eabcf)
</details>

<details>
    <summary>Pic. 3</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/df41379c-2aed-4492-a7cf-68293fc67d21)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a fresh instance on Neve + Neve Pro, install the [AMP plugin](https://wordpress.org/plugins/amp/)
2. Use the standard Starter Site that is imported when first publishing the Customizer.
3. Activate the AMP plugin and set the **Template Mode** to **Standard** (see Pic. 1)
4. Check the front page, and see if issues are reported for the URL (see Pic. 2)
5. Previously the `onclick` attribute was reported (see Pic. 3)

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4000.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
