### PR TITLE
fix: woo block checkout cupon button Codeinwp/neve-pro-addon#2697

### DIFF
--- a/assets/scss/components/compat/woocommerce/_checkout.scss
+++ b/assets/scss/components/compat/woocommerce/_checkout.scss
@@ -144,7 +144,7 @@
 		border: 0 !important;
 	}
 
-	main button {
+	main button:not(.wc-block-components-button) {
 		width: 100%;
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Fixes the coupon code button on the WooCommerce checkout page when using the WooCommerce blocks.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<img width="923" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/19c4bc99-3b05-4352-9288-e054e9badf6a">


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On an instance with Neve, Neve Pro, and WooCommerce 8.3
2. Change the checkout page to use blocks
3. Check that when clicking `Add discount Code` the input and button display correctly, previously the button would take up all the space available.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2697
<!-- Should look like this: `Closes #1, #2, #3.` . -->
