### PR TITLE
fix: alignment of secondary menu on mobile #4015

### DIFF
--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -209,7 +209,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap a { flex-grow: 1; display: flex; }';
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap a .dd-title { width: var(--wrapdropdownwidth); }';
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap button { border: 0; z-index: 1; background: 0; }';
-		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li:not([class*=block]):not(.menu-item-has-children) > .wrap > a { padding-right: calc(1em + (18px*2));}';
+		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li.menu-item-has-children:not([class*=block])  > .wrap > a { margin-right: calc(-1em - (18px*2));}';
 
 		return Dynamic_Css::minify_css( $mobile_button_caret_css );
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Changes the spacing between the text and submenu toggle to keep the elements aligned to the center on mobile even when a submenu is not present. 

It also accounts for the previous fix for the submenu alignment https://github.com/Codeinwp/neve/issues/3980 ie. it keeps the elements aligned when the submenu toggle is present.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->

YES 
### Screenshots <!-- if applicable -->

[Alignment on mobile when submenu is present](https://vertis.d.pr/i/qiCpTO)

[Alignment for the secundary menu when submenu's are defined for the primary menu](https://vertis.d.pr/i/Nwokuk)
### Test instructions
<!-- Describe how this pull request can be tested. -->

First we need to test that the secundary menu is aligned to center on mobile as in the issue description: 

   1. Create a primary and a secondary menu, without any submenus
   2. Add the primary menu on desktop and the secondary menu in the mobile sidebar
   3.  Set the mobile sidebar alignment to center and check the frontend
   4.  Create a submenu for the primary menu and check again the mobile sidebar in frontend
   5. Check that the secundary menu is aligned to the center on mobile. 

We also need to ensure we do not introduce a regression by breaking the fix for https://github.com/Codeinwp/neve/issues/3980. 

For this the steps are: 

1. Create a primary menu with submenu's. 
2. Add the primary menu to the mobile and set the Mobile sidebar to the Center .
3. Check the alignment between the menu elements. 



## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4015.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
