### PR TITLE
fix: use 2.9 for required in compatibility with NevePro

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -112,7 +112,7 @@ add_filter(
 
 		$compatibilities['NevePro'] = [
 			'basefile'  => defined( 'NEVE_PRO_BASEFILE' ) ? NEVE_PRO_BASEFILE : '',
-			'required'  => '3.0',
+			'required'  => '2.9',
 			'tested_up' => '3.0',
 		];
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

We should use a lower value than `tested_up`.