### PR TITLE
Redirect to Onboarding

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/Start.js
+++ b/assets/apps/dashboard/src/Components/Content/Start.js
@@ -9,7 +9,7 @@ import { withSelect } from '@wordpress/data';
 
 const Start = (props) => {
 	const { setTab, tier } = props;
-	const { pro, whiteLabel, customizerShortcuts, tpcAdminURL } = neveDash;
+	const { pro, whiteLabel, customizerShortcuts, tpcOnboardingURL } = neveDash;
 	const starterSitesHidden = whiteLabel && whiteLabel.hideStarterSites;
 
 	const renderCustomizerLinks = () => {
@@ -65,7 +65,7 @@ const Start = (props) => {
 								{__('Go to Starter Sites', 'neve')}
 							</Button>
 						) : (
-							<Button href={tpcAdminURL} isPrimary>
+							<Button href={tpcOnboardingURL} isPrimary>
 								{__('Go to Starter Sites', 'neve')}
 							</Button>
 						)}

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -379,6 +379,7 @@ class Main {
 			'hidePluginsTab'          => apply_filters( 'neve_hide_useful_plugins', ! array_key_exists( 'useful_plugins', $old_about_config ) ),
 			'tpcPath'                 => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
 			'tpcAdminURL'             => admin_url( 'admin.php?page=tiob-starter-sites' ),
+			'tpcOnboardingURL'        => admin_url( 'admin.php?page=neve-onboarding' ),
 			'pluginsURL'              => esc_url( admin_url( 'plugins.php' ) ),
 			'getPluginStateBaseURL'   => esc_url( rest_url( '/nv/v1/dashboard/plugin-state/' ) ),
 			'canInstallPlugins'       => current_user_can( 'install_plugins' ),


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Redirect to Onboarding when clicking on the `Starter Sites` button in the Dashboard.



### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- After installing TPC, click on the `Starter Sites` button in the Dashboard and see if you are redirected to the Onboarding workflow

> [!NOTE]
> For sidebar sub-menu, use this https://github.com/Codeinwp/templates-patterns-collection/pull/423

https://github.com/user-attachments/assets/bef65930-c935-4a1d-9211-e20182de253d


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2910
<!-- Should look like this: `Closes #1, #2, #3.` . -->
