### PR TITLE
fix: remove unnecessary title attributes from brand elements

### DIFF
--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -47,11 +47,10 @@ $title_tagline .= '</div>';
 
 $aria_label = trim( get_bloginfo( 'name' ) . ' ' . get_bloginfo( 'description' ) );
 if ( $is_not_link ) {
-	$start_tag = '<span class="brand" title="&larr; ' . get_bloginfo( 'name' ) . '" aria-label="' . esc_attr( $aria_label ) . '">';
+	$start_tag = '<span class="brand" aria-label="' . esc_attr( $aria_label ) . '">';
 	$end_tag   = '</span>';
 } else {
-	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" title="&larr; ' . get_bloginfo( 'name' ) . '"
-			aria-label="' . esc_attr( $aria_label ) . '" rel="home">';
+	$start_tag = '<a class="brand" href="' . esc_url( home_url( '/' ) ) . '" aria-label="' . esc_attr( $aria_label ) . '" rel="home">';
 	$end_tag   = '</a>';
 }
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Remove `title` attributes with its arrow value since we already have `aria-label` 

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

<img width="521" alt="Screenshot 2025-01-09 at 17 06 12" src="https://github.com/user-attachments/assets/8823845a-5174-4bf7-8e57-0b3509ffc477" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if the `title` no longer appears.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2930
<!-- Should look like this: `Closes #1, #2, #3.` . -->
