### PR TITLE
Fix/2759

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "736dac6b20e7c4fec7706baa4769f819",
+    "content-hash": "8350f1110e2296b94e8dfa1199e72b1d",
     "packages": [
         {
             "name": "codeinwp/themeisle-sdk",
@@ -52,12 +52,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeinwp/webfont-loader.git",
-                "reference": "0294f21a20549f0c5e79700399946583dfa496b0"
+                "reference": "68c93e1dc8f6e438f93e81ebdf632e6243e43e0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeinwp/webfont-loader/zipball/0294f21a20549f0c5e79700399946583dfa496b0",
-                "reference": "0294f21a20549f0c5e79700399946583dfa496b0",
+                "url": "https://api.github.com/repos/Codeinwp/webfont-loader/zipball/68c93e1dc8f6e438f93e81ebdf632e6243e43e0f",
+                "reference": "68c93e1dc8f6e438f93e81ebdf632e6243e43e0f",
                 "shasum": ""
             },
             "require": {
@@ -100,7 +100,7 @@
                 "issues": "https://github.com/WPTT/font-loader/issues",
                 "source": "https://github.com/WPTT/font-loader"
             },
-            "time": "2023-02-03T11:14:21+00:00"
+            "time": "2024-02-21T09:17:13+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
### Summary

Updates the webfont loader package with the latest changes. 

The changes were tested and approved here: https://github.com/Codeinwp/webfont-loader. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2759.

