### PR TITLE
Fix Breadcrumb NavXT breadcrumb rendering

### DIFF
--- a/inc/views/breadcrumbs.php
+++ b/inc/views/breadcrumbs.php
@@ -162,6 +162,15 @@ class Breadcrumbs extends Base_View {
 			}
 		}
 
+		// Breadcrumb NavXT breadcrumbs
+		if ( function_exists( 'bcn_display' ) ) {
+			echo '<small class="neve-breadcrumbs-wrapper">';
+			bcn_display();
+			echo '</small>';
+
+			return true;
+		}
+
 		return false;
 	}
 


### PR DESCRIPTION
This fixes Breadcrumb NavXT breadcrumb rendering which was removed by in ee748ab1469559c56dd26444089e0cf8646e7e36 (by mistake I assume).

I tested the change (in prod :wink:) on my [WordPress/WooCommerce installation](https://42keebs.eu/build-guides/lumberjack-pro/).

### Summary
This change re-adds the code that calls the `bcn_display()` Breadcrumb NavXT function to display the breadcrumbs.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES (I guess? It adds breadcrumbs that have been missing)

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install WordPress with Neve
- Install Breadcrumb NavXT and enable breadcrumbs
- Breadcrumbs **will not** be rendered
- Update the Neve code with this PR
- Breadcrumbs will now be rendered correctly


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR (was instructed by @selul to submit the PR even though I lack the time to add tests)
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass (again, didn't have time to set up the dev environment)
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4267.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
