### PR TITLE
Popover issues in wp 6.4

### DIFF
--- a/assets/apps/components/src/Common/DropdownFix.js
+++ b/assets/apps/components/src/Common/DropdownFix.js
@@ -145,6 +145,7 @@ export default function Dropdown(props) {
 						popoverProps ? popoverProps.className : undefined,
 						contentClassName
 					)}
+					inline={true}
 				>
 					{renderContent(args)}
 				</Popover>

--- a/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
@@ -177,6 +177,8 @@ const ComponentsPopover: React.FC<Props> = ({
 			position="top center"
 			className="items-popover"
 			onFocusOutside={closePopup}
+			// @ts-ignore
+			inline={true}
 		>
 			<div className="popover-header">
 				<Icon icon={search} />

--- a/assets/apps/customizer-controls/src/font-family/FontFamilySelector.js
+++ b/assets/apps/customizer-controls/src/font-family/FontFamilySelector.js
@@ -197,6 +197,7 @@ const FontFamilySelector = ({
 							setVisible(false);
 							setSearch('');
 						}}
+						inline={true}
 					>
 						{fonts ? getFontList() : __('In Progress', 'neve')}
 					</Popover>

--- a/assets/apps/customizer-controls/src/repeater/IconSelector.js
+++ b/assets/apps/customizer-controls/src/repeater/IconSelector.js
@@ -51,6 +51,7 @@ const IconSelector = ({ label, value, onIconChoice, icons }) => {
 					onFocusOutside={() => {
 						setVisible(!visible);
 					}}
+					inline={true}
 				>
 					{
 						<Suspense fallback={<Spinner />}>


### PR DESCRIPTION
### Summary
- Fix the popover issue that appears in WP 6.4. The source of it comes from https://github.com/WordPress/gutenberg/pull/53889

### Will affect the visual aspect of the product
NO

### Test instructions
- Please test if the problems mentioned inside the issue's body are fixed

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4107.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
