### PR TITLE
fix: disable excerpt more filter when excerpt block is used

### DIFF
--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -22,6 +22,11 @@ use Neve_Pro\Modules\Blog_Pro\Dynamic_Style;
 class Template_Parts extends Base_View {
 	use Layout;
 
+	/**
+	 * Use to temporary disable excerpt functionality.
+	 *
+	 * @var bool
+	 */
 	private $disable_excerpt = false;
 	/**
 	 * Function that is run after instantiation.
@@ -41,9 +46,9 @@ class Template_Parts extends Base_View {
 	/**
 	 * Checks if a query block has the excerpt more block added to avoid duplicate read more.
 	 *
-	 * @param array  $block_data Block data.
+	 * @param array $block_data Block data.
 	 * @param array $block_type Block type.
-	 * @param array  $attributes Block attributes.
+	 * @param array $attributes Block attributes.
 	 *
 	 * @return array
 	 */

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -22,6 +22,7 @@ use Neve_Pro\Modules\Blog_Pro\Dynamic_Style;
 class Template_Parts extends Base_View {
 	use Layout;
 
+	private $disable_excerpt = false;
 	/**
 	 * Function that is run after instantiation.
 	 *
@@ -34,6 +35,25 @@ class Template_Parts extends Base_View {
 		add_action( 'neve_blog_post_template_part_content', array( $this, 'render_post' ) );
 		add_filter( 'excerpt_more', array( $this, 'link_excerpt_more' ) );
 		add_filter( 'the_content_more_link', array( $this, 'link_excerpt_more' ) );
+		add_filter( 'render_block_data', array( $this, 'temporary_disable_excerpt_more' ), -99, 3 );
+	}
+
+	/**
+	 * Checks if a query block has the excerpt more block added to avoid duplicate read more.
+	 *
+	 * @param array  $block_data Block data.
+	 * @param array $block_type Block type.
+	 * @param array  $attributes Block attributes.
+	 *
+	 * @return array
+	 */
+	public function temporary_disable_excerpt_more( $block_data, $block_type, $attributes ) {
+
+		if ( 'core/post-excerpt' === $block_type['blockName'] ) {
+			$this->disable_excerpt = true;
+		}
+		return $block_data;
+
 	}
 
 	/**
@@ -211,7 +231,7 @@ class Template_Parts extends Base_View {
 				$class .= ' nv-non-grid-article';
 			}
 		}
-		
+
 		// Filter the Core classes for missing components.
 		$is_thumbnail_inactive = ! in_array( 'thumbnail', $this->get_ordered_components(), true );
 		if ( $is_thumbnail_inactive ) {
@@ -417,6 +437,13 @@ class Template_Parts extends Base_View {
 	 * @return string
 	 */
 	public function link_excerpt_more( $moretag, $post_id = null ) {
+
+
+		if ( $this->disable_excerpt ) {
+			$this->disable_excerpt = false;
+			return $moretag;
+		}
+
 		$new_moretag = '&hellip;&nbsp;';
 
 		if ( $moretag !== ' [&hellip;]' ) {


### PR DESCRIPTION
### Summary

During the `render_block_data` filter we check if the rendered block is a `core/post-excerpt` block and we disable our excerpt addon for the first call after the `render_block_data` hook. 


### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

Duplicate read more is no longer present when the excert more block is used: https://vertis.d.pr/i/aqx1p7 and works as excepted in the rest of the cases: https://vertis.d.pr/i/uAYkUZ .


### Test instructions
<!-- Describe how this pull request can be tested. -->

Check the instructions from the linked issue for replication. The `read more` should not be doubled anymore. 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve/issues/4187.

