### PR TITLE
fix: description visible in regular menu

### DIFF
--- a/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
@@ -1,0 +1,99 @@
+import { test, expect } from '@playwright/test';
+import { setCustomizeSettings } from '../../../utils';
+import data from '../../../fixtures/customizer/hfg/menu-item-alignment-setup.json';
+
+test.describe('Menu item description', function () {
+	test.beforeAll(async ({ browser, request, baseURL }) => {
+		await setCustomizeSettings('hfgMenuItemAlignment', data, {
+			request,
+			baseURL,
+		});
+
+		const context = await browser.newContext();
+		const page = await context.newPage();
+
+		await page.goto('/wp-admin/edit-tags.php?taxonomy=category');
+		await page.getByRole('textbox', { name: 'Name' }).click();
+		await page
+			.getByRole('textbox', { name: 'Name' })
+			.fill('ADescriptionCat');
+		await page.getByRole('textbox', { name: 'Slug' }).click();
+		await page
+			.getByRole('textbox', { name: 'Slug' })
+			.fill('adescriptioncat');
+		await page.getByRole('textbox', { name: 'Description' }).click();
+		await page
+			.getByRole('textbox', { name: 'Description' })
+			.fill('Some Description for the category');
+		await page.getByRole('button', { name: 'Add New Category' }).click();
+		await page.goto('wp-admin/nav-menus.php');
+
+		// await page.getByRole('button', { name: 'Screen Options ' }).click();
+		// await page.getByLabel('Description', { exact: true }).check();
+		// await page.getByRole('button', { name: 'Screen Options ' }).click();
+		// await page.getByRole('link', { name: 'Level 2. Sub item number 1 under Level 1.' }).scrollIntoViewIfNeeded();
+		// await page.getByRole('link', { name: 'Level 2. Sub item number 1 under Level 1.' }).click();
+		// await page.getByRole('textbox', { name: 'Description The description will be displayed in the menu if the active theme supports it.' }).click();
+		// await page.getByRole('textbox', { name: 'Description The description will be displayed in the menu if the active theme supports it.' }).fill('Product Description');
+		// await page.getByRole('button', { name: 'Save Menu' }).click();
+
+		await page
+			.getByRole('heading', {
+				name: 'Categories Press return or enter to open this section ',
+			})
+			.click();
+		await page
+			.locator('#taxonomy-category-tabs')
+			.getByRole('link', { name: 'View All' })
+			.click();
+		await page.getByLabel('ADescriptionCat').check();
+
+		await Promise.all([
+			page.waitForResponse(
+				(res) =>
+					res.url().includes('wp-admin/admin-ajax.php') &&
+					res.status() === 200
+			),
+			page.getByRole('button', { name: 'Add to Menu' }).click(),
+		]);
+
+		await page.keyboard.press('End');
+		await page.waitForTimeout(500);
+
+		await expect(
+			page.locator('#menu-to-edit li.menu-item:last-child a.item-edit')
+		).toBeVisible();
+		await page
+			.locator('#menu-to-edit li.menu-item:last-child a.item-edit')
+			.click({ force: true });
+		await page.waitForTimeout(500);
+		await page
+			.locator(
+				'#menu-to-edit li.menu-item:last-child .menu-item-settings button.menus-move-right'
+			)
+			.click({ force: true });
+		await page.getByRole('button', { name: 'Save Menu' }).click();
+	});
+
+	test.afterAll(async ({ browser, request, baseURL }) => {
+		const context = await browser.newContext();
+		const page = await context.newPage();
+
+		await page.goto('/wp-admin/edit-tags.php?taxonomy=category');
+
+		await page.getByLabel('Select ADescriptionCat').check();
+		await page.locator('#bulk-action-selector-top').selectOption('delete');
+		await page.locator('#doaction').click();
+	});
+
+	test('Checks up item alignment', async ({ page }) => {
+		await page.goto('/?test_data=hfgMenuItemAlignment');
+
+		await page
+			.locator(
+				'.primary-menu-ul.nav-ul.menu-desktop li.menu-item.menu-item-has-children:last-child'
+			)
+			.hover();
+		await expect(page.locator('.neve-mm-description')).toHaveCount(0);
+	});
+});

--- a/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
@@ -28,15 +28,6 @@ test.describe('Menu item description', function () {
 		await page.getByRole('button', { name: 'Add New Category' }).click();
 		await page.goto('wp-admin/nav-menus.php');
 
-		// await page.getByRole('button', { name: 'Screen Options ' }).click();
-		// await page.getByLabel('Description', { exact: true }).check();
-		// await page.getByRole('button', { name: 'Screen Options ' }).click();
-		// await page.getByRole('link', { name: 'Level 2. Sub item number 1 under Level 1.' }).scrollIntoViewIfNeeded();
-		// await page.getByRole('link', { name: 'Level 2. Sub item number 1 under Level 1.' }).click();
-		// await page.getByRole('textbox', { name: 'Description The description will be displayed in the menu if the active theme supports it.' }).click();
-		// await page.getByRole('textbox', { name: 'Description The description will be displayed in the menu if the active theme supports it.' }).fill('Product Description');
-		// await page.getByRole('button', { name: 'Save Menu' }).click();
-
 		await page
 			.getByRole('heading', {
 				name: 'Categories Press return or enter to open this section ',

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -317,7 +317,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 				if ( ! self::$mega_menu_enqueued ) {
 					$this->enqueue_mega_menu_style();
 				}
-				if ( $this->uses_mega_menu( $item ) ) {
+				if ( strpos( $output, 'neve-mega-menu' ) !== false ) {
 					$output .= '<div class="neve-mm-description">' . esc_html( $item->description ) . '</div>';
 				}
 			}

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -239,6 +239,17 @@ class Nav_Walker extends \Walker_Nav_Menu {
 	}
 
 	/**
+	 * Check if item uses the Mega Menu.
+	 *
+	 * @param \WP_Post $item Item.
+	 *
+	 * @return bool
+	 */
+	private function uses_mega_menu( $item ) {
+		return isset( $item->classes ) && in_array( 'neve-mega-menu', $item->classes );
+	}
+
+	/**
 	 * Start_el
 	 *
 	 * @param string    $output Output.
@@ -260,7 +271,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 			$this->enqueue_accessibility_menu_js();
 		}
 
-		if ( ! self::$mega_menu_enqueued && isset( $item->classes ) && in_array( 'neve-mega-menu', $item->classes ) ) {
+		if ( ! self::$mega_menu_enqueued && $this->uses_mega_menu( $item ) ) {
 			$this->enqueue_mega_menu_style();
 		}
 
@@ -306,7 +317,9 @@ class Nav_Walker extends \Walker_Nav_Menu {
 				if ( ! self::$mega_menu_enqueued ) {
 					$this->enqueue_mega_menu_style();
 				}
-				$output .= '<div class="neve-mm-description">' . esc_html( $item->description ) . '</div>';
+				if ( $this->uses_mega_menu( $item ) ) {
+					$output .= '<div class="neve-mm-description">' . esc_html( $item->description ) . '</div>';
+				}
 			}
 		}
 		$output .= "</li>{$n}";


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Do not show item descriptions in regular navigation.
Added e2e test for this specific case.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a fresh instance of Neve FREE
2. Change an existing menu item to have a description or use a category with a description as a menu item.
3. Check that the description is not visible inside the navigation when the item is nested under a main item.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4199.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
