### PR TITLE
Fix redirect to new onboarding

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
+++ b/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
@@ -3,9 +3,8 @@ import InstallActivate from '../Plugin/InstallActivate';
 import { withSelect } from '@wordpress/data';
 
 const StarterSitesUnavailable = ({ templatesPluginData }) => {
-	const { tpcPath, tpcAdminURL, isOnboarding, assets } = neveDash;
-	const activateRedirect =
-		tpcAdminURL + (isOnboarding ? '&onboarding=yes' : '');
+	const { tpcPath, tpcAdminURL, assets } = neveDash;
+	const activateRedirect = tpcAdminURL + '&onboarding=yes';
 	const currentState = templatesPluginData?.cta || 'install';
 
 	return (

--- a/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
+++ b/assets/apps/dashboard/src/Components/Content/StarterSitesUnavailable.js
@@ -3,8 +3,9 @@ import InstallActivate from '../Plugin/InstallActivate';
 import { withSelect } from '@wordpress/data';
 
 const StarterSitesUnavailable = ({ templatesPluginData }) => {
-	const { tpcPath, tpcAdminURL, assets } = neveDash;
-	const activateRedirect = tpcAdminURL + '&onboarding=yes';
+	const { tpcPath, tpcAdminURL, canInstallPlugins, assets } = neveDash;
+	const activateRedirect =
+		tpcAdminURL + (canInstallPlugins ? '&onboarding=yes' : '');
 	const currentState = templatesPluginData?.cta || 'install';
 
 	return (

--- a/assets/apps/dashboard/src/Components/PluginCard.js
+++ b/assets/apps/dashboard/src/Components/PluginCard.js
@@ -83,7 +83,8 @@ const Card = ({ slug, data, setPluginState }) => {
 							setPluginState(slug, 'activate');
 						}
 						if ('templates-patterns-collection' === slug) {
-							window.location.reload();
+							window.location.href =
+								neveDash.tpcAdminURL + '&onboarding=yes';
 						}
 						setInProgress(false);
 					});

--- a/assets/apps/dashboard/src/Components/PluginCard.js
+++ b/assets/apps/dashboard/src/Components/PluginCard.js
@@ -84,7 +84,10 @@ const Card = ({ slug, data, setPluginState }) => {
 						}
 						if ('templates-patterns-collection' === slug) {
 							window.location.href =
-								neveDash.tpcAdminURL + '&onboarding=yes';
+								neveDash.tpcAdminURL +
+								(neveDash.canInstallPlugins
+									? '&onboarding=yes'
+									: '');
 						}
 						setInProgress(false);
 					});

--- a/assets/apps/starter-sites/src/ss-try-button/SSTryButton.tsx
+++ b/assets/apps/starter-sites/src/ss-try-button/SSTryButton.tsx
@@ -34,6 +34,7 @@ type TPCPluginData = {
 	pluginsURL: string;
 	ajaxURL: string;
 	ajaxNonce: string;
+	canInstall: boolean;
 };
 
 const get = async (route: string, useNonce = '') => {
@@ -67,7 +68,9 @@ const dismiss = async (route: string, action = '', useNonce = '') => {
 
 const SSTryButton: React.FC = () => {
 	const templatesPluginData = window.tpcPluginData as TPCPluginData;
-	const tpcRedirect = templatesPluginData.adminURL + '&onboarding=yes';
+	const tpcRedirect =
+		templatesPluginData.adminURL +
+		(templatesPluginData.canInstall ? '&onboarding=yes' : '');
 
 	const [installing, setInstalling] = useState(false);
 	const [activating, setActivating] = useState(false);

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -131,6 +131,7 @@ class Admin {
 		$tpc_plugin_data['pluginsURL'] = esc_url( admin_url( 'plugins.php' ) );
 		$tpc_plugin_data['ajaxURL']    = esc_url( admin_url( 'admin-ajax.php' ) );
 		$tpc_plugin_data['ajaxNonce']  = esc_attr( wp_create_nonce( 'remove_notice_confirmation' ) );
+		$tpc_plugin_data['canInstall'] = current_user_can( 'install_plugins' );
 
 		return $tpc_plugin_data;
 	}
@@ -484,8 +485,14 @@ class Admin {
 				$name
 			)
 		);
-		$ob_btn_link = admin_url( defined( 'TIOB_PATH' ) ? 'admin.php?page=tiob-starter-sites&onboarding=yes' : 'admin.php?page=' . $theme_page . '&onboarding=yes#starter-sites' );
-		$ob_btn      = sprintf(
+		$ob_btn_link = 'admin.php?page=' . $theme_page . '&onboarding=yes#starter-sites';
+		if ( admin_url( defined( 'TIOB_PATH' ) ) ) {
+			$ob_btn_link = 'admin.php?page=tiob-starter-sites';
+			if ( current_user_can( 'install_plugins' ) ) {
+				$ob_btn_link .= '&onboarding=yes';
+			}
+		}
+		$ob_btn = sprintf(
 		/* translators: 1 - onboarding url, 2 - button text */
 			'<a href="%1$s" class="button button-primary button-hero install-now" >%2$s</a>',
 			esc_url( $ob_btn_link ),

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -485,12 +485,13 @@ class Admin {
 				$name
 			)
 		);
-		$ob_btn_link = 'admin.php?page=' . $theme_page . '&onboarding=yes#starter-sites';
-		if ( admin_url( defined( 'TIOB_PATH' ) ) ) {
-			$ob_btn_link = 'admin.php?page=tiob-starter-sites';
+		$ob_btn_link = admin_url( 'admin.php?page=' . $theme_page . '&onboarding=yes#starter-sites' );
+		if ( defined( 'TIOB_PATH' ) ) {
+			$url_path = 'admin.php?page=tiob-starter-sites';
 			if ( current_user_can( 'install_plugins' ) ) {
-				$ob_btn_link .= '&onboarding=yes';
+				$url_path .= '&onboarding=yes';
 			}
+			$ob_btn_link = admin_url( $url_path );
 		}
 		$ob_btn = sprintf(
 		/* translators: 1 - onboarding url, 2 - button text */


### PR DESCRIPTION
### Summary
Change the redirect button link to the new onboarding.

### Will affect the visual aspect of the product
NO


### Test instructions
- Please install this version of Neve
- Go to Neve's dashboard and check the Starter Sites tab
- Install TPC from there. After the installation, the redirect to the new onboarding should happen.
- The same thing should happen when you install TPC from Neve Dashboard plugins tab and from About Us
- I don't recall to be other TPC installations but please have another look and see if I missed something

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/templates-patterns-collection#289
<!-- Should look like this: `Closes #1, #2, #3.` . -->
