### PR TITLE
fix: set correct post context for author hooks #4011

### DIFF
--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -263,6 +263,11 @@ class Post_Meta extends Base_View {
 		if ( ! isset( $current_post ) ) {
 			return false;
 		}
+		// we need to set the global post to the current post in order to allow other filters that hook into get_the_author_meta hooks access to the current post.
+		// we reset this at the end of the function.
+		$original_global_post = $post;
+		$post                 = $current_post; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		setup_postdata( $current_post );
 
 		$author_id      = $current_post->post_author;
 		$user_nicename  = get_the_author_meta( 'user_nicename', $author_id );
@@ -312,6 +317,8 @@ class Post_Meta extends Base_View {
 		 */
 		$markup = apply_filters( 'neve_filter_author_meta_markup', $markup, $post_id, $show_before );
 
+		$post = $original_global_post; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		wp_reset_postdata();
 		return wp_kses_post( $markup );
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The Feedzy uses the `global $post` inside the hook that changes the Author.
In order to allow hooks that rely on the global to work properly, I changed the context while rendering the template part
with the post that is dynamically passed.
Also, a cleanup was added at the end to preserve the original global for further code execution.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
    <summary>Import Feed (Pic 1)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/fd20b612-70fd-466e-89e7-43cb93ee505c)
</details>

<details>
    <summary>Map Content (Pic 2)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/69ee8c74-65e1-4bf4-9634-d96a7eb1e432)
</details>

<details>
    <summary>Map Content (Pic 3)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/c98d8426-962c-442f-a367-016a3db58b87)
</details>

<details>
    <summary>Import Posts (Pic 4)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/10b34cf0-84e5-4b96-8bae-b1fd9c61509a)
</details>

<details>
    <summary>Featured Posts Sticky (Pic 5)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/ef5044ff-54bd-4a73-979c-bba98d3ebc23)
</details>

<details>
    <summary>Correct Sticky Frontend (Pic 6)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/98181410-c8fa-4837-bdae-cd8961b1c24a)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->

1. Create a fresh Neve instance
2. Install Feedzy and Feedzy PRO
3. Go to **Feedzy** > **Import Posts**, and create a **New Import**
4. Inside **Source Configuration** add `https://www.techzone.ro/rss-stiri-hardware` as a source, or any other RSS feed. (see Pic 1)
5. Under **Map Content** for the **General** tab set the options as in Pic 2
6. Under **Map Content** > **Advanced Options**, toggle the save options for the Post Author (see Pic 3)
7. Save the import, and select **Run Now** on the Import Posts list (see Pic 4)
8. Check that posts are imported with the author from the source RSS
9. Set one of the posts as Sticky
10. Enable inside the **Customizer**, under **Layout** > **Blog Archive** the Featured Post featured and set it to Sticky (see Pic 5)
11. Check the front-end
12. Create a new Post and set it to sticky as well, check that the author is correct for each sticky post. (see Pic 6)

Video with the bug can be found here for comparison: https://vertis.d.pr/v/uJ03Oa

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4011.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
