### PR TITLE
Fix dashboard permissions

### DIFF
--- a/assets/apps/dashboard/src/Components/Notification.js
+++ b/assets/apps/dashboard/src/Components/Notification.js
@@ -1,15 +1,16 @@
 /* global neveDash */
 import classnames from 'classnames';
 
-import { __ } from '@wordpress/i18n';
+import { sprintf, __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import { external } from '@wordpress/icons';
-import { Button, Dashicon, Icon } from '@wordpress/components';
+import { Button, Dashicon, Icon, Tooltip } from '@wordpress/components';
 
 const Notification = ({ data, slug }) => {
 	// eslint-disable-next-line no-unused-vars
 	const [hidden, setHidden] = useState(false);
 	const { text, cta, type, update, url, targetBlank } = data;
+	const { canInstallPlugins } = neveDash;
 	const [inProgress, setInProgress] = useState(false);
 	const [done, setDone] = useState(false);
 	const [errorMessage, setErrorMessage] = useState(null);
@@ -112,6 +113,51 @@ const Notification = ({ data, slug }) => {
 		});
 	};
 
+	const ctaContent = () => {
+		if (!cta || done) {
+			return null;
+		}
+		return (
+			<Button
+				isSecondary
+				disabled={inProgress || !canInstallPlugins}
+				className={classnames({ 'is-loading': inProgress })}
+				onClick={() => {
+					if (update) {
+						updateEntity();
+					}
+				}}
+			>
+				{inProgress ? (
+					<span>
+						<Dashicon icon="update" />{' '}
+						{__('In Progress', 'neve') + '...'}{' '}
+					</span>
+				) : (
+					cta
+				)}
+			</Button>
+		);
+	};
+
+	const wrappedButtonContent = !canInstallPlugins ? (
+		<Tooltip
+			text={sprintf(
+				// translators: %s: Plugin and theme names.
+				__('Ask your admin to update %s on your site', 'neve'),
+				'Neve and Neve Pro'
+			)}
+			position="top center"
+			style={{
+				opacity: 1,
+			}}
+		>
+			{ctaContent()}
+		</Tooltip>
+	) : (
+		ctaContent()
+	);
+
 	const UpdateNotification = () => {
 		return (
 			<div className={classes}>
@@ -132,27 +178,7 @@ const Notification = ({ data, slug }) => {
 							)}
 					</p>
 				)}
-				{cta && !done && (
-					<Button
-						isSecondary
-						disabled={inProgress}
-						className={classnames({ 'is-loading': inProgress })}
-						onClick={() => {
-							if (update) {
-								updateEntity();
-							}
-						}}
-					>
-						{inProgress ? (
-							<span>
-								<Dashicon icon="update" />{' '}
-								{__('In Progress', 'neve') + '...'}{' '}
-							</span>
-						) : (
-							cta
-						)}
-					</Button>
-				)}
+				{wrappedButtonContent}
 			</div>
 		);
 	};

--- a/assets/apps/dashboard/src/scss/components/_notification.scss
+++ b/assets/apps/dashboard/src/scss/components/_notification.scss
@@ -110,7 +110,8 @@
 
     &[disabled] {
       text-shadow: none;
-      opacity: .5;
+	  color: rgba( 54, 54, 54, .5 );
+	  border-color: rgba( 54, 54, 54, .5 );
     }
   }
 

--- a/assets/apps/dashboard/src/scss/content/_plugins.scss
+++ b/assets/apps/dashboard/src/scss/content/_plugins.scss
@@ -24,7 +24,8 @@
     padding: 20px 15px 20px 20px;
     display: flex;
     align-items: center;
-		margin-top: auto;
+	margin-top: auto;
+	justify-content: space-between;
 
     .plugin-data {
       font-size: 14px;

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -176,7 +176,7 @@ class Main {
 		}
 		$neve_icon  = apply_filters( 'neve_menu_icon', $icon );
 		$priority   = apply_filters( 'neve_menu_priority', 59 );  // The position of the menu item, 60 is the position of the Appearance menu.
-		$capability = 'activate_plugins';
+		$capability = 'manage_options';
 
 		// Place a theme page in the Appearance menu, for older versions of Neve Pro or TPC. to maintain backwards compatibility.
 		if (
@@ -374,6 +374,8 @@ class Main {
 			'tpcAdminURL'             => admin_url( 'admin.php?page=tiob-starter-sites' ),
 			'pluginsURL'              => esc_url( admin_url( 'plugins.php' ) ),
 			'getPluginStateBaseURL'   => esc_url( rest_url( '/nv/v1/dashboard/plugin-state/' ) ),
+			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
+			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
 		];
 
 		if ( defined( 'NEVE_PRO_PATH' ) ) {

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -115,7 +115,7 @@ class Plugin_Helper {
 				'paged'         => '1',
 				'_wpnonce'      => wp_create_nonce( $action . '-plugin_' . $this->get_plugin_path( $slug ) ),
 			),
-			esc_url( network_admin_url( 'plugins.php' ) )
+			esc_url( 'plugins.php' )
 		);
 	}
 


### PR DESCRIPTION
### Summary
- Admin users on multisite are now allowed to access Neve Options.
- They should be able to:
  - See all the pages that a super admin user sees
  - If the super admin [enables the plugins in the administration menu](https://vertis.d.pr/i/RXiwvO) the admin should be able to activate a plugin but not install one.
- They should not be able to install or click on the install plugins button. They should see a tooltip asking them to ask the admin to install that specific plugin
- They should be able to create Custom Layouts ( available once you apply the changes from Neve Pro )
- They should NOT be able to edit a custom layout in PHP mode ( available once you apply the changes from Neve Pro )

### Will affect the visual aspect of the product
NO

### Test instructions
- Please test the features described in the Summary section.
- Please check other potential places that I might have missed. Look for buttons that install or activate plugins. For example, they can appear in notices like this one: 
![Screenshot 2023-08-29 at 13 19 21](https://github.com/Codeinwp/neve/assets/9929553/a0378a72-f6e4-4fe7-8b7e-dd915d3aa17f)
- Check the tab when TPC is not installed, there is a button there too.

**NOTE**: Everything else related to TPC will be treated in a separate issue.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4036
<!-- Should look like this: `Closes #1, #2, #3.` . -->
