### PR TITLE
Revert starter site menu items

### DIFF
--- a/inc/compatibility/starter-content/contact.php
+++ b/inc/compatibility/starter-content/contact.php
@@ -148,21 +148,6 @@ return [
 <!-- /wp:social-links --></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"center","width":"50%","style":{"spacing":{"padding":{"right":"var:preset|spacing|30","left":"var:preset|spacing|30"}}}} -->
-<div class="wp-block-column is-vertically-aligned-center" style="padding-right:var(--wp--preset--spacing--30);padding-left:var(--wp--preset--spacing--30);flex-basis:50%;"><!-- wp:themeisle-blocks/form {"id":"wp-block-themeisle-blocks-form-b0061c8f","optionName":"8e3c28cc41eef4a60477f9c4566338072ba8621f_b0061c8f","submitLabel":"Send Message","inputBorderRadius":{"top":"3px","left":"3px","right":"3px","bottom":"3px"},"submitBackgroundColor":"var(\u002d\u002dnv-primary-accent)","submitBackgroundColorHover":"var(\u002d\u002dnv-secondary-accent)"} -->
-<div id="wp-block-themeisle-blocks-form-b0061c8f" class="wp-block-themeisle-blocks-form" data-option-name="8e3c28cc41eef4a60477f9c4566338072ba8621f_b0061c8f"><form class="otter-form__container"><!-- wp:themeisle-blocks/form-input {"id":"wp-block-themeisle-blocks-form-input-334449d1","type":"email","label":"Email","isRequired":true} -->
-<div id="wp-block-themeisle-blocks-form-input-334449d1" class="wp-block-themeisle-blocks-form-input"><label for="wp-block-themeisle-blocks-form-input-334449d1-input" class="otter-form-input-label"><span class="otter-form-input-label__label">Email</span><span class="required">*</span></label><input type="email" id="wp-block-themeisle-blocks-form-input-334449d1-input" required class="otter-form-input"/></div>
-<!-- /wp:themeisle-blocks/form-input -->
-
-<!-- wp:themeisle-blocks/form-nonce {"formId":"wp-block-themeisle-blocks-form-b0061c8f"} /-->
-
-<!-- wp:themeisle-blocks/form-textarea {"id":"wp-block-themeisle-blocks-form-textarea-3a8375eb","label":"Message"} -->
-<div id="wp-block-themeisle-blocks-form-textarea-3a8375eb" class="wp-block-themeisle-blocks-form-textarea"><label for="wp-block-themeisle-blocks-form-textarea-3a8375eb-input" class="otter-form-textarea-label"><span class="otter-form-textarea-label__label">Message</span></label><textarea id="wp-block-themeisle-blocks-form-textarea-3a8375eb-input" rows="10" class="otter-form-textarea-input"></textarea></div>
-<!-- /wp:themeisle-blocks/form-textarea --><div class="wp-block-button"><button class="wp-block-button__link" type="submit">Send Message</button></div></form></div>
-<!-- /wp:themeisle-blocks/form --></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
-
 <!-- wp:spacer {"height":"40px"} -->
 <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer --></div>

--- a/inc/compatibility/starter_content.php
+++ b/inc/compatibility/starter_content.php
@@ -114,10 +114,10 @@ class Starter_Content {
 				'object'    => 'page',
 				'object_id' => '{{' . self::HOME_SLUG . '}}',
 			],
-			'link_about'           => [
-				'type'  => 'custom',
-				'title' => 'About Us',
-				'url'   => home_url( self::ABOUT_SLUG ),
+			'page_about'           => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::ABOUT_SLUG . '}}',
 			],
 			'page_portofolio'      => [
 				'type'      => 'post_type',
@@ -129,15 +129,15 @@ class Starter_Content {
 				'object'    => 'page',
 				'object_id' => '{{' . self::PROJECT_DETAILS . '}}',
 			],
-			'link_blog'            => [
-				'type'  => 'custom',
-				'title' => 'News',
-				'url'   => home_url( self::BLOG_SLUG ),
+			'page_blog'            => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::BLOG_SLUG . '}}',
 			],
-			'link_contact'         => [
-				'type'  => 'custom',
-				'title' => 'Contact Us',
-				'url'   => home_url( self::CONTACT ),
+			'page_contact'         => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::CONTACT . '}}',
 			],
 		];
 
@@ -147,20 +147,20 @@ class Starter_Content {
 				'object'    => 'page',
 				'object_id' => '{{' . self::HOME_SLUG . '}}',
 			],
-			'link_blog'    => [
-				'type'  => 'custom',
-				'title' => 'Blog',
-				'url'   => home_url( self::HOME_SLUG ),
+			'page_blog'    => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::BLOG_SLUG . '}}',
 			],
-			'link_about'   => [
-				'type'  => 'custom',
-				'title' => 'About',
-				'url'   => home_url( self::ABOUT_SLUG ),
+			'page_about'   => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::ABOUT_SLUG . '}}',
 			],
-			'link_contact' => [
-				'type'  => 'custom',
-				'title' => 'Contact',
-				'url'   => home_url( self::CONTACT ),
+			'page_contact' => [
+				'type'      => 'post_type',
+				'object'    => 'page',
+				'object_id' => '{{' . self::CONTACT . '}}',
 			],
 		];
 


### PR DESCRIPTION
### Summary
I've reverted the starter site menu items, due to the 404 pages issue with a new release.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #2823