### PR TITLE
Fixed duplicate id issue with secondary nav menu

### DIFF
--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -307,7 +307,7 @@ class SecondNav extends Abstract_Component {
 	 */
 	public function render_component() {
 		do_action( 'neve_before_render_nav', $this->get_id() );
-		Main::get_instance()->load( 'components/component-nav-secondary' );
+		Main::get_instance()->load( 'components/component-nav-secondary', '', $this->args );
 		do_action( 'neve_after_render_nav', $this->get_id() );
 	}
 

--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -33,16 +33,6 @@ class SecondNav extends Abstract_Component {
 	const SPACING             = 'spacing';
 
 	/**
-	 * Secondary nav number
-	 *
-	 * @since   3.8.7
-	 * @access  private
-	 *
-	 * @var int $secondary_nav_num
-	 */
-	private $secondary_nav_num = 0;
-
-	/**
 	 * Nav constructor.
 	 *
 	 * @since   1.0.0
@@ -316,9 +306,8 @@ class SecondNav extends Abstract_Component {
 	 * @access  public
 	 */
 	public function render_component() {
-		$this->secondary_nav_num++;
 		do_action( 'neve_before_render_nav', $this->get_id() );
-		Main::get_instance()->load( 'components/component-nav-secondary', '', array( 'nav_num' => $this->secondary_nav_num ) );
+		Main::get_instance()->load( 'components/component-nav-secondary' );
 		do_action( 'neve_after_render_nav', $this->get_id() );
 	}
 

--- a/header-footer-grid/Core/Components/SecondNav.php
+++ b/header-footer-grid/Core/Components/SecondNav.php
@@ -33,6 +33,16 @@ class SecondNav extends Abstract_Component {
 	const SPACING             = 'spacing';
 
 	/**
+	 * Secondary nav number
+	 *
+	 * @since   3.8.7
+	 * @access  private
+	 *
+	 * @var int $secondary_nav_num
+	 */
+	private $secondary_nav_num = 0;
+
+	/**
 	 * Nav constructor.
 	 *
 	 * @since   1.0.0
@@ -306,8 +316,9 @@ class SecondNav extends Abstract_Component {
 	 * @access  public
 	 */
 	public function render_component() {
+		$this->secondary_nav_num++;
 		do_action( 'neve_before_render_nav', $this->get_id() );
-		Main::get_instance()->load( 'components/component-nav-secondary' );
+		Main::get_instance()->load( 'components/component-nav-secondary', '', array( 'nav_num' => $this->secondary_nav_num ) );
 		do_action( 'neve_after_render_nav', $this->get_id() );
 	}
 

--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -10,6 +10,7 @@
 namespace HFG;
 
 use HFG\Core\Components\SecondNav;
+use HFG\Core\Builder\Header as HeaderBuilder;
 
 $style = component_setting( SecondNav::STYLE_ID );
 
@@ -18,7 +19,7 @@ if ( $style !== 'style-plain' ) {
 	$container_classes[] = $style;
 	$container_classes[] = 'm-style';
 }
-$nav_num = ! empty( $args['nav_num'] ) ? (int) $args['nav_num'] : 0;
+$menu_id = SecondNav::COMPONENT_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 ?>
 <div class="nv-top-bar">
 	<div role="navigation" class="menu-content <?php echo esc_attr( join( ' ', $container_classes ) ); ?>"
@@ -28,7 +29,7 @@ $nav_num = ! empty( $args['nav_num'] ) ? (int) $args['nav_num'] : 0;
 			array(
 				'theme_location' => 'top-bar',
 				'menu_class'     => 'nav-ul',
-				'menu_id'        => $nav_num > 1 ? "secondary-menu_$nav_num" : 'secondary-menu',
+				'menu_id'        => $menu_id,
 				'container'      => 'ul',
 				'depth'          => - 1,
 				'fallback_cb'    => '__return_false',

--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -18,7 +18,7 @@ if ( $style !== 'style-plain' ) {
 	$container_classes[] = $style;
 	$container_classes[] = 'm-style';
 }
-
+$nav_num = ! empty( $args['nav_num'] ) ? (int) $args['nav_num'] : 0;
 ?>
 <div class="nv-top-bar">
 	<div role="navigation" class="menu-content <?php echo esc_attr( join( ' ', $container_classes ) ); ?>"
@@ -28,7 +28,7 @@ if ( $style !== 'style-plain' ) {
 			array(
 				'theme_location' => 'top-bar',
 				'menu_class'     => 'nav-ul',
-				'menu_id'        => 'secondary-menu',
+				'menu_id'        => $nav_num > 1 ? "secondary-menu_$nav_num" : 'secondary-menu',
 				'container'      => 'ul',
 				'depth'          => - 1,
 				'fallback_cb'    => '__return_false',

--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -12,14 +12,15 @@ namespace HFG;
 use HFG\Core\Components\SecondNav;
 use HFG\Core\Builder\Header as HeaderBuilder;
 
-$style = component_setting( SecondNav::STYLE_ID );
-
+$style             = component_setting( SecondNav::STYLE_ID );
+$device_class      = isset( $args ) && ! empty( $args ) ? $args['device'] : '';
 $container_classes = [ 'nav-menu-secondary' ];
+
 if ( $style !== 'style-plain' ) {
 	$container_classes[] = $style;
 	$container_classes[] = 'm-style';
 }
-$menu_id = SecondNav::COMPONENT_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
+$menu_id = SecondNav::COMPONENT_ID . '-' . $device_class . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 ?>
 <div class="nv-top-bar">
 	<div role="navigation" class="menu-content <?php echo esc_attr( join( ' ', $container_classes ) ); ?>"


### PR DESCRIPTION
### Summary
When the page load, I count the number of secondary menus and add it to the nav menu wrap ID.
e.g: `secondary-menu_2`
ref: https://github.com/Codeinwp/neve/blob/master/.storybook/dummy-data.js#L514

### Test instructions
1. Create Wordpress site with Neve.
2. Add a header element to both desktop and mobile view (for example a secondary menu)
3. Save
4. The HTML source will contain duplicate id values (e.g. secondary-menu)

## Check before Pull Request is ready:

* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #4256