### PR TITLE
Fixed PHP warning in template_parts.php

### DIFF
--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -455,7 +455,7 @@ class Template_Parts extends Base_View {
 			$new_moretag = '';
 		}
 
-		$read_more_args = (array) apply_filters(
+		$read_more_args = apply_filters(
 			'neve_read_more_args',
 			array(
 				'text'    => esc_html__( 'Read More', 'neve' ) . ' &raquo;',

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -455,7 +455,7 @@ class Template_Parts extends Base_View {
 			$new_moretag = '';
 		}
 
-		$read_more_args = apply_filters(
+		$read_more_args = (array) apply_filters(
 			'neve_read_more_args',
 			array(
 				'text'    => esc_html__( 'Read More', 'neve' ) . ' &raquo;',
@@ -463,8 +463,15 @@ class Template_Parts extends Base_View {
 			)
 		);
 
-		$markup  = '<a href="' . esc_url( get_the_permalink( $post_id ) ) . '"';
-		$markup .= ' class="' . esc_attr( $read_more_args['classes'] ) . '"';
+		// Return $new_moretag if 'text' key is not set in $read_more_args.
+		if ( ! isset( $read_more_args['text'] ) ) {
+			return $new_moretag;
+		}
+
+		$markup = '<a href="' . esc_url( get_the_permalink( $post_id ) ) . '"';
+		if ( ! empty( $read_more_args['classes'] ) ) {
+			$markup .= ' class="' . esc_attr( $read_more_args['classes'] ) . '"';
+		}
 		$markup .= ' rel="bookmark">';
 		$markup .= esc_html( $read_more_args['text'] );
 		$markup .= '<span class="screen-reader-text">' . get_the_title( $post_id ) . '</span>';


### PR DESCRIPTION
### Summary
In this PR, I've fixed the PHP warning.

### Test instructions

Please follow the test instructions provided in the issue description or use the code snippets below.

`add_filter( 'neve_read_more_args', '__return_false', 99 );`

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve-pro-addon/issues/2854