### PR TITLE
Fixed load textdomain issue with WP 6.7

### DIFF
--- a/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
+++ b/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
@@ -33,10 +33,12 @@ test.describe('Custom Global Color Control', () => {
 		);
 		await clearWelcome(page);
 
-		await page.waitForTimeout( 200 );
-		await page.locator( '.block-editor-default-block-appender__content' ).click();
-
-		await page.locator('.block-editor-rich-text__editable').first().click();
+		const iframeElement = await page.waitForSelector('iframe');
+		const frame = await iframeElement.contentFrame();
+		if (frame) {
+			await frame.waitForSelector('.block-editor-rich-text__editable');
+			await frame.locator('.block-editor-rich-text__editable').first().click();
+		}
 		// use Background color control to open the color picker, available since WP 6.1
 		await page.getByRole('button', { name: 'Background' }).click();
 		await page.getByRole('option', { name: 'Color: Custom 1' }).click();

--- a/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
+++ b/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
@@ -33,6 +33,9 @@ test.describe('Custom Global Color Control', () => {
 		);
 		await clearWelcome(page);
 
+		await page.waitForTimeout( 200 );
+		await page.locator( '.block-editor-default-block-appender__content' ).click();
+
 		await page.locator('.block-editor-rich-text__editable').first().click();
 		// use Background color control to open the color picker, available since WP 6.1
 		await page.getByRole('button', { name: 'Background' }).click();

--- a/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
@@ -28,16 +28,36 @@ test.describe('Menu item description', function () {
 		await page.getByRole('button', { name: 'Add New Category' }).click();
 		await page.goto('wp-admin/nav-menus.php');
 
-		await page
-			.getByRole('heading', {
-				name: 'Categories Press return or enter to open this section ',
-			})
-			.click();
+		await page.waitForSelector('.menu-name');
+		await page.locator('.menu-name').fill('My New Menu');
+		await page.getByLabel('Primary Menu').check();
+		await page.locator('#save_menu_footer ').click();
+
+		await page.locator('#add-category h3').click();
 		await page
 			.locator('#taxonomy-category-tabs')
 			.getByRole('link', { name: 'View All' })
 			.click();
 		await page.getByLabel('ADescriptionCat').check();
+
+		await Promise.all([
+			page.waitForResponse(
+				(res) =>
+					res.url().includes('wp-admin/admin-ajax.php') &&
+					res.status() === 200
+			),
+			page.getByRole('button', { name: 'Add to Menu' }).click(),
+		]);
+
+		await page.keyboard.press('End');
+		await page.waitForTimeout(500);
+
+		await page.locator('#add-post-type-page h3').click();
+		await page
+			.locator('#posttype-page-tabs')
+			.getByRole('link', { name: 'View All' })
+			.click();
+		await page.getByLabel('Sample Page').last().check();
 
 		await Promise.all([
 			page.waitForResponse(

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -81,7 +81,6 @@ class Main {
 	 */
 	public function init() {
 
-		$this->setup_config();
 		add_action( 'init', [ $this, 'setup_config' ] );
 		add_action( 'admin_menu', [ $this, 'register' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -81,6 +81,7 @@ class Main {
 	 */
 	public function init() {
 
+		$this->setup_config();
 		add_action( 'init', [ $this, 'setup_config' ] );
 		add_action( 'admin_menu', [ $this, 'register' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );

--- a/inc/compatibility/web_stories.php
+++ b/inc/compatibility/web_stories.php
@@ -37,7 +37,7 @@ class Web_Stories {
 	 * Load hooks.
 	 */
 	private function load_hooks() {
-		add_action( 'after_setup_theme', array( $this, 'setup' ) );
+		add_action( 'init', array( $this, 'setup' ) );
 		add_action( 'wp_body_open', array( $this, 'embed' ) );
 	}
 

--- a/inc/core/core_loader.php
+++ b/inc/core/core_loader.php
@@ -174,7 +174,7 @@ class Core_Loader {
 		);
 		$front_end = new Front_End();
 		add_action( 'wp_enqueue_scripts', array( $front_end, 'enqueue_scripts' ) );
-		add_action( 'after_setup_theme', array( $front_end, 'setup_theme' ) );
+		add_action( 'init', array( $front_end, 'setup_theme' ) );
 		add_action( 'widgets_init', array( $front_end, 'register_sidebars' ) );
 		add_filter( 'load_script_translation_file', array( $front_end, 'fix_script_translation_files' ), 10, 3 );
 	}

--- a/start.php
+++ b/start.php
@@ -53,7 +53,14 @@ function neve_run() {
 	}
 
 	$autoloader->register();
+}
 
+neve_run();
+
+/**
+ * Load core modules.
+ */
+function neve_core_loader() {
 	if ( class_exists( '\\Neve\\Core\\Core_Loader' ) ) {
 		new \Neve\Core\Core_Loader();
 	}
@@ -71,5 +78,4 @@ function neve_run() {
 		\Neve_Pro\Core\Loader::instance();
 	}
 }
-
-neve_run();
+add_action( 'after_setup_theme', 'neve_core_loader' );


### PR DESCRIPTION
### Summary
I have removed the early translation function call following [WordPress standards](https://make.wordpress.org/core/2024/10/21/i18n-improvements-6-7/).

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve/issues/4322
