### PR TITLE
Fix #4286 EDD Before Archive Hook

### DIFF
--- a/taxonomy-download_category.php
+++ b/taxonomy-download_category.php
@@ -15,15 +15,16 @@ get_header();
 <div id= "nv-edd-download-archive-container" class="<?php echo esc_attr( $container_class ); ?>">
 
 		<div id="wrapper">
+			<?php
+				/**
+				 * Executes actions before the archive content.
+				 *
+				 * @since 3.0.0
+				 */
+				do_action( 'neve_before_download_archive' );
+			?>
 			<div id="nv-edd-grid-container">
 				<?php
-					/**
-					 * Executes actions before the post content.
-					 *
-					 * @since 3.0.0
-					 */
-					do_action( 'neve_before_download_archive' );
-					
 				if ( have_posts() ) {
 				
 					while ( have_posts() ) {

--- a/taxonomy-download_tag.php
+++ b/taxonomy-download_tag.php
@@ -15,15 +15,16 @@ get_header();
 <div id= "nv-edd-download-archive-container" class="<?php echo esc_attr( $container_class ); ?>">
 
 		<div id="wrapper">
+			<?php
+				/**
+				 * Executes actions before the archive content.
+				 *
+				 * @since 3.0.0
+				 */
+				do_action( 'neve_before_download_archive' );
+			?>
 			<div id="nv-edd-grid-container">
 				<?php
-					/**
-					 * Executes actions before the post content.
-					 *
-					 * @since 3.0.0
-					 */
-					do_action( 'neve_before_download_archive' );
-					
 				if ( have_posts() ) {
 				
 					while ( have_posts() ) {


### PR DESCRIPTION
### Summary
Fixes https://github.com/Codeinwp/neve/issues/4286 by moving the apply "Before Download Archive" hook to above the download grid div.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
#### Before Fix
<img width="1508" alt="archive_tag" src="https://github.com/user-attachments/assets/c941050b-18a4-4f9d-8957-cdd6af2b231b">
<img width="1481" alt="archive_taxonomy" src="https://github.com/user-attachments/assets/2087cefb-3003-4af0-a5a4-a9a9f4f68df9">

#### After Fix
<img width="1508" alt="archive_tag_fixed" src="https://github.com/user-attachments/assets/562e1453-36d2-459d-a6ab-abf2735f1578">
<img width="1454" alt="archive_taxonomy_fixed" src="https://github.com/user-attachments/assets/7ee15592-75c6-4655-b72e-2a56b86d0ea1">

### Test instructions
<!-- Describe how this pull request can be tested. -->
See reproduction steps in https://github.com/Codeinwp/neve/issues/4286
- 
- 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
