### PR TITLE
Images not loading in mega menu with AMP

### DIFF
--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -70,7 +70,6 @@
 			position: absolute;
 			padding: 20px 10px;
 			top: auto;
-			display: none;
 
 			&:not(.dropdown-open) {
 				pointer-events: none;


### PR DESCRIPTION
### Summary
- Removed a display none that was causing AMP not to remove the overlay over the images in Mega Menu
I checked https://vertis.d.pr/hNU3z0 that was the reason for adding that display none. The issue in the video is not happening.

### Will affect the visual aspect of the product
NO

### Test instructions
1. Go to WordPress Dashboard > Neve > Neve Options > Neve Pro and enable the Mega Menu setting.
2. Go to your WordPress Dashboard > Appearance > Menus and create a Mega Menu there and [place an image there](https://share.getcloudapp.com/eDuEE254) as I did. 
3. Go to Plugins > Add New and install and Activate AMP Plugin. https://wordpress.org/plugins/amp/
4. Go to AMP > Settings and set the Template Mode to Standard if it's not already that.
5. Place your the Menu in Header using the Customizer > Header Builder
6. Check the image on the frontend 
7. Double-check that [this issue](https://vertis.d.pr/hNU3z0) is not happening 
8. Try the [mega menu from Neve](https://docs.themeisle.com/article/964-neve-mega-menu-setup) free too.


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2586.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
