### PR TITLE
Enable full HTML5 theme support

### DIFF
--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -58,7 +58,7 @@ class Front_End {
 		add_theme_support( 'fl-theme-builder-headers' );
 		add_theme_support( 'fl-theme-builder-parts' );
 		add_theme_support( 'header-footer-elementor' );
-		add_theme_support( 'html5', array( 'search-form', 'script' ) );
+		add_theme_support( 'html5', array( 'search-form', 'script', 'style', 'comment-form', 'comment-list', 'gallery', 'caption' ) );
 		add_theme_support( 'lifterlms-sidebars' );
 		add_theme_support( 'lifterlms' );
 		add_theme_support( 'link-color' );

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -58,7 +58,7 @@ class Front_End {
 		add_theme_support( 'fl-theme-builder-headers' );
 		add_theme_support( 'fl-theme-builder-parts' );
 		add_theme_support( 'header-footer-elementor' );
-		add_theme_support( 'html5', array( 'search-form' ) );
+		add_theme_support( 'html5', array( 'search-form', 'script' ) );
 		add_theme_support( 'lifterlms-sidebars' );
 		add_theme_support( 'lifterlms' );
 		add_theme_support( 'link-color' );


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Not having HTML5 support for scripts might impact some users who use specific plugins. More context about the problem [here](https://wordpress.org/support/topic/popular-posts-disapeared-after-wp6-4-update/#post-17184460)

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure that the build is OK.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4167
<!-- Should look like this: `Closes #1, #2, #3.` . -->
