### PR TITLE
fix: footer id unique

### DIFF
--- a/e2e-tests/specs/customizer/hfg/hfg-footer-mobile.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-footer-mobile.spec.ts
@@ -44,4 +44,16 @@ test.describe('Different Footer for Mobile vs Desktop', function () {
 			page.locator('.hfg_footer .nav-menu-footer')
 		).toBeVisible();
 	});
+
+	test('Check IDs are unique', async ({ page }) => {
+		await page.goto('/?test_name=hfgFooterMobile');
+
+		await expect(page.locator('#cb-row--footer-bottom')).toHaveCount(0);
+		await expect(
+			page.locator('#cb-row--footer-desktop-bottom')
+		).toHaveCount(1);
+		await expect(page.locator('#cb-row--footer-mobile-bottom')).toHaveCount(
+			1
+		);
+	});
 });

--- a/header-footer-grid/templates/footer-row-wrapper.php
+++ b/header-footer-grid/templates/footer-row-wrapper.php
@@ -43,7 +43,7 @@ if ( is_customize_preview() ) {
 $row_wrapper_classes = join( ' ', $row_wrapper_classes );
 ?>
 <div class="<?php echo esc_attr( join( ' ', $row_classes ) ); ?>"
-	id="cb-row--footer-<?php echo esc_attr( $row_index ); ?>"
+	id="cb-row--footer-<?php echo esc_attr( $device ); ?>-<?php echo esc_attr( $row_index ); ?>"
 	data-row-id="<?php echo esc_attr( $row_index ); ?>" data-show-on="<?php echo esc_attr( $device ); ?>">
 	<div
 		class="footer--row-inner footer-<?php echo esc_attr( $row_index ); ?>-inner footer-content-wrap">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
Solves the issue with the footer not having a unique ID since mobile was introduced.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->
1. Check on any page where the footer is being used that there is only one element with `id` any of the IDs: 
    - `cb-row--footer-desktop-top` 
    - `cb-row--footer-mobile-top`
    - `cb-row--footer-desktop-bottom` 
    - `cb-row--footer-mobile-bottom`
    - `cb-row--footer-desktop-main` 
    - `cb-row--footer-mobile-main`

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes: #4212.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
