### PR TITLE
fix: long menu items with toggle overlap

### DIFF
--- a/e2e-tests/specs/customizer/hfg/hfg-menu-item-wrap.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-menu-item-wrap.spec.ts
@@ -27,5 +27,11 @@ test.describe('Menu item alignment', function () {
 			.getByRole('link', {
 				name: 'Level 3b',
 			});
+
+		// Check that a toggle menu has proper padding.
+		const toggleItemLink = page.getByRole('link', {
+			name: 'About The Tests',
+		});
+		await expect(toggleItemLink).toHaveCSS('padding-right', '46px');
 	});
 });

--- a/inc/views/nav_walker.php
+++ b/inc/views/nav_walker.php
@@ -210,7 +210,7 @@ class Nav_Walker extends \Walker_Nav_Menu {
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap a .dd-title { width: var(--wrapdropdownwidth); }';
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li .wrap button { border: 0; z-index: 1; background: 0; }';
 		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li:not([class*=block]):not(.menu-item-has-children) > .wrap > a { padding-right: calc(1em + (18px*2)); text-wrap: wrap; white-space: normal;}';
-		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li.menu-item-has-children:not([class*=block])  > .wrap > a { margin-right: calc(-1em - (18px*2));}';
+		$mobile_button_caret_css .= '.header-menu-sidebar .nav-ul li.menu-item-has-children:not([class*=block])  > .wrap > a { margin-right: calc(-1em - (18px*2)); padding-right: 46px;}';
 
 		return Dynamic_Css::minify_css( $mobile_button_caret_css );
 	}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Fixes long items with a dropdown on the mobile menu overlapping with the dropdown button.

### Will affect the visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://github.com/Codeinwp/neve/assets/23024731/172ac516-6ce7-4f62-b5d6-08898255cf33)


### Test instructions
<!-- Describe how this pull request can be tested. -->
1. On a fresh instance, create a primary menu
2. Add some items with longer names
3. Add subitems to them so the submenu icon will be visible
4. Check on the mobile menu that the text will not overlap with the dropdown icon.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4226.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
