### PR TITLE
Added messenger social media support

### DIFF
--- a/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
+++ b/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
@@ -67,6 +67,12 @@ const RepeaterItemContent = ({
 
 		switch (currentField.type) {
 			case 'text':
+				if (
+					'page_name' === key &&
+					'messenger' !== value[index]?.social_network
+				) {
+					return;
+				}
 				return (
 					<TextControl
 						label={currentField.label}

--- a/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
+++ b/assets/apps/customizer-controls/src/repeater/RepeaterItemContent.js
@@ -4,6 +4,7 @@ import {
 	TextControl,
 	ToggleControl,
 	TextareaControl,
+	ExternalLink,
 } from '@wordpress/components';
 import IconSelector from './IconSelector';
 import { getIcons, ColorControl } from '@neve-wp/components';
@@ -68,18 +69,26 @@ const RepeaterItemContent = ({
 		switch (currentField.type) {
 			case 'text':
 				if (
-					'page_name' === key &&
+					'fb_page_id' === key &&
 					'messenger' !== value[index]?.social_network
 				) {
 					return;
 				}
 				return (
-					<TextControl
-						label={currentField.label}
-						value={value[index][key] || currentField.default}
-						onChange={(newData) => changeContent(key, newData)}
-						key={key + index}
-					/>
+					<>
+						<TextControl
+							label={currentField.label}
+							value={value[index][key] || currentField.default}
+							onChange={(newData) => changeContent(key, newData)}
+							key={key + index}
+							help={currentField.help_text || ''}
+						/>
+						{currentField?.help_link && (
+							<ExternalLink href={currentField?.help_link?.link}>
+								{currentField?.help_link?.text}
+							</ExternalLink>
+						)}
+					</>
 				);
 			case 'textarea':
 				return (

--- a/stories/utils/values.js
+++ b/stories/utils/values.js
@@ -220,6 +220,7 @@ export const FIELDS = {
 			whatsapp: 'WhatsApp',
 			sms: 'SMS',
 			vk: 'VKontakte'
+			messenger: 'Messenger'
 		}
 	},
 	display_desktop: {


### PR DESCRIPTION
### Summary
In this PR, I've hidden the `Page Name` option if the user does not select the messenger social media option. 

I've registered the `Page Name` and added messager support in this PR https://github.com/Codeinwp/neve-pro-addon/pull/2852

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve-pro-addon/issues/2788
