### PR TITLE
Tracking improvements for Header/Footer Builder in Customizer

### DIFF
--- a/assets/apps/customizer-controls/src/builder/components/BuilderItem.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/BuilderItem.tsx
@@ -17,7 +17,8 @@ type Props = {
 
 const BuilderItem: React.FC<Props> = (props) => {
 	const { componentId, currentSection, slot, row, index } = props;
-	const { actions, builder, sidebarItems } = useContext(BuilderContext);
+	const { actions, builder, sidebarItems, device } =
+		useContext(BuilderContext);
 
 	const itemDetails =
 		window.NeveReactCustomize.HFG[builder].items[componentId];
@@ -52,11 +53,13 @@ const BuilderItem: React.FC<Props> = (props) => {
 			})
 		);
 
-		window.tiTrk?.with('neve').set(`${componentId}_removed`, {
-			feature: builder + '_builder',
-			featureComponent: 'component-removed',
-			featureValue: { row, slot, item: componentId },
-		});
+		window.tiTrk
+			?.with('neve')
+			.set(`${componentId}__${device}_${builder}_removed`, {
+				feature: builder + '_builder',
+				featureComponent: 'component-removed',
+				featureValue: { row, slot, item: componentId, device },
+			});
 	};
 
 	const iconSize = 18;

--- a/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/ComponentsPopover.tsx
@@ -25,7 +25,8 @@ const ComponentsPopover: React.FC<Props> = ({
 
 	const url = window.NeveReactCustomize.upsellComponentsLink;
 
-	const { builder, actions, sidebarItems } = useContext(BuilderContext);
+	const { builder, actions, sidebarItems, device } =
+		useContext(BuilderContext);
 	const { updateLayout, setSidebarItems } = actions;
 
 	const addItemToSlot = (itemId: string) => {
@@ -37,11 +38,19 @@ const ComponentsPopover: React.FC<Props> = ({
 		updateLayout(rowId, slotId, nextItems);
 		setSidebarItems(sidebarItems.filter((i) => i.id !== itemId));
 
-		window.tiTrk?.with('neve').set(`${itemId}_added`, {
-			feature: builder + '_builder',
-			featureComponent: 'component-added',
-			featureValue: { row: rowId, slot: slotId, item: itemId },
-		});
+		window.tiTrk
+			?.with('neve')
+			.set(`${itemId}__${device}_${builder}_added`, {
+				feature: builder + '_builder',
+				featureComponent: 'component-added',
+				featureValue: {
+					row: rowId,
+					slot: slotId,
+					item: itemId,
+					device,
+					trigger: 'popover',
+				},
+			});
 		closePopup();
 	};
 

--- a/assets/apps/customizer-controls/src/builder/components/Slot.tsx
+++ b/assets/apps/customizer-controls/src/builder/components/Slot.tsx
@@ -19,7 +19,7 @@ type Props = {
 };
 
 const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
-	const { currentSection, builder, actions, dragging } =
+	const { currentSection, builder, actions, dragging, device } =
 		useContext(BuilderContext);
 	const { updateLayout, onDragStart } = actions;
 
@@ -44,6 +44,26 @@ const Slot: React.FC<Props> = ({ items, slotId, rowId, className }) => {
 					const nextState = newState.map((item) => {
 						return { id: item.id };
 					});
+
+					// Track the added components.
+					nextState
+						?.filter((item) => !items.some((i) => i.id === item.id))
+						?.forEach((item) => {
+							window.tiTrk
+								?.with('neve')
+								.set(`${item.id}__${device}_${builder}_added`, {
+									feature: builder + '_builder',
+									featureComponent: 'component-added',
+									featureValue: {
+										row: rowId,
+										slot: slotId,
+										item: item.id,
+										device,
+										trigger: 'drag-and-drop',
+									},
+								});
+						});
+
 					updateLayout(rowId, slotId, nextState);
 				}}
 			>


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Improve the tracking for components of the Header/Footer Builder in Customizer:
- track the device (desktop, mobile)
- improve the tracking id to differentiate between device and builder type.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Have Neve Pro installed
- Active the anonymous tracking in Neve Dashboard
- Go to Customizer in Header Builder, then open the Browser Console
- Add components into the builder, either via drag-and-drop or Popup
- In the browser console, write `tiTrk.events`
- You should see something similar to the image below (Notice the `device` property)

<img width="1188" alt="Screenshot 2024-03-06 at 09 49 37" src="https://github.com/Codeinwp/neve/assets/17597852/165171f4-dc0f-495e-9aed-29a0ece22c3a">


![image](https://github.com/Codeinwp/neve/assets/17597852/605052b6-9db8-4e77-94ea-2f481bf9192c)



## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2776
<!-- Should look like this: `Closes #1, #2, #3.` . -->
