### PR TITLE
fix: mega menu opening on tablet

### DIFF
--- a/assets/scss/components/elements/_mega-menu.scss
+++ b/assets/scss/components/elements/_mega-menu.scss
@@ -66,7 +66,7 @@
 		.neve-mega-menu > .sub-menu {
 			left: 50% !important;
 			right: unset !important;
-			transform: translateX(-50%);
+			transform: translateX(-50%) !important;
 			position: absolute;
 			padding: 20px 10px;
 			top: auto;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Override calculated styles for the mega-menu as it uses a different display style for the dropdown.
The `translateX` changes were introduced here: https://github.com/Codeinwp/neve/pull/4165 previous properties like `right` and `left` are overridden by mega-menu styles the `translateX` were not as it was not expected there.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a fresh instance with Neve and Neve PRO
2. Enable the Mega Menu and use it for the Primary Menu.
3. Check that on the front end for the emulated tablet (iPad), it opens and displays correctly.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes: Codeinwp/neve-pro-addon#2769.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
