### PR TITLE
fix: woocommerce notices for wc8.5 #4189

### DIFF
--- a/assets/scss/components/compat/woocommerce/_notices.scss
+++ b/assets/scss/components/compat/woocommerce/_notices.scss
@@ -64,6 +64,75 @@ $notices: (
 	}
 }
 
+$blockNotices: (
+	"success": $success,
+	"error": $error,
+	"info": var(--nv-primary-accent),
+);
+
+.neve-main .wc-block-components-notice-banner {
+	--btnfs: $text-sm;
+	--primarybtnpadding: 10px 15px;
+	--primarybtnborderwidth: 3px;
+	--primarybtncolor: #fff;
+	--primarybtnhovercolor: #fff;
+	--primarybtnhoverbg: transparent;
+	--primarybtnbg: transparent;
+
+	.wc-block-components-notice-banner__content:has(.wc-forward, .showcoupon) {
+		display: inline-flex;
+		flex-basis: 100%;
+		flex-wrap: nowrap;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.wc-block-components-notice-banner__content:has(.wc-forward) {
+		flex-direction: row-reverse;
+	}
+
+	.wc-block-components-notice-banner__content:has(.showcoupon) {
+		flex-direction: row;
+	}
+}
+
+@each $noticeName, $color in $blockNotices {
+	.neve-main .wc-block-components-notice-banner.is-#{$noticeName} {
+		border-radius: 3px;
+		background-color: $color;
+		border: 0;
+		color: #fff;
+		font-size: inherit;
+		line-height: inherit;
+		align-items: center;
+
+		svg {
+			background-color: #fff;
+			fill: $color;
+		}
+
+		a.wc-forward,
+		a.showcoupon {
+			background: var(--primarybtnbg) !important;
+			border: var(--primarybtnborderwidth, 0) solid currentColor !important;
+			border-radius: var(--primarybtnborderradius, 3px);
+			color: var(--primarybtncolor) !important;
+			padding: var(--primarybtnpadding, 13px 15px) !important;
+			text-decoration: none !important;
+			opacity: 1;
+			float: none;
+		}
+
+		a.wc-forward:hover,
+		a.showcoupon:hover {
+			background: var(--primarybtnhoverbg) !important;
+			color: var(--primarybtnhovercolor) !important;
+			border-color: var(--primarybtnhovercolor) !important;
+			opacity: 0.9;
+		}
+	}
+}
+
 .woocommerce .woocommerce-error {
 	padding-left: 3.5em;
 

--- a/assets/scss/components/compat/woocommerce/_notices.scss
+++ b/assets/scss/components/compat/woocommerce/_notices.scss
@@ -79,20 +79,23 @@ $blockNotices: (
 	--primarybtnhoverbg: transparent;
 	--primarybtnbg: transparent;
 
-	.wc-block-components-notice-banner__content:has(.wc-forward, .showcoupon) {
-		display: inline-flex;
-		flex-basis: 100%;
-		flex-wrap: nowrap;
-		justify-content: space-between;
-		align-items: center;
-	}
+	.wc-block-components-notice-banner__content {
 
-	.wc-block-components-notice-banner__content:has(.wc-forward) {
-		flex-direction: row-reverse;
-	}
+		&:has(.wc-forward, .showcoupon) {
+			display: inline-flex;
+			flex-basis: 100%;
+			flex-wrap: nowrap;
+			justify-content: space-between;
+			align-items: center;
+		}
 
-	.wc-block-components-notice-banner__content:has(.showcoupon) {
-		flex-direction: row;
+		&:has(.wc-forward) {
+			flex-direction: row-reverse;
+		}
+
+		&:has(.showcoupon) {
+			flex-direction: row;
+		}
 	}
 }
 
@@ -111,8 +114,7 @@ $blockNotices: (
 			fill: $color;
 		}
 
-		a.wc-forward,
-		a.showcoupon {
+		a:is(.wc-forward, .showcoupon) {
 			background: var(--primarybtnbg) !important;
 			border: var(--primarybtnborderwidth, 0) solid currentColor !important;
 			border-radius: var(--primarybtnborderradius, 3px);
@@ -121,15 +123,15 @@ $blockNotices: (
 			text-decoration: none !important;
 			opacity: 1;
 			float: none;
+
+			&:hover {
+				background: var(--primarybtnhoverbg) !important;
+				color: var(--primarybtnhovercolor) !important;
+				border-color: var(--primarybtnhovercolor) !important;
+				opacity: 0.9;
+			}
 		}
 
-		a.wc-forward:hover,
-		a.showcoupon:hover {
-			background: var(--primarybtnhoverbg) !important;
-			color: var(--primarybtnhovercolor) !important;
-			border-color: var(--primarybtnhovercolor) !important;
-			opacity: 0.9;
-		}
 	}
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
With the release of WooCommerce v8.5.0, the notices have been changed to use a new HTML structure.
I added new rules to style the notices as they were previously based on the customizer settings.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
<details>
    <summary>Product notice BEFORE wc.8.5</summary>

<img width="1183" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/0d89d216-7985-4ba6-95ac-69bc0e70caec">
</details>

<details>
    <summary>Product notice AFTER wc.8.5</summary>

<img width="1227" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/d951c31c-c821-47d2-acd5-d84d79c3e743">
</details>

<details>
    <summary>Cart notices BEFORE wc.8.5</summary>

<img width="1163" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/0cbeb35b-fae8-41a9-a5cd-7c247f94d000">

<img width="1161" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/28934338-23fc-4c0d-9355-f3d096c72666">
</details>

<details>
    <summary>Cart notices AFTER wc.8.5</summary>

<img width="1154" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/3b58b78d-b125-4dc7-8a3e-460a335ac34c">

<img width="1160" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/51f0df59-eac5-4a37-945f-f8cfb279fbf2">
</details>

<details>
    <summary>Checkout notices BEFORE wc.8.5</summary>

<img width="1179" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/6604f2ef-7e55-45b6-ad91-b3934be87460">
</details>

<details>
    <summary>Checkout notices AFTER wc.8.5</summary>

<img width="1167" alt="image" src="https://github.com/Codeinwp/neve/assets/23024731/20cd8954-f20a-4cba-b6d0-0ba3623f6a3a">
</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->

- 
- 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4189.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
