### PR TITLE
fix: hero btn onboarding on large text

### DIFF
--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -601,12 +601,13 @@ class Admin {
 		.nv-notice-column-container a.button.button-hero.button-secondary,
 		.nv-notice-column-container a.button.button-hero.button-primary{
 			margin:0px;
+			white-space: normal;
 		}
 		.nv-notice-column-container .nv-notice-column:not(.nv-notice-image) {
 			display: -ms-grid;
 			display: grid;
 			-ms-grid-rows: auto 100px;
-			grid-template-rows: auto 100px;
+			grid-template-rows: auto auto;
 		}
 		@media screen and (max-width: 1280px) {
 			.nv-notice-wrapper .nv-notice-column-container {

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -598,9 +598,8 @@ class Admin {
 			grid-template-columns: 24% 32% 32%;
 			margin-bottom: 13px;
 		}
-		.nv-notice-column-container a.button.button-hero.button-secondary,
-		.nv-notice-column-container a.button.button-hero.button-primary{
-			margin:0px;
+		.nv-notice-column-container .button.button-hero:is( .button-primary, .button-secondary ) {
+			margin: 0px;
 			white-space: normal;
 			text-align: center;
 			line-height: 1.2;

--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -602,12 +602,15 @@ class Admin {
 		.nv-notice-column-container a.button.button-hero.button-primary{
 			margin:0px;
 			white-space: normal;
+			text-align: center;
+			line-height: 1.2;
+			padding: 12px 36px;
 		}
 		.nv-notice-column-container .nv-notice-column:not(.nv-notice-image) {
 			display: -ms-grid;
 			display: grid;
 			-ms-grid-rows: auto 100px;
-			grid-template-rows: auto auto;
+			grid-template-rows: auto 100px;
 		}
 		@media screen and (max-width: 1280px) {
 			.nv-notice-wrapper .nv-notice-column-container {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Changed the primary hero button to be more flexible and not break the layout when it contains a large text (generated by the translations).
- Also balanced the design. (centered text and lower line-height, thanks to @mghenciu )

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/Codeinwp/neve/assets/17597852/29910e97-6da5-4585-b22f-b06dd612666a)

![image](https://github.com/Codeinwp/neve/assets/17597852/ce24abf2-c3aa-4898-a913-ba3d0e5f9960)

![image](https://github.com/Codeinwp/neve/assets/17597852/3b7e5dfe-3bc8-4dae-becd-ea0514e1423f)


### Test instructions
<!-- Describe how this pull request can be tested. -->

- In fresh instances with the Romanian Language, install Neve. (Alternatively you can edit the HTML directly in the page to add some extra text )
- Check the onboarding notice.

> [!NOTE]
> When testing with TasteWP,  make sure do not have Neve installed already when you try to put the new build. TasteWP might server some cached file!

## Check before Pull Request is ready:

* [ ] ~I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve/issues/4240
<!-- Should look like this: `Closes #1, #2, #3.` . -->
