### PR TITLE
Support changes for custom payment icons in pro

### DIFF
--- a/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
+++ b/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
@@ -3,6 +3,7 @@ import {
 	SelectControl,
 	TextControl,
 	ToggleControl,
+	TextareaControl,
 } from '@wordpress/components';
 import IconSelector from './IconSelector';
 import { getIcons, ColorControl } from '@neve-wp/components';
@@ -68,6 +69,15 @@ const RepeaterItemContent = ({
 			case 'text':
 				return (
 					<TextControl
+						label={currentField.label}
+						value={value[index][key] || currentField.default}
+						onChange={(newData) => changeContent(key, newData)}
+						key={key + index}
+					/>
+				);
+			case 'textarea':
+				return (
+					<TextareaControl
 						label={currentField.label}
 						value={value[index][key] || currentField.default}
 						onChange={(newData) => changeContent(key, newData)}

--- a/start.php
+++ b/start.php
@@ -34,6 +34,7 @@ function neve_run() {
 			'hfg_d_search_iconbutton'   => true, // Dynamic icon selection or a button for search components
 			'restrict_content'          => true,
 			'theme_dedicated_menu'      => true, // Theme uses the new menu location for settings and sub-pages.
+			'custom_payment_icons'      => true,
 		]
 	);
 	$vendor_file = trailingslashit( get_template_directory() ) . 'vendor/autoload.php';


### PR DESCRIPTION
### Summary
Added some support chages for custom payment icons feature in PRO

### Will affect visual aspect of the product
NO

### Test instructions
- Nothing to test here, check the PR from Neve Pro


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2549.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
