### PR TITLE
Fix: [i18n] Added text domain to strings

### DIFF
--- a/assets/apps/customizer-controls/src/global-colors/PaletteForm.js
+++ b/assets/apps/customizer-controls/src/global-colors/PaletteForm.js
@@ -50,7 +50,7 @@ const PaletteForm = ({ values, save, disabled }) => {
 					iconSize={16}
 					onClick={toggleAdding}
 				>
-					{__('Add Custom Palette')}
+					{__('Add Custom Palette', 'neve')}
 				</Button>
 			</div>
 		);

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -158,6 +158,7 @@ class Admin {
 
 		wp_localize_script( 'neve-ss-notice', 'tpcPluginData', $this->get_tpc_plugin_data() );
 		wp_enqueue_script( 'neve-ss-notice' );
+		wp_set_script_translations( 'neve-ss-notice', 'neve' );
 	}
 
 	/**

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -177,6 +177,7 @@ class Admin {
 				'customizerURL'           => esc_url( admin_url( 'customize.php' ) ),
 			]
 		);
+		wp_set_script_translations( 'neve-components', 'neve' );
 		wp_register_style( 'neve-components', trailingslashit( NEVE_ASSETS_URL ) . 'apps/components/build/style-components.css', [ 'wp-components' ], $deps['version'] );
 		wp_add_inline_style( 'neve-components', Dynamic_Css::get_root_css() );
 	}


### PR DESCRIPTION
### Summary
Added text domain to strings in PaletteForm.js
Fix to admin.php file for displaying color palette and SS notice text translations

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Install Poedit and generate a language file, you can use this video: https://www.youtube.com/watch?v=HzcZeNZu7To&ab_channel=AuroobaMakes. 
2. Translate "Try one of our ready to use Starter Sites" which is the button text of our welcome notice
3. In WordPress, switch to your new language in dashboard settings
4. Check the notice button text 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4096
<!-- Should look like this: `Closes #1, #2, #3.` . -->
