### PR TITLE
Fix wrong position of search input on minimal when it does not fit in the space.

### DIFF
--- a/assets/js/src/frontend/hgf.js
+++ b/assets/js/src/frontend/hgf.js
@@ -38,16 +38,15 @@ const toggleAria = (elements, add = true) => {
  * @param {boolean} skipSidebar
  */
 HFG.prototype.init = function (skipSidebar = false) {
+	const doc = window.document;
 	if (skipSidebar === false) {
-		const closeButtons = document.querySelectorAll(closeNavSelector);
+		const closeButtons = doc.querySelectorAll(closeNavSelector);
 		addEvent(closeButtons, 'click', () => {
 			this.toggleMenuSidebar(false);
 		});
 	}
 
-	const menuMobileToggleButtons = document.querySelectorAll(
-		'.menu-mobile-toggle'
-	);
+	const menuMobileToggleButtons = doc.querySelectorAll('.menu-mobile-toggle');
 	addEvent(menuMobileToggleButtons, 'click', (event) => {
 		this.toggleMenuSidebar(
 			!event.target.parentElement.classList.contains('is-active'),
@@ -58,7 +57,7 @@ HFG.prototype.init = function (skipSidebar = false) {
 	/**
 	 * When click to outside of menu sidebar.
 	 */
-	const overlay = document.querySelector('.header-menu-sidebar-overlay');
+	const overlay = doc.querySelector('.header-menu-sidebar-overlay');
 	if (overlay) {
 		addEvent(
 			overlay,
@@ -77,36 +76,37 @@ HFG.prototype.init = function (skipSidebar = false) {
  * @param {Element} target
  */
 HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
+	const doc = window.document;
 	const TOGGLE_CLASS_CONTAINER = '.menu-mobile-toggle';
-	const buttonsContainer = document.querySelectorAll(TOGGLE_CLASS_CONTAINER);
-	removeClass(document.body, sidebarClasses[1]);
+	const buttonsContainer = doc.querySelectorAll(TOGGLE_CLASS_CONTAINER);
+	removeClass(doc.body, sidebarClasses[1]);
 
 	/**
 	 * Elements to apply aria-hidden on
 	 */
-	const ariaShowOnToggle = document.querySelectorAll(
+	const ariaShowOnToggle = doc.querySelectorAll(
 		'#header-menu-sidebar, .hfg-ov'
 	);
-	const ariaHideOnToggle = document.querySelectorAll(
+	const ariaHideOnToggle = doc.querySelectorAll(
 		'.neve-skip-link, #content, .scroll-to-top, #site-footer, .header--row'
 	);
 
 	if (
 		(!NeveProperties.isCustomize &&
-			document.body.classList.contains(sidebarClasses[0])) ||
+			doc.body.classList.contains(sidebarClasses[0])) ||
 		toggle === false
 	) {
-		const navClickaway = document.querySelector('.nav-clickaway-overlay');
+		const navClickaway = doc.querySelector('.nav-clickaway-overlay');
 		if (navClickaway !== null) {
 			navClickaway.parentNode.removeChild(navClickaway);
 		}
-		addClass(document.body, sidebarClasses[1]);
-		removeClass(document.body, sidebarClasses[0]);
+		addClass(doc.body, sidebarClasses[1]);
+		removeClass(doc.body, sidebarClasses[0]);
 		removeClass(buttonsContainer, sidebarClasses[2]);
 		// Remove the hiding class after 1 second.
 		setTimeout(
 			function () {
-				removeClass(document.body, sidebarClasses[1]);
+				removeClass(doc.body, sidebarClasses[1]);
 			}.bind(this),
 			1000
 		);
@@ -117,17 +117,15 @@ HFG.prototype.toggleMenuSidebar = function (toggle, target = null) {
 		toggleAria(ariaHideOnToggle, false);
 		toggleAria(ariaShowOnToggle);
 		// Remove focus trap when closing.
-		document.dispatchEvent(new CustomEvent(NV_FOCUS_TRAP_END));
+		doc.dispatchEvent(new CustomEvent(NV_FOCUS_TRAP_END));
 	} else {
-		addClass(document.body, sidebarClasses[0]);
+		addClass(doc.body, sidebarClasses[0]);
 		addClass(buttonsContainer, sidebarClasses[2]);
 		if (target) {
-			document.dispatchEvent(
+			doc.dispatchEvent(
 				new CustomEvent(NV_FOCUS_TRAP_START, {
 					detail: {
-						container: document.getElementById(
-							'header-menu-sidebar'
-						),
+						container: doc.getElementById('header-menu-sidebar'),
 						close: closeNavSelector,
 						firstFocus: closeNavSelector + ',.menu-item a',
 						backFocus: target,

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -29,12 +29,14 @@ export const initNavigation = () => {
  */
 export const repositionDropdowns = () => {
 	const { isRTL } = NeveProperties;
-	const dropDowns =
-		document.querySelectorAll('.sub-menu, .minimal .nv-nav-search') || [];
+	const dropDowns = document.querySelectorAll(
+		'.sub-menu, .minimal .nv-nav-search'
+	);
 
 	if (dropDowns.length === 0) return;
 
 	const windowWidth = window.innerWidth;
+
 	dropDowns.forEach((dropDown) => {
 		let bounding = dropDown.getBoundingClientRect(),
 			rightDist = bounding.left;
@@ -49,14 +51,17 @@ export const repositionDropdowns = () => {
 			dropDown.style.left = 'auto';
 		}
 
+		// Recalculate bounding after we've made adjustments.
 		bounding = dropDown.getBoundingClientRect();
 		rightDist = bounding.left;
 
 		if (rightDist < 0 || rightDist + bounding.width >= windowWidth) {
 			// Calculate how much should we offset the dropdown to make it fit.
-			dropDown.style.transform = `translateX(${isRTL ? '-' : ''}${
-				Math.abs(rightDist) + 20 // Difference + 20px padding.
-			}px)`;
+			dropDown.style.transform =
+				'translateX(' +
+				(isRTL ? '-' : '') +
+				(Math.abs(rightDist) + 20) +
+				'px)';
 		}
 	});
 	if (typeof menuCalcEvent !== 'undefined') {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -36,7 +36,7 @@ export const repositionDropdowns = () => {
 
 	const windowWidth = window.innerWidth;
 	dropDowns.forEach((dropDown) => {
-		const bounding = dropDown.getBoundingClientRect(),
+		let bounding = dropDown.getBoundingClientRect(),
 			rightDist = bounding.left;
 
 		if (rightDist < 0) {
@@ -47,6 +47,16 @@ export const repositionDropdowns = () => {
 		if (rightDist + bounding.width >= windowWidth) {
 			dropDown.style.right = isRTL ? 0 : '100%';
 			dropDown.style.left = 'auto';
+		}
+
+		bounding = dropDown.getBoundingClientRect();
+		rightDist = bounding.left;
+
+		if (rightDist < 0 || rightDist + bounding.width >= windowWidth) {
+			// Calculate how much should we offset the dropdown to make it fit.
+			dropDown.style.transform = `translateX(${isRTL ? '-' : ''}${
+				Math.abs(rightDist) + 20 // Difference + 20px padding.
+			}px)`;
 		}
 	});
 	if (typeof menuCalcEvent !== 'undefined') {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -186,15 +186,16 @@ function startFocusTrap(event) {
  * Handle searches.
  */
 function handleSearch() {
-	const navSearch = document.querySelectorAll('.nv-nav-search') || [],
-		navItem = document.querySelectorAll('.menu-item-nav-search') || [],
-		close = document.querySelectorAll('.close-responsive-search') || [];
+	const doc = window.document;
+	const navSearch = doc.querySelectorAll('.nv-nav-search') || [],
+		navItem = doc.querySelectorAll('.menu-item-nav-search') || [],
+		close = doc.querySelectorAll('.close-responsive-search') || [];
 	addEvent(navItem, 'click', (e, searchItem) => {
 		e.preventDefault();
 		e.stopPropagation();
 		toggleClass(searchItem, strings[1]);
 		createNavOverlay(searchItem, strings[1]);
-		document.dispatchEvent(
+		doc.dispatchEvent(
 			new CustomEvent(NV_FOCUS_TRAP_START, {
 				detail: {
 					container: searchItem.querySelector('.nv-nav-search'),
@@ -211,7 +212,7 @@ function handleSearch() {
 	addEvent(close, 'click', (e) => {
 		e.preventDefault();
 		removeClass(navItem, strings[1]);
-		const overlay = document.querySelector(`.${strings[2]}`);
+		const overlay = doc.querySelector(`.${strings[2]}`);
 		if (overlay === null) {
 			return;
 		}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

By default, the search input is positioned on the left or the right of the search icon, depending on the position. The input popup might be partially offscreen if the search icon is in the middle of a position not too close to the edge.

To solve this, I added an extra step that rechecks if the search input fits. If not, I add an extra offset on the X-axis, which solves the offscreen bug. ℹ️ This is the solution with the least amount of code, which helps us to stay below the limit.

> [!TIP]
> Create an alias for `document.window` to save space. The build does not do an aggressive optimization to do this step automatically.  

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

#### Before
<img width="480" alt="Screenshot 2023-12-04 at 11 37 54" src="https://github.com/Codeinwp/neve/assets/17597852/2bdfe060-9237-49d8-8509-242e5b9d9078">

#### After
<img width="448" alt="Screenshot 2023-12-04 at 11 36 47" src="https://github.com/Codeinwp/neve/assets/17597852/4eda233e-aee4-4c5c-9223-47c87a7084ce">



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Like in the issue, position the icon search near the middle and check in a small window.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4017
<!-- Should look like this: `Closes #1, #2, #3.` . -->
