### PR TITLE
feat: show visual cue for disabled title inside editor

### DIFF
--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -183,11 +183,6 @@ class MetaFieldsManager extends Component {
 				) + 'px';
 		}
 
-		if (
-			document.contains(document.getElementById('neve-meta-editor-style'))
-		) {
-			document.getElementById('neve-meta-editor-style').remove();
-		}
 		const css =
 			'.wp-block:not([data-align="full"]) { max-width: ' +
 			('on' === isCustomContentWidth ? blocKWidth : blockWidthDefault) +

--- a/assets/apps/metabox/src/components/MetaFieldsManager.js
+++ b/assets/apps/metabox/src/components/MetaFieldsManager.js
@@ -66,6 +66,7 @@ class MetaFieldsManager extends Component {
 		this.updateValues = this.updateValues.bind(this);
 		this.resetAll = this.resetAll.bind(this);
 		this.updateBlockWidth = this.updateBlockWidth.bind(this);
+		this.updateTitleVisibility = this.updateTitleVisibility.bind(this);
 	}
 
 	componentDidUpdate() {
@@ -91,6 +92,7 @@ class MetaFieldsManager extends Component {
 		}
 
 		this.updateBlockWidth();
+		this.updateTitleVisibility();
 	}
 
 	updateValues(id, value) {
@@ -124,12 +126,41 @@ class MetaFieldsManager extends Component {
 		});
 	}
 
+	addCSSToHead(css, styleID = 'neve-meta-editor-style') {
+		const head = document.head;
+		const hasStyle = document.getElementById(styleID);
+		if (hasStyle) {
+			hasStyle.innerHTML = css;
+			return false;
+		}
+		const style = document.createElement('style');
+		style.setAttribute('id', styleID);
+		style.innerHTML = css;
+		head.appendChild(style);
+	}
+
+	updateTitleVisibility() {
+		const title = this.props.metaValue('neve_meta_disable_title');
+		let titleOpacity = 1;
+		if ('on' === title) {
+			// make title less visible
+			titleOpacity = 0.5;
+		}
+
+		const css = 'h1.editor-post-title { opacity: ' + titleOpacity + '; }';
+
+		this.addCSSToHead(css, 'neve-meta-title-visibility-style');
+	}
 	updateBlockWidth() {
 		const isCustomContentWidth = this.props.metaValue(
 			'neve_meta_enable_content_width'
 		);
 		let containerType = this.props.metaValue('neve_meta_container');
-		if ('default' === containerType || '' === containerType) {
+		if (
+			'default' === containerType ||
+			'' === containerType ||
+			undefined === containerType
+		) {
 			containerType =
 				metaSidebar.actions.neve_meta_content_width.container;
 		}
@@ -162,11 +193,7 @@ class MetaFieldsManager extends Component {
 			('on' === isCustomContentWidth ? blocKWidth : blockWidthDefault) +
 			'; }';
 
-		const head = document.head;
-		const style = document.createElement('style');
-		style.setAttribute('id', 'neve-meta-editor-style');
-		style.innerHTML = css;
-		head.appendChild(style);
+		this.addCSSToHead(css);
 	}
 
 	renderPageLayoutGroup() {

--- a/e2e-tests/specs/editor/page.spec.ts
+++ b/e2e-tests/specs/editor/page.spec.ts
@@ -1,0 +1,19 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Page Neve Options / Title Visibility', () => {
+	test('Starter Sites Plugin install from Dashboard Notice', async ({
+		page,
+	}) => {
+		await page.goto('wp-admin/post-new.php?post_type=page');
+
+		await page.getByRole('textbox', { name: 'Add title' }).click();
+		await page
+			.getByRole('textbox', { name: 'Add title' })
+			.fill('Test Title Visibility');
+		await page.getByRole('button', { name: 'Neve Options' }).click();
+		const titleLocator = page.locator('h1.editor-post-title');
+		await expect(titleLocator).toHaveCSS('opacity', '1');
+		await page.getByLabel('Disable Title').check();
+		await expect(titleLocator).toHaveCSS('opacity', '0.5');
+	});
+});

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -207,6 +207,11 @@ class Metabox_Settings {
 			$editor_width_normal = ( empty( $meta_value ) ? 100 : $meta_value ) . '%';
 		}
 
+		$editor_title_opacity = 1;
+		$tile_disabled        = $this->get_title_disabled();
+		if ( $tile_disabled ) {
+			$editor_title_opacity = 0.5;
+		}
 
 		$style = sprintf(
 			'
@@ -224,8 +229,10 @@ class Metabox_Settings {
 			.wp-block[data-align="full"] {
 			    max-width: none;
 			}
+			h1.editor-post-title { opacity: %s; }
 			',
-			$editor_width_normal
+			$editor_width_normal,
+			$editor_title_opacity
 		);
 
 		$style = $this->add_button_shadow_styles( $style );
@@ -233,6 +240,19 @@ class Metabox_Settings {
 		wp_add_inline_style( 'neve-gutenberg-style', $style );
 
 
+	}
+
+	/**
+	 * Get the disabled title status.
+	 *
+	 * @return false|mixed Status of the title.
+	 */
+	public function get_title_disabled() {
+		$post_id = $this->get_post_id();
+		if ( $post_id === false ) {
+			return false;
+		}
+		return get_post_meta( $post_id, self::DISABLE_TITLE, true );
 	}
 
 	/**

--- a/inc/views/pluggable/metabox_settings.php
+++ b/inc/views/pluggable/metabox_settings.php
@@ -209,7 +209,7 @@ class Metabox_Settings {
 
 		$editor_title_opacity = 1;
 		$tile_disabled        = $this->get_title_disabled();
-		if ( $tile_disabled ) {
+		if ( $tile_disabled === 'on' ) {
 			$editor_title_opacity = 0.5;
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Decrease the opacity of the Editor Title if the disabled title toggle is active from the editor Neve Options.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<details open>
    <summary>Title visual cue (Pic 1)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/62526f1a-b21b-4c5f-a504-61b053c772f4)
</details>

<details>
    <summary>Neve Page Options (Pic 2)</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/6739198a-e4a7-4a28-9e5e-495bb93fe1e4)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
**Check Title visibility**
1. On a new Instance of Neve create a new page
2. Add a title
3. Check that when you disable the title from Neve Options of the page (see Pic 2) the title is less visible (see Pic 1)

**Check Defaults**
Check that when you reload the page the visual cues are correctly applied.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2550.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
