### PR TITLE
Fix the opening of Search Icon in Mobile Sidebar.

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -226,7 +226,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		$sidebar_animation_css .= '.is-menu-sidebar.menu_sidebar_dropdown .header-menu-sidebar { height: auto; }';
 		$sidebar_animation_css .= '.is-menu-sidebar.menu_sidebar_dropdown .header-menu-sidebar-inner { max-height: 400px; padding: 20px 0; }';
 		$sidebar_animation_css .= '.is-menu-sidebar.menu_sidebar_full_canvas .header-menu-sidebar { opacity: 1; }';
-		$sidebar_animation_css .= '.header-menu-sidebar .menu-item-nav-search { pointer-events: none; }';
+		$sidebar_animation_css .= '.header-menu-sidebar .menu-item-nav-search:not(.floating) { pointer-events: none; }';
 		$sidebar_animation_css .= '.header-menu-sidebar .menu-item-nav-search .is-menu-sidebar & { pointer-events: unset; }';
 		/* Accessibility css. */
 		$accessibility_caret_css  = '.nav-ul li:focus-within .wrap.active + .sub-menu { opacity: 1; visibility: visible; }';


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The search icon no longer be opened because of the CSS property that nullifies the click event. 

This regression was introduced in this commit https://github.com/Codeinwp/neve/commit/320f2ee363b5090c9630ce39a6cd599cf0e2b560 for this issue https://github.com/Codeinwp/neve/issues/3729 (which seems to have a rich history)

I added an exception to the CSS selector to ensure that Search Icon is not targeted. The identification is made via the unique class `.floating`.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/neve/assets/17597852/702904a3-d67d-458b-80c2-090645fe962f


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add the Search Icon in the Mobile Sidebar
- Check if you can open/close.

> [!NOTE]  
> It will be good to check other search components to see if they have the same problem with click. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #2702
<!-- Should look like this: `Closes #1, #2, #3.` . -->
