### PR TITLE
fix: make woo breadcrumps scrollable

### DIFF
--- a/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
+++ b/assets/scss/components/compat/woocommerce/_breadcrumbs.scss
@@ -4,6 +4,13 @@
 	color: var(--nv-text-color);
 	font-size: 14px;
 	white-space: nowrap;
+	scrollbar-width: none; /* Firefox */
+	overflow-x: scroll;
+
+	&::-webkit-scrollbar {
+		display: none; /* Chrome, Safari, Opera*/
+	}
+
 
 	a {
 		color: var(--nv-secondary-accent);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This [property ](https://github.com/Codeinwp/neve/blob/388f8d7485c81c7633030ed39b610bd5c0efd758/assets/scss/components/compat/woocommerce/_breadcrumbs.scss#L6)prevents long breadcrumb names from wrapping, thus creating an overflow that was inaccessible to the user. 

To solve this, I made the breadcrumbs scrollable like on the [reference point](https://www.emag.ro/masina-de-spalat-rufe-arctic-8-kg-1000-rpm-clasa-c-motor-silent-inverter-extrasteam-alb-apl81023xlw0/pd/D4YDZ3MBM/ )

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/neve/assets/17597852/2c687fab-dd08-4321-80ef-392420eb524b

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Have WooCommerce with some long product names
- On Mobile, check if the breadcrumbs are scrollable.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4112 
<!-- Should look like this: `Closes #1, #2, #3.` . -->
