### PR TITLE
fix: solve customizer permissions on multisites #4033

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -217,7 +217,7 @@ class Main {
 			[ $this, 'render' ]
 		);
 
-		$this->copy_customizer_page( $theme_page, $capability );
+		$this->copy_customizer_page( $theme_page );
 
 		if ( ! defined( 'NEVE_PRO_VERSION' ) || 'valid' !== apply_filters( 'product_neve_license_status', false ) ) {
 			// Add Custom Layout submenu for upsell.
@@ -235,11 +235,10 @@ class Main {
 	 * Copy the customizer page to the dashboard.
 	 *
 	 * @param string $theme_page The theme page slug.
-	 * @param string $capability The capability required to view the page.
 	 *
 	 * @return void
 	 */
-	private function copy_customizer_page( $theme_page, $capability ) {
+	private function copy_customizer_page( $theme_page ) {
 		global $submenu;
 		if ( ! isset( $submenu['themes.php'] ) ) {
 			return;
@@ -267,7 +266,7 @@ class Main {
 			$theme_page,
 			$customizer_menu_item[0],
 			$customizer_menu_item[0],
-			$capability,
+			'manage_options',
 			'customize.php'
 		);
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changed capability for the page we register to point back to the Customizer.
The previous capability was `activate_plugins`, now it is set to `manage_options` only for this page.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://github.com/Codeinwp/neve/assets/23024731/f8e4d2e5-f22b-4f09-b61c-aa351ed29dfe)

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a fresh multisite instance that is using Neve or use an existing one and enable Neve
2. Create a user with the role of `Administrator` to use instead of the `Super Admin` account
3. Login with the `Administrator` account
4. Check that you can access the Customizer, previously it will not allow the user as it does not have the capability to activate plugins.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4033.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
