### PR TITLE
fix: use `WC_Payment_Gateways` instance

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -213,7 +213,7 @@ class Woocommerce {
 		$payment_method = WC()->session->get( 'chosen_payment_method' );
 		if ( ! $payment_method ) {
 			// If payment method is null, see if there is only one option;
-			$payment_gateways          = new WC_Payment_Gateways();
+			$payment_gateways          = WC_Payment_Gateways::instance();
 			$available_payment_methods = $payment_gateways->get_available_payment_gateways();
 			if ( is_array( $available_payment_methods ) && count( $available_payment_methods ) === 1 ) {
 				return array_keys( $available_payment_methods )[0];


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Because we were using `new WC_Payment_Gateways`, we added duplicate filters in the loop, which resulted in duplicate behavior when rendering the bank details.

By using the singleton pattern provided by the class via `WC_Payment_Gateways:instance()`, we prevent this bad behavior. 

##### Debugging process

To find where the problem was, I first printed the stack trace on the function that renders the bank details and then checked all Neve functions that were used. There was nothing problematic with them; there were no multiple calls.

This leads me to the idea that some filter was added multiple times, so I printed the stack trace of the `WC_Payment_Gateways` constructor, which revealed the Neve function that added the filter multiple times.

### Will affect the  visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/neve/assets/17597852/917a3cc3-c37f-48c9-ae12-23c9a604fcc6)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use WooCommerce
- Activate `Direct bank transfer` in Payments tab of WooCommerce settings
- Put some items in the carts and do the checkout.
- We should see only an instance of bank details displayed.

## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve/issues/4244
<!-- Should look like this: `Closes #1, #2, #3.` . -->
