### PR TITLE
fix: safari compatibility with image width on onboarding notice

### DIFF
--- a/inc/core/admin.php
+++ b/inc/core/admin.php
@@ -576,7 +576,6 @@ class Admin {
 		.nv-notice-column-container img {
 			border: 1px solid #f3f4f5;
 			max-height: 300px;
-			width: fit-content;
 		}
 		.nv-notice-column-container {
 			display: flex;


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Remove property that is not compatible with Safari.


