### PR TITLE
fix: use post type label in meta box settings

### DIFF
--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -116,10 +116,12 @@ final class Manager {
 	 * Register meta box to control layout on pages and posts.
 	 */
 	public function add() {
-		$post_type         = 'Neve';
+		$post_type_label   = 'Neve';
 		$post_type_from_db = get_post_type();
-		if ( $post_type_from_db ) {
-			$post_type = ucfirst( $post_type_from_db );
+		$post_type_object  = get_post_type_object( $post_type_from_db );
+		
+		if ( $post_type_object && isset( $post_type_object->labels->name ) ) {
+			$post_type_label = $post_type_object->labels->name;
 		}
 
 		add_meta_box(
@@ -127,7 +129,7 @@ final class Manager {
 			sprintf(
 			/* translators: %s - post type */
 				__( '%s Settings', 'neve' ),
-				$post_type
+				$post_type_label
 			),
 			array( $this, 'render_metabox' ),
 			array( 'post', 'page', 'product' ),
@@ -144,7 +146,7 @@ final class Manager {
 				sprintf(
 				/* translators: %s - post type */
 					__( '%s Settings', 'neve' ),
-					$post_type
+					$post_type_label
 				),
 				array( $this, 'render_metabox_notice' ),
 				Supported_Post_Types::get( 'block_editor' ),


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Use the Post Type registered display name as the label instead of using the database slug.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

#### Normal

<img width="1510" alt="Screenshot 2025-01-09 at 17 35 29" src="https://github.com/user-attachments/assets/76b4ba91-4b25-4338-ad03-42ce3da34575" />

#### BEFORE in Russian

<img width="1221" alt="Screenshot 2025-01-09 at 17 44 51" src="https://github.com/user-attachments/assets/f854c264-da29-4d98-b931-e6e788f5c53d" />

#### AFTER in Russian

<img width="1081" alt="Screenshot 2025-01-09 at 17 47 33" src="https://github.com/user-attachments/assets/e1d5b9e5-4417-4d76-b7cb-5d2e914910ee" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if the label is displayed correctly.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2938
<!-- Should look like this: `Closes #1, #2, #3.` . -->
