### PR TITLE
fix: menu dropdown aria attribute #4020

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -12,7 +12,6 @@ namespace Neve\Views;
 
 use HFG\Core\Components\Nav;
 use Neve\Core\Dynamic_Css;
-use function _PHPStan_bcbc46924\RingCentral\Psr7\str;
 
 /**
  * Class Nav_Walker

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -12,6 +12,7 @@ namespace Neve\Views;
 
 use HFG\Core\Components\Nav;
 use Neve\Core\Dynamic_Css;
+use function _PHPStan_bcbc46924\RingCentral\Psr7\str;
 
 /**
  * Class Nav_Walker
@@ -151,7 +152,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 				$expand_dropdowns = apply_filters( 'neve_first_level_expanded', false );
 				$additional_class = $expand_dropdowns && $depth === 0 ? 'dropdown-open' : '';
 
-				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . esc_attr( (string) $item->menu_order ) . ' ' . esc_attr( $additional_class ) . '" style="' . esc_attr( $caret_wrap_css ) . '">';
+				$caret  = '<button ' . $expanded . ' type="button" class="caret-wrap navbar-toggle ' . esc_attr( (string) $item->menu_order ) . ' ' . esc_attr( $additional_class ) . '" style="' . esc_attr( $caret_wrap_css ) . '"  aria-label="' . __( 'Toggle', 'neve' ) . ' ' . wp_filter_nohtml_kses( $title ) . '">';
 				$caret .= $caret_pictogram;
 				$caret .= '</button>';
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Add `aria-label` on the dropdown of the sidebar menu.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
    <summary>Pic 1</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/91455c32-3e67-4127-9f60-753f58867da3)
</details>

<details open>
    <summary>Aria Label</summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/e7c891a9-8f61-4a7b-ad46-0e1dc093ecc3)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a fresh instance of Neve
2. Import the Web Agency Starter site
3. Check on mobile view if the sidebar dropdown (see Pic 1) has the proper aria-label (you can use Inspect element from the browser).

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4020.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
