### PR TITLE
Fixed compatibility issue TranslatePress plugin

### DIFF
--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -47,10 +47,10 @@ $title_tagline .= '</div>';
 
 $aria_label = trim( get_bloginfo( 'name' ) . ' ' . get_bloginfo( 'description' ) );
 if ( $is_not_link ) {
-	$start_tag = '<span class="brand" title="← ' . get_bloginfo( 'name' ) . '" aria-label="' . esc_attr( $aria_label ) . '">';
+	$start_tag = '<span class="brand" title="&larr; ' . get_bloginfo( 'name' ) . '" aria-label="' . esc_attr( $aria_label ) . '">';
 	$end_tag   = '</span>';
 } else {
-	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" title="← ' . get_bloginfo( 'name' ) . '"
+	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" title="&larr; ' . get_bloginfo( 'name' ) . '"
 			aria-label="' . esc_attr( $aria_label ) . '" rel="home">';
 	$end_tag   = '</a>';
 }


### PR DESCRIPTION
### Summary
I've used arrows unicode to fix the issue with `TranslatePress`

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve/issues/4301
