### PR TITLE
Add a second Nav_Walker for Secondary Menu

### DIFF
--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -34,6 +34,7 @@ if ( $style !== 'style-plain' ) {
 				'fallback_cb'    => '__return_false',
 				'before'         => '<div class="wrap">',
 				'after'          => '</div>',
+				'walker'         => '\Neve\Views\Secondary_Nav_Walker',
 			)
 		);
 		?>

--- a/inc/views/secondary_nav_walker.php
+++ b/inc/views/secondary_nav_walker.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Custom navwalker for secondary menu.
+ *
+ * Author:          Soare Robert <robert.soare@themeisle.com>
+ * Created on:      25/04/2024
+ *
+ * @package Neve\Views
+ */
+
+namespace Neve\Views;
+
+/**
+ * Class Secondary_Nav_Walker
+ *
+ * @package Neve\Views
+ */
+class Secondary_Nav_Walker extends Nav_Walker {
+
+	/**
+	 * Secondary_Nav_Walker constructor.
+	 */
+	public function __construct() {
+		add_action( 'neve_after_header_wrapper_hook', [ $this, 'inline_style_for_sidebar' ], 9 );
+	}
+}


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

The Secondary Menu was using only the default WordPress Nav Walker. Because of this, some missing elements prevented the Mobile Sidebar from working.

Since only the primary menu could enqueue those resources, the secondary menu did not work correctly in his absence.

To fix this, I added a new class that inherits all the functionality of the `Nav_Walker` but enqueues only the needed resources. 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Follow the instructions from the issue description
- The mobile sidebar should work only when the secondary menu is present.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2802
<!-- Should look like this: `Closes #1, #2, #3.` . -->
