### PR TITLE
chore: use 7.4 for PHP tests

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -54,7 +54,7 @@ jobs:
         - name: Setup PHP version
           uses: shivammathur/setup-php@v2
           with:
-            php-version: '7.1'
+            php-version: '7.4'
             extensions: simplexml, mysql
             tools: phpunit-polyfills
         - name: Checkout source code

--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.1'
+          php-version: '7.4'
           extensions: simplexml
           tools: composer:v2.1
       - name: Checkout source code

--- a/tests/test-neve-dynamic-selector.php
+++ b/tests/test-neve-dynamic-selector.php
@@ -286,7 +286,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '' . $subscriber;
 
 		$this->assertStringContainsString( ",.one-test-selector", $css );
-		$this->assertStringContainsString( \Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER, $css );
+		$this->assertStringContainsString( \Neve\Core\Settings\Config::$css_selectors_map[\Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER], $css );
 		$this->assertStringContainsString( "color: #fff", $css );
 	}
 }

--- a/tests/test-neve-dynamic-selector.php
+++ b/tests/test-neve-dynamic-selector.php
@@ -33,7 +33,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '';
 		$css        .= $subscriber;
 		$this->assertNotEmpty( $css );
-		$this->assertContains( "#ccc", $css );
+		$this->assertStringContainsString( "#ccc", $css );
 	}
 
 	public function test_css_generation_with_generic_rule() {
@@ -45,7 +45,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		] );
 		$css        = '';
 		$css        .= $subscriber;
-		$this->assertContains('--css-var-example', $css);
+		$this->assertStringContainsString('--css-var-example', $css);
 		$this->assertNotEmpty( $css );
 	}
 
@@ -65,7 +65,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 
 		$this->assertNotEmpty( $css );
 		$this->assertNotContains( "#bada55", $css );
-		$this->assertContains( "var(--nv-text-color)", $css );
+		$this->assertStringContainsString( "var(--nv-text-color)", $css );
 	}
 
 	public function test_css_generation_with_key() {
@@ -81,7 +81,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        .= $subscriber;
 
 		$this->assertNotEmpty( $css );
-		$this->assertContains( "#eee", $css );
+		$this->assertStringContainsString( "#eee", $css );
 	}
 
 	public function test_css_generation_with_suffix() {
@@ -98,7 +98,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        .= $subscriber;
 
 		$this->assertNotEmpty( $css );
-		$this->assertContains( "333em", $css );
+		$this->assertStringContainsString( "333em", $css );
 	}
 
 	public function test_css_generation_with_default() {
@@ -113,7 +113,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '';
 		$css        .= $subscriber;
 		$this->assertNotEmpty( $css );
-		$this->assertContains( "929", $css );
+		$this->assertStringContainsString( "929", $css );
 	}
 
 	public function test_css_generation_with_filter() {
@@ -132,7 +132,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '';
 		$css        .= $subscriber;
 		$this->assertNotEmpty( $css );
-		$this->assertContains( "box-shadow: 333px;", $css );
+		$this->assertStringContainsString( "box-shadow: 333px;", $css );
 	}
 
 	public function test_css_generation_on_breakpoints() {
@@ -149,7 +149,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$tablet_css  = '' . $subscriber->for_tablet();
 
 		$this->assertNotEmpty( $mobile_css );
-		$this->assertContains( "929", $mobile_css );
+		$this->assertStringContainsString( "929", $mobile_css );
 		$this->assertEmpty( $desktop_css );
 		$this->assertEmpty( $tablet_css );
 	}
@@ -172,9 +172,9 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$mobile_css  = '' . $subscriber;
 		$desktop_css = '' . $subscriber->for_desktop();
 		$tablet_css  = '' . $subscriber->for_tablet();
-		$this->assertContains( "10px;", $mobile_css );
-		$this->assertContains( "50px;", $desktop_css );
-		$this->assertContains( "300px;", $tablet_css );
+		$this->assertStringContainsString( "10px;", $mobile_css );
+		$this->assertStringContainsString( "50px;", $desktop_css );
+		$this->assertStringContainsString( "300px;", $tablet_css );
 	}
 
 	public function test_css_generation_with_responsiveness_encoded() {
@@ -194,9 +194,9 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$mobile_css  = '' . $subscriber;
 		$desktop_css = '' . $subscriber->for_desktop();
 		$tablet_css  = '' . $subscriber->for_tablet();
-		$this->assertContains( "10px;", $mobile_css );
-		$this->assertContains( "50px;", $desktop_css );
-		$this->assertContains( "300px;", $tablet_css );
+		$this->assertStringContainsString( "10px;", $mobile_css );
+		$this->assertStringContainsString( "50px;", $desktop_css );
+		$this->assertStringContainsString( "300px;", $tablet_css );
 	}
 
 	public function test_css_generation_with_responsiveness_no_devices() {
@@ -212,9 +212,9 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$mobile_css  = '' . $subscriber;
 		$desktop_css = '' . $subscriber->for_desktop();
 		$tablet_css  = '' . $subscriber->for_tablet();
-		$this->assertContains( "200px;", $mobile_css );
-		$this->assertContains( "200px;", $desktop_css );
-		$this->assertContains( "200px;", $tablet_css );
+		$this->assertStringContainsString( "200px;", $mobile_css );
+		$this->assertStringContainsString( "200px;", $desktop_css );
+		$this->assertStringContainsString( "200px;", $tablet_css );
 	}
 
 	public function test_css_generation_responsiveness_with_subkey() {
@@ -236,9 +236,9 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$mobile_css  = '' . $subscriber;
 		$desktop_css = '' . $subscriber->for_desktop();
 		$tablet_css  = '' . $subscriber->for_tablet();
-		$this->assertContains( "555px;", $mobile_css );
-		$this->assertContains( "666px;", $desktop_css );
-		$this->assertContains( "777px;", $tablet_css );
+		$this->assertStringContainsString( "555px;", $mobile_css );
+		$this->assertStringContainsString( "666px;", $desktop_css );
+		$this->assertStringContainsString( "777px;", $tablet_css );
 	}
 
 	public function test_css_generation_responsiveness_with_subkey_with_suffix() {
@@ -265,9 +265,9 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$mobile_css  = '' . $subscriber;
 		$desktop_css = '' . $subscriber->for_desktop();
 		$tablet_css  = '' . $subscriber->for_tablet();
-		$this->assertContains( "555em;", $mobile_css );
-		$this->assertContains( "666%;", $desktop_css );
-		$this->assertContains( "777px;", $tablet_css );
+		$this->assertStringContainsString( "555em;", $mobile_css );
+		$this->assertStringContainsString( "666%;", $desktop_css );
+		$this->assertStringContainsString( "777px;", $tablet_css );
 	}
 
 	public function test_css_generation_with_extra_selectors() {
@@ -286,7 +286,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '' . $subscriber;
 
 		$this->assertContains( ",.one-test-selector", $css );
-		$this->assertNotContains( \Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER, $css );
+		$this->assertStringContainsString( \Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER, $css );
 		$this->assertContains( "color: #fff", $css );
 	}
 }

--- a/tests/test-neve-dynamic-selector.php
+++ b/tests/test-neve-dynamic-selector.php
@@ -286,6 +286,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        = '' . $subscriber;
 
 		$this->assertStringContainsString( ",.one-test-selector", $css );
+		$this->assertStringNotContainsString( \Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER, $css );
 		$this->assertStringContainsString( \Neve\Core\Settings\Config::$css_selectors_map[\Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER], $css );
 		$this->assertStringContainsString( "color: #fff", $css );
 	}

--- a/tests/test-neve-dynamic-selector.php
+++ b/tests/test-neve-dynamic-selector.php
@@ -64,7 +64,7 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		$css        .= $subscriber;
 
 		$this->assertNotEmpty( $css );
-		$this->assertNotContains( "#bada55", $css );
+		$this->assertStringNotContainsString( "#bada55", $css );
 		$this->assertStringContainsString( "var(--nv-text-color)", $css );
 	}
 
@@ -285,8 +285,8 @@ class TestDynamicSelector extends WP_UnitTestCase {
 		] );
 		$css        = '' . $subscriber;
 
-		$this->assertContains( ",.one-test-selector", $css );
+		$this->assertStringContainsString( ",.one-test-selector", $css );
 		$this->assertStringContainsString( \Neve\Core\Settings\Config::CSS_SELECTOR_BTN_PRIMARY_HOVER, $css );
-		$this->assertContains( "color: #fff", $css );
+		$this->assertStringContainsString( "color: #fff", $css );
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Use the same PHP version running for Lint and PHPUnit as in PHPStan.

> [!NOTE]  
> PHPUnit 9 will be used to run the tests.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Just an update to dev tools. Nothing should be changed in the build.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4169
<!-- Should look like this: `Closes #1, #2, #3.` . -->
