### PR TITLE
Fixed lightbox issue with alignment control

### DIFF
--- a/assets/scss/components/main/_gutenberg.scss
+++ b/assets/scss/components/main/_gutenberg.scss
@@ -150,16 +150,3 @@ blockquote {
 		margin-right: calc(50% - 35vw);
 	}
 }
-
-.wp-lightbox-overlay {
-
-	figure {
-
-		img {
-			height: var(--wp--lightbox-image-height);
-			min-height: var(--wp--lightbox-image-height);
-			min-width: var(--wp--lightbox-image-width);
-			width: var(--wp--lightbox-image-width);
-		}
-	}
-}

--- a/assets/scss/components/main/_gutenberg.scss
+++ b/assets/scss/components/main/_gutenberg.scss
@@ -151,3 +151,15 @@ blockquote {
 	}
 }
 
+.wp-lightbox-overlay {
+
+	figure {
+
+		img {
+			height: var(--wp--lightbox-image-height);
+			min-height: var(--wp--lightbox-image-height);
+			min-width: var(--wp--lightbox-image-width);
+			width: var(--wp--lightbox-image-width);
+		}
+	}
+}

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -36,6 +36,7 @@ class Template_Parts extends Base_View {
 	public function init() {
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_featured_post_style' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_vertical_spacing_style' ) );
+		add_action( 'wp_enqueue_scripts', array( $this, 'add_lightbox_style' ) );
 		add_action( 'neve_do_featured_post', array( $this, 'render_featured_post' ) );
 		add_action( 'neve_blog_post_template_part_content', array( $this, 'render_post' ) );
 		add_filter( 'excerpt_more', array( $this, 'link_excerpt_more' ) );
@@ -551,5 +552,34 @@ class Template_Parts extends Base_View {
 		);
 
 		return json_decode( get_theme_mod( 'neve_post_content_ordering', wp_json_encode( $default_ordered_components ) ), $associative );
+	}
+
+	/**
+	 * Add inline lightbox style if the post content includes an image block with lightbox.
+	 */
+	public function add_lightbox_style() {
+		global $post;
+		if ( ! has_block( 'core/image', $post ) ) {
+			return;
+		}
+		$blocks = parse_blocks( $post->post_content );
+		$blocks = array_filter(
+			$blocks,
+			function( $block ) {
+				return 'core/image' === $block['blockName'] && ! empty( $block['attrs']['lightbox']['enabled'] );
+			}
+		);
+		if ( empty( $blocks ) ) {
+			return;
+		}
+		$inline_style = '
+			.wp-lightbox-overlay figure img {
+				height: var(--wp--lightbox-image-height);
+				min-height: var(--wp--lightbox-image-height);
+				min-width: var(--wp--lightbox-image-width);
+				width: var(--wp--lightbox-image-width);
+			}
+		';
+		wp_add_inline_style( 'neve-style', Dynamic_Css::minify_css( $inline_style ) );
 	}
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38.3 KB",
+			"limit": "38.1 KB",
 			"path": "style-main-new.min.css"
 		}
 	],

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38.1 KB",
+			"limit": "38.3 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
Fixed issue with WP default lightbox model.

### Test instructions
1. Add an image block
2. enable “Expand on click” for the image
3. change the alignment of the image ( left/right/center) -> when an alignment option (other than None ) is enabled, the image doesn't expand to full width


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes #4260
