### PR TITLE
feat: show BF banner for Tier 1 Pro and Free

### DIFF
--- a/assets/apps/dashboard/src/Components/Deal.js
+++ b/assets/apps/dashboard/src/Components/Deal.js
@@ -1,6 +1,10 @@
 /* global neveDash */
 
 const Deal = () => {
+	if (1 < neveDash?.license?.tier) {
+		return <></>;
+	}
+
 	if (
 		!Boolean(window.neveDash?.deal?.active) ||
 		!Boolean(neveDash?.deal?.bannerUrl) ||

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -384,7 +384,7 @@ class Main {
 			'getPluginStateBaseURL'   => esc_url( rest_url( '/nv/v1/dashboard/plugin-state/' ) ),
 			'canInstallPlugins'       => current_user_can( 'install_plugins' ),
 			'canActivatePlugins'      => current_user_can( 'activate_plugins' ),
-			'deal'                    => ! defined( 'NEVE_PRO_VERSION' ) ? $offer->get_localized_data() : array(),
+			'deal'                    => $offer->get_localized_data(),
 			'rootUrl'                 => get_site_url(),
 			'daysSinceInstall'        => round( ( time() - get_option( 'neve_install', 0 ) ) / DAY_IN_SECONDS ),
 			'proPluginVersion'        => defined( 'NEVE_PRO_VERSION' ) ? NEVE_PRO_VERSION : '',


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Include Tier 1 Pro for BF promotion on Dashboard

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

![image](https://github.com/user-attachments/assets/b532959b-124f-4fc5-9102-c3e9b6ed7865)


### Test instructions
<!-- Describe how this pull request can be tested. -->

Must be used with https://github.com/Codeinwp/themeisle-sdk/pull/269

- Set the instance date between 25 NOV and 3 DEC to trigger Black Friday banner
- You should see the banner on the Library page.
- You should NOT see the banner if it is not a Blackfriday Interval

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1688
<!-- Should look like this: `Closes #1, #2, #3.` . -->
