### PR TITLE
Fixed WC icon display issue with notices

### DIFF
--- a/assets/scss/components/compat/woocommerce/_notices.scss
+++ b/assets/scss/components/compat/woocommerce/_notices.scss
@@ -25,10 +25,6 @@
 	--primarybtnhoverbg: transparent;
 	--primarybtnbg: transparent;
 
-	&::before {
-		display: none;
-	}
-
 	> a {
 
 		@extend %nv-button-primary-no-colors;
@@ -136,7 +132,6 @@ $blockNotices: (
 }
 
 .woocommerce .woocommerce-error {
-	padding-left: 3.5em;
 
 	li {
 		width: 100%;


### PR DESCRIPTION
### Summary
Fixed WooCommerce notices icon issue with mobile screen.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve/issues/4319#event-15262468572
