### PR TITLE
Fixed submenu text wrapping issue on mobile

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -132,7 +132,7 @@
 
 		li:not([class*="block"]) > .wrap > a {
 			padding: $spacing-sm 0;
-			white-space: unset;
+			white-space: normal;
 		}
 
 		.caret svg {


### PR DESCRIPTION
### Summary
I resolved the text wrapping issue in the mobile nested submenus.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes Codeinwp/neve-pro-addon/issues/2868
