### PR TITLE
fix: remove survey from dash deps

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -299,20 +299,19 @@ class Main {
 
 		$build_path   = get_template_directory_uri() . '/assets/apps/dashboard/build/';
 		$dependencies = ( include get_template_directory() . '/assets/apps/dashboard/build/dashboard.asset.php' );
-
-		$survey_handler = apply_filters( 'themeisle_sdk_dependency_script_handler', 'survey' );
-		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
 		
 		wp_register_style( 'neve-dash-style', $build_path . 'style-dashboard.css', [ 'wp-components', 'neve-components' ], $dependencies['version'] );
 		wp_style_add_data( 'neve-dash-style', 'rtl', 'replace' );
 		wp_enqueue_style( 'neve-dash-style' );
-		wp_register_script( 'neve-dash-script', $build_path . 'dashboard.js', array_merge( $dependencies['dependencies'], [ 'updates', $survey_handler ] ), $dependencies['version'], true );
+		wp_register_script( 'neve-dash-script', $build_path . 'dashboard.js', array_merge( $dependencies['dependencies'], [ 'updates' ] ), $dependencies['version'], true );
 		wp_localize_script( 'neve-dash-script', 'neveDash', apply_filters( 'neve_dashboard_page_data', $this->get_localization() ) );
 		wp_enqueue_script( 'neve-dash-script' );
 
 		if ( function_exists( 'wp_set_script_translations' ) ) {
 			wp_set_script_translations( 'neve-dash-script', 'neve' );
 		}
+
+		do_action( 'themeisle_sdk_dependency_enqueue_script', 'survey' );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Remove survey from dashboard script deps.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

https://github.com/Codeinwp/neve/assets/17597852/ad02b80d-2b9c-4bcb-9080-b74d1ad0de7e


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the script loading in Neve dashboard like in the video

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2785
<!-- Should look like this: `Closes #1, #2, #3.` . -->
