### PR TITLE
fix: Related Posts Exerpt

### DIFF
--- a/inc/views/partials/post_meta.php
+++ b/inc/views/partials/post_meta.php
@@ -318,7 +318,6 @@ class Post_Meta extends Base_View {
 		$markup = apply_filters( 'neve_filter_author_meta_markup', $markup, $post_id, $show_before );
 
 		$post = $original_global_post; //phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-		wp_reset_postdata();
 		return wp_kses_post( $markup );
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
This was triggered only when also using the Author meta.

References: #4011

This was a bug introduced with the changes from #4011 the `wp_reset_postdata` would reset the secondary query back to the main query. It should not be required and have both issues fixed without the need for resetting the post data.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details open>
   <summary><h4>Related Posts displaying correct excerpt</h4></summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/ed0acd74-cd77-42c6-9004-6613537987ef)
</details>

<details>
   <summary><h4>Sticky Post Author Name</h4></summary>

![image](https://github.com/Codeinwp/neve/assets/23024731/461a48e6-3e96-41ec-b7f4-7e2364f405bc)
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->

<details open>
    <summary><h4>Test Related Posts Exerpt</h4></summary>

1. Enable the related posts section on the single post
2. Add two, three, or more articles in the same category
3. Check a post.
4. Each post should display the correct excerpt, previously it would show the excerpt from the main post.
5. Check the **Read More** link as well.
6. As a last step use the testing from https://github.com/Codeinwp/neve/pull/4037 to ensure no regression is introduced and the issue remains fixed.

</details>

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2656.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
