### PR TITLE
Check the input type in neve_get_default_meta_value function

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -700,48 +700,46 @@ function neve_get_default_meta_value( $field, $default ) {
 
 	$components = apply_filters(
 		'neve_meta_filter',
-		array(
+		[
 			'author'   => __( 'Author', 'neve' ),
 			'category' => __( 'Category', 'neve' ),
 			'date'     => __( 'Date', 'neve' ),
 			'comments' => __( 'Comments', 'neve' ),
-		)
+		]
 	);
 
 	$default_data = get_theme_mod( $field, $default );
-	if ( empty( $default_data ) ) {
-		return $new_control_data;
+
+	if ( is_string( $default_data ) ) {
+		$default_data = json_decode( $default_data, true );
 	}
 
-	$default_data = json_decode( $default_data, true );
 	if ( ! is_array( $default_data ) ) {
-		return $new_control_data;
+		$default_data = [];
 	}
 
 	foreach ( $default_data as $meta_component ) {
-		if ( ! array_key_exists( $meta_component, $components ) ) {
-			continue;
+		if ( array_key_exists( $meta_component, $components ) ) {
+			$new_control_data[ $meta_component ] = (object) [
+				'slug'           => $meta_component,
+				'title'          => $components[ $meta_component ],
+				'visibility'     => 'yes',
+				'hide_on_mobile' => false,
+				'blocked'        => 'yes',
+			];
 		}
-		$new_control_data[ $meta_component ] = (object) [
-			'slug'           => $meta_component,
-			'title'          => $components[ $meta_component ],
-			'visibility'     => 'yes',
-			'hide_on_mobile' => false,
-			'blocked'        => 'yes',
-		];
 	}
 
 	foreach ( $components as $component_id => $label ) {
-		if ( array_key_exists( $component_id, $new_control_data ) ) {
-			continue;
+		if ( ! array_key_exists( $component_id, $new_control_data ) ) {
+			$new_control_data[ $component_id ] = (object) [
+				'slug'           => $component_id,
+				'title'          => $label,
+				'visibility'     => 'no',
+				'hide_on_mobile' => false,
+				'blocked'        => 'yes',
+			];
 		}
-		$new_control_data[ $component_id ] = (object) [
-			'slug'           => $component_id,
-			'title'          => $label,
-			'visibility'     => 'no',
-			'hide_on_mobile' => false,
-			'blocked'        => 'yes',
-		];
 	}
 
 	return array_values( $new_control_data );


### PR DESCRIPTION
### Summary
I've changed the function to make sure that `json_decode` will get the proper parameter type. This should fix user's error and prevent similar things from happening.

**Note:** I could not replicate the issue or see the HS ticket and I saw that the user switched to Hestia. Those changes should prevent the error from happening but I could not properly test if it solves the problem since I don't have access to the user's site.

### Will affect visual aspect of the product
NO

### Test instructions
- Not much to test here as I wasn't able to replicate the issue, just a general check that post-meta defaults are working fine.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2544.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
