### PR TITLE
fix: SEO site-title tag for homepage

### DIFF
--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -12,7 +12,8 @@ namespace HFG;
 use HFG\Core\Builder\Header as HeaderBuilder;
 use HFG\Core\Components\Logo;
 
-$_id = current_component( HeaderBuilder::BUILDER_NAME )->get_id();
+$_id    = current_component( HeaderBuilder::BUILDER_NAME )->get_id();
+$device = current_device( HeaderBuilder::BUILDER_NAME );
 
 $show_name     = component_setting( Logo::SHOW_TITLE );
 $show_desc     = component_setting( Logo::SHOW_TAGLINE );
@@ -26,7 +27,7 @@ $conditional_logo = json_decode( component_setting( Logo::LOGO, Logo::sanitize_l
 $custom_logo_id   = isset( $conditional_logo['light'] ) ? $conditional_logo['light'] : $active_logo;
 
 $wrapper_tag = 'p';
-if ( get_option( 'show_on_front' ) === 'posts' && is_home() ) {
+if ( get_option( 'show_on_front' ) === 'posts' && is_home() && $device === 'desktop' ) {
 	$wrapper_tag = 'h1';
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Changed the tag for `site-title` on mobile to use `p` instead of `h1` the same as for all other pages where the site title should not be the main title. SEO will now see only the `h1` used by the desktop on the homepage where usually no other main title is present.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Create a new instance with Neve and set the home page to your latest posts
2. Add the Logo & Site Identity component
3. Set a site title if not already set
4. Enable `Show Site Title`
5. Check on the front-end homepage that only one h1 tag is present.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #3984.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
