### PR TITLE
feat: enhance copyright quick link with upsell description and badge

### DIFF
--- a/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
+++ b/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { WPCustomizeControl } from '../@types/customizer-control';
 
@@ -10,7 +10,7 @@ type Props = {
 const Instructions: React.FC<Props> = ({ control }) => {
 	const { params, id } = control;
 	const { options } = params;
-	const { description, quickLinks, builderMigrated, hadOldBuilder } = options;
+	const { description, quickLinks } = options;
 
 	const linkKeys = Object.keys(quickLinks);
 
@@ -48,8 +48,13 @@ const Instructions: React.FC<Props> = ({ control }) => {
 					</span>
 					<ul className="quick-links">
 						{linkKeys.map((settingSlug, index) => {
-							const { label, icon, url } =
-								quickLinks[settingSlug];
+							const {
+								label,
+								icon,
+								url,
+								upsellDescription,
+								badge,
+							} = quickLinks[settingSlug];
 
 							return (
 								<li key={index}>
@@ -66,7 +71,28 @@ const Instructions: React.FC<Props> = ({ control }) => {
 									>
 										<span className={`dashicons ${icon}`} />
 										{label}
+										{url && badge && (
+											<span className="quick-links-badge">
+												{badge}
+											</span>
+										)}
 									</Button>
+									{url && upsellDescription && (
+										<div className="quick-links-upsell">
+											<p className="quick-links-description">
+												<div
+													dangerouslySetInnerHTML={{
+														// eslint-disable-next-line @wordpress/valid-sprintf
+														__html: sprintf(
+															upsellDescription,
+															`<a href="${url}" target="_blank" rel="noopener noreferrer">`,
+															'</a>'
+														),
+													}}
+												/>
+											</p>
+										</div>
+									)}
 								</li>
 							);
 						})}

--- a/assets/apps/customizer-controls/src/builder/scss/_instructional-section.scss
+++ b/assets/apps/customizer-controls/src/builder/scss/_instructional-section.scss
@@ -14,6 +14,27 @@
 	button {
 	  text-decoration: none;
 	}
+
+	.quick-links-badge {
+		text-transform: uppercase;
+		margin-left: 6px;
+		color: #3965e3;
+		background-color: #dee8fc;
+		padding: 2px 6px;
+		border-radius: 5px;
+		font-weight: 600;
+		font-size: 12px;
+	}
+
+	.quick-links-upsell {
+		background-color: #f9fafb;
+		padding: 20px 15px;
+
+		p {
+			margin: 0;
+			color: #4d5562;
+		}
+	}
   }
 
   .quick-links-wrap {

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -65,9 +65,12 @@ class Footer extends Abstract_Builder {
 				),
 				'quickLinks'  => array(
 					'footer_copyright_content'            => array(
-						'label' => esc_html__( 'Change Copyright', 'neve' ),
-						'icon'  => 'dashicons-nametag',
-						'url'   => $this->has_valid_addons() ? null : tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', 'copyright' ), 'query' ),
+						'label'             => esc_html__( 'Change Copyright', 'neve' ),
+						'icon'              => 'dashicons-nametag',
+						'url'               => $this->has_valid_addons() ? null : tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', 'copyright' ), 'query' ),
+						'badge'             => esc_html__( 'Pro', 'neve' ),
+						/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+						'upsellDescription' => __( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
 					),
 					'hfg_footer_layout_bottom_background' => array(
 						'label' => esc_html__( 'Change Footer Color', 'neve' ),


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Improve the Copyright upsell in Customizer

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="978" alt="Screenshot 2025-01-22 at 14 35 16" src="https://github.com/user-attachments/assets/347c93e6-c557-47d6-9531-58a764891269" />

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check if the new elements (badge and description) appear.
- When Neve Pro is active, it should be hidden.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2916
<!-- Should look like this: `Closes #1, #2, #3.` . -->
