### PR TITLE
chore: register otter product page 

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -87,18 +87,20 @@ class Main {
 		add_filter(
 			'neve_about_us_metadata',
 			function () {
+				$product_pages = [];
+				if ( ! defined( 'OTTER_BLOCKS_VERSION' ) ) {
+					$product_pages[] = 'otter-page';
+				}
+
 				return [
 					// Top-level page in the dashboard sidebar
 					'location'         => 'neve-welcome',
 					// Logo to display on the page
 					'logo'             => get_template_directory_uri() . '/assets/img/dashboard/logo.svg',
-					// Menu displayed at the top of the page - optional
-					// 'page_menu'        => [
-					// [ 'text' => 'SDK GitHub Issues', 'url' => esc_url( 'https://github.com/codeinwp/themeisle-sdk/issues' ) ],
-					// [ 'text' => 'Themeisle', 'url' => esc_url( 'https://themeisle.com' ) ]
-					// ],
 					// Condition to show or hide the upgrade menu in the sidebar
 					'has_upgrade_menu' => ! defined( 'NEVE_PRO_VERSION' ),
+					// Add predefined product pages to the about page.
+					'product_pages'    => $product_pages,
 					// Upgrade menu item link & text
 					'upgrade_link'     => tsdk_utmify( esc_url( 'https://themeisle.com/themes/neve/upgrade/' ), 'aboutfilter', 'nevedashboard' ),
 					'upgrade_text'     => __( 'Upgrade', 'neve' ) . ' ' . $this->theme_args['name'],


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
I have modified the filter for the `About us` page to register the Otter product page.
These are supporting changes for the page added from the SDK.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
Testing instructions for this PR can be found here: https://github.com/Codeinwp/themeisle-sdk/pull/184

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2519.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
