### PR TITLE
fix: neve meta sidebar error on widgets.php [#4069]

### DIFF
--- a/assets/apps/metabox/src/components/Sidebar.js
+++ b/assets/apps/metabox/src/components/Sidebar.js
@@ -49,13 +49,16 @@ const Sidebar = compose(
 		}, [])
 	);
 
-	if ('elementor_canvas' === templateData.template) {
-		document.getElementById('neve-page-settings-notice').style.display =
-			'none';
+	const pageSettingsNotice = document.getElementById(
+		'neve-page-settings-notice'
+	);
+	if ('elementor_canvas' === templateData.template && pageSettingsNotice) {
+		pageSettingsNotice.style.display = 'none';
 		return false;
 	}
-	document.getElementById('neve-page-settings-notice').style.display =
-		'block';
+	if (pageSettingsNotice) {
+		pageSettingsNotice.style.display = 'block';
+	}
 	//translators: %s - Theme name
 	let sidebarLabel = sprintf(__('%s Options', 'neve'), __('Neve', 'neve'));
 	if (metaSidebar.whiteLabeled) {

--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -326,8 +326,10 @@ final class Manager {
 	 * Register the metabox sidebar.
 	 */
 	public function meta_sidebar_script_enqueue() {
-		global $post_type;
-		if ( ! in_array( $post_type, Supported_Post_Types::get( 'block_editor' ) ) ) {
+		global $post_type, $pagenow;
+
+		// $post_type returns "page" on widgets.php so we need to check if it's widget page separately.
+		if ( $pagenow === 'widgets.php' || ! in_array( $post_type, Supported_Post_Types::get( 'block_editor' ) ) ) {
 			return false;
 		}
 

--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -328,7 +328,7 @@ final class Manager {
 	public function meta_sidebar_script_enqueue() {
 		global $post_type, $pagenow;
 
-		$do_not_load_on = [ 'widget.php', 'customize.php' ];
+		$do_not_load_on = [ 'widgets.php', 'customize.php' ];
 
 		// $post_type returns "page" on widgets.php and on customize.php so we need to check this separately.
 		if ( in_array( $pagenow, $do_not_load_on, true ) || ! in_array( $post_type, Supported_Post_Types::get( 'block_editor' ) ) ) {

--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -328,8 +328,10 @@ final class Manager {
 	public function meta_sidebar_script_enqueue() {
 		global $post_type, $pagenow;
 
-		// $post_type returns "page" on widgets.php so we need to check if it's widget page separately.
-		if ( $pagenow === 'widgets.php' || ! in_array( $post_type, Supported_Post_Types::get( 'block_editor' ) ) ) {
+		$do_not_load_on = [ 'widget.php', 'customize.php' ];
+
+		// $post_type returns "page" on widgets.php and on customize.php so we need to check this separately.
+		if ( in_array( $pagenow, $do_not_load_on, true ) || ! in_array( $post_type, Supported_Post_Types::get( 'block_editor' ) ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Summary
The script where the error occurs shouldn't even be loaded there. It seems like "global $post_type" returns "page" on "widgets.php" so it loads the script. I did a separate check for "widgets.php" page and prevent the script from loading.
I also fixed the script so even if it loads there, it won't throw an error.

### Will affect visual aspect of the product
NO


### Test instructions
- Go to widgets.php / customize.php and make sure the error doesn't appear anymore.
- Go to a post type ( cpt, page, posts etc. ) single post editor and make sure the neve sidebar is still visible


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4069.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
