### PR TITLE
fix: single post title alignment on full width

### DIFF
--- a/assets/scss/components/elements/blog/_single.scss
+++ b/assets/scss/components/elements/blog/_single.scss
@@ -110,6 +110,7 @@
 	background-size: cover;
 	background-repeat: no-repeat;
 	background-position: center;
+	text-align: var(--textalign, center);
 
 	.nv-title-meta-wrap {
 		color: var(--color, var(--nv-text-dark-bg));
@@ -130,7 +131,6 @@
 	.container {
 		display: flex;
 		justify-content: var(--justify, center);
-		text-align: var(--textalign, center);
 	}
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The text alignment CSS property for the title in Single Post was only used when the option `Cover Container` had `contained` as a value. For value `Full Width`, it was missing because the CSS property was only on `.container` selector.

Moving the CSS property to parent `.nv-post-cover` solves this issue.


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->


https://github.com/Codeinwp/neve/assets/17597852/0d3fee57-0035-4a9f-a272-3eae8d4dbfe6

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make a long title for the Post
- Go to Customizer > Layout > Single Post
- Modify the `Cover Container` like in the video

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4018
<!-- Should look like this: `Closes #1, #2, #3.` . -->
