### PR TITLE
feat: add starter content notice and dismissal functionality

### DIFF
--- a/assets/apps/customizer-controls/src/controls.js
+++ b/assets/apps/customizer-controls/src/controls.js
@@ -45,6 +45,7 @@ import { initLocalGoogleFonts } from './typography-extra/LocalGoogleFonts';
 
 import MainSearch from './customizer-search/MainSearch.tsx';
 import { FontPairControl } from './typography-font-pair/Control';
+import { initStarterContentNotice } from './starter-content/Notice.js';
 
 const { controlConstructor } = wp.customize;
 
@@ -326,6 +327,7 @@ const checkHasElementorTemplates = () => {
 };
 
 window.wp.customize.bind('ready', () => {
+	initStarterContentNotice();
 	initDocSection();
 	initDynamicFields();
 	initUpsellSection();

--- a/assets/apps/customizer-controls/src/starter-content/Notice.js
+++ b/assets/apps/customizer-controls/src/starter-content/Notice.js
@@ -35,10 +35,8 @@ const NoticeWrapper = () => {
 					setError(response.data.message);
 					return;
 				}
-				if (wp.customize.previewer) {
-					wp.customize.previewer.refresh();
-				}
 				wp.customize.notifications.remove(noticeId);
+				window.location.reload();
 			})
 			.catch((err) => {
 				setError(

--- a/assets/apps/customizer-controls/src/starter-content/Notice.js
+++ b/assets/apps/customizer-controls/src/starter-content/Notice.js
@@ -1,0 +1,85 @@
+/* global NeveReactCustomize fetch ajaxurl */
+
+import StarterContentNotice from './StarterContentNotice.js';
+import { render, useState } from '@wordpress/element';
+
+const noticeId = 'neve-starter-content';
+
+const NoticeWrapper = () => {
+	const [error, setError] = useState(null);
+
+	const handleKeep = () => {
+		setError(null);
+		wp.customize.previewer.save();
+		if (wp.customize.previewer) {
+			wp.customize.previewer.refresh();
+		}
+		wp.customize.notifications.remove(noticeId);
+	};
+
+	const handleRemove = () => {
+		setError(null);
+		fetch(ajaxurl, {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/x-www-form-urlencoded',
+			},
+			body: new URLSearchParams({
+				action: 'neve_dismiss_starter_content',
+				nonce: NeveReactCustomize.starterContent.nonce,
+			}),
+		})
+			.then((response) => response.json())
+			.then((response) => {
+				if (!response.success) {
+					setError(response.data.message);
+					return;
+				}
+				if (wp.customize.previewer) {
+					wp.customize.previewer.refresh();
+				}
+				wp.customize.notifications.remove(noticeId);
+			})
+			.catch((err) => {
+				setError(
+					err.message ||
+						NeveReactCustomize.starterContent.labels.error
+				);
+			});
+	};
+
+	return (
+		<StarterContentNotice
+			onKeep={handleKeep}
+			onRemove={handleRemove}
+			error={error}
+			labels={window.NeveReactCustomize.starterContent.labels}
+		/>
+	);
+};
+
+export const initStarterContentNotice = () => {
+	if (!NeveReactCustomize.starterContent.active) {
+		return;
+	}
+
+	const renderNotice = () => {
+		const root = document.querySelector('#nv-starter-content-notice');
+		if (!root) {
+			return;
+		}
+		render(<NoticeWrapper />, root);
+	};
+
+	const notice = new wp.customize.Notification(noticeId, {
+		type: 'info',
+		message: '<div id="nv-starter-content-notice"></div>',
+		dismissible: true,
+	});
+
+	wp.customize.notifications.add(noticeId, notice);
+
+	wp.customize.notifications.bind('add', renderNotice);
+	wp.customize.notifications.bind('remove', renderNotice);
+	wp.customize.bind('pane-contents-reflowed', renderNotice);
+};

--- a/assets/apps/customizer-controls/src/starter-content/StarterContentNotice.js
+++ b/assets/apps/customizer-controls/src/starter-content/StarterContentNotice.js
@@ -1,0 +1,26 @@
+const StarterContentNotice = ({ onKeep, onRemove, labels, error }) => {
+	return (
+		<div className="nv-notice">
+			<h3>{labels.title}</h3>
+			<p>{labels.description}</p>
+			<button
+				type="button"
+				className="button button-primary"
+				onClick={onKeep}
+			>
+				{labels.save}
+			</button>
+			<button
+				type="button"
+				className="button secondary"
+				onClick={onRemove}
+			>
+				{labels.dismiss}
+			</button>
+			{error && <div className="nv-notice-error">{error}</div>}
+			<span className="nv-subtitle">{labels.info}</span>
+		</div>
+	);
+};
+
+export default StarterContentNotice;

--- a/assets/customizer/css/_generic.css
+++ b/assets/customizer/css/_generic.css
@@ -67,3 +67,27 @@
 	margin-right: 8px;
 	color: #2271b1;
 }
+
+#nv-starter-content-notice {
+	min-height: 200px;
+}
+
+#nv-starter-content-notice .nv-notice {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+}
+
+#nv-starter-content-notice .nv-notice :is(p, h3) {
+	margin: 0;
+}
+
+#nv-starter-content-notice .nv-subtitle {
+	text-align: center;
+	color: #707070;
+}
+
+#nv-starter-content-notice .nv-notice-error {
+	text-align: center;
+	color: red;
+}

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -35,6 +35,7 @@ class Loader {
 		add_action( 'customize_preview_init', array( $this, 'enqueue_customizer_preview' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'set_featured_image' ) );
 		add_action( 'customize_controls_enqueue_scripts', array( $this, 'enqueue_customizer_controls' ) );
+		add_action( 'wp_ajax_neve_dismiss_starter_content', array( $this, 'dismiss_starter_content' ) );
 	}
 
 	/**
@@ -153,6 +154,19 @@ class Loader {
 						],
 					],
 					'deal'                          => ! defined( 'NEVE_PRO_VERSION' ) ? $offer->get_localized_data() : array(),
+					'starterContent'                => array(
+						'active'          => is_customize_preview() && current_theme_supports( 'starter-content' ) && get_option( 'fresh_site' ),
+						'nonce'           => wp_create_nonce( 'neve_dismiss_starter_content' ),
+						'dismissEndpoint' => admin_url( 'admin-ajax.php' ),
+						'labels'          => array(
+							'title'       => __( 'Welcome to your new site!', 'neve' ),
+							'description' => __( "We've added some started pages to help you get going quickly.", 'neve' ),
+							'save'        => __( 'Keep these helpful pages', 'neve' ),
+							'dismiss'     => __( 'Start with a clean slate.', 'neve' ),
+							'info'        => __( "Don't worry - you can always add or remove pages later.", 'neve' ),
+							'error'       => __( 'An error occurred. Please reload the page and try again.', 'neve' ),
+						),
+					),
 				)
 			)
 		);
@@ -277,6 +291,40 @@ class Loader {
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'default'           => false,
 			]
+		);
+	}
+
+	/**
+	 * Handle the starter content dismissal.
+	 * 
+	 * @return void
+	 */
+	public function dismiss_starter_content() {
+		if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( $_POST['nonce'] ), 'neve_dismiss_starter_content' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Invalid security token.', 'neve' ),
+				) 
+			);
+		}
+
+		if ( ! current_user_can( 'manage_options' ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'You do not have permission to perform this action.', 'neve' ),
+				) 
+			);
+		}
+
+		$result = update_option( 'fresh_site', '0' );
+		if ( $result ) {
+			wp_send_json_success();
+		}
+
+		wp_send_json_error(
+			array(
+				'message' => __( 'An error occurred. Please reload the page and try again.', 'neve' ),
+			) 
 		);
 	}
 }

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -155,7 +155,7 @@ class Loader {
 					],
 					'deal'                          => ! defined( 'NEVE_PRO_VERSION' ) ? $offer->get_localized_data() : array(),
 					'starterContent'                => array(
-						'active'          => is_customize_preview() && current_theme_supports( 'starter-content' ) && get_option( 'fresh_site' ),
+						'active'          => (bool) get_option( 'fresh_site' ),
 						'nonce'           => wp_create_nonce( 'neve_dismiss_starter_content' ),
 						'dismissEndpoint' => admin_url( 'admin-ajax.php' ),
 						'labels'          => array(


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Show a notice if the Starter Content is being used.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="301" alt="Screenshot 2025-01-22 at 12 42 35" src="https://github.com/user-attachments/assets/e61cc79a-4835-43d3-a5ec-80efa59d22d5" />

<img width="314" alt="Screenshot 2025-01-22 at 12 43 34" src="https://github.com/user-attachments/assets/5011f726-799e-4cbb-8da2-fb6634c80c91" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- On a new instance, if the Starter Content is being used, the notice should be visible in the Customizer Sidebar

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2919
<!-- Should look like this: `Closes #1, #2, #3.` . -->
