### PR TITLE
refactor: allow closing the upsell modal for Custom Layout

### DIFF
--- a/inc/admin/hooks_upsells.php
+++ b/inc/admin/hooks_upsells.php
@@ -270,16 +270,22 @@ class Hooks_Upsells {
 			}
 
 			/* ----- CLOSE BUTTON ----- */
-			.cl-close-button {
+			.cl-modal-dismiss .cl-close-button {
 				position: absolute;
 				top: 10px;
 				right: 10px;
-				font-size: 24px;
-				color: #aaa;
 				cursor: pointer;
+				min-width: 30px;;
+				text-decoration: none;
 			}
-			.cl-close-button:hover {
+
+			.cl-modal-dismiss .cl-close-button:hover {
 				color: #333;
+			}
+
+			.cl-modal-dismiss .cl-close-button span {
+				color: black;
+				font-size: 2rem;
 			}
 
 			/* ----- HEADER / TITLE ----- */
@@ -398,6 +404,12 @@ class Hooks_Upsells {
 
 		<div class="cl-overlay">
 			<div class="cl-modal">
+				<div class="cl-modal-dismiss">
+					<button id="cl-close-modal" class="cl-close-button button button-link">
+						<span class="dashicons dashicons-no-alt" aria-hidden="true"></span>
+						<span class="screen-reader-text"><?php echo esc_html__( 'Close', 'neve' ); ?></span>
+					</button>
+				</div>
 				<div class="cl-modal-header">
 					<span class="dashicons dashicons-star-filled" aria-hidden="true"></span>
 					<h2><?php echo esc_html__( 'Take Your Site to the Next Level', 'neve' ); ?></h2>
@@ -460,6 +472,22 @@ class Hooks_Upsells {
 				</div>
 			</div>
 		</div>
+		<script type="text/javascript">
+		document.addEventListener('DOMContentLoaded', function() {
+			const overlay = document.querySelector('.cl-overlay');
+			if ( ! overlay ) {
+				return;
+			}
+
+			document.getElementById('cl-close-modal')?.addEventListener('click', function() {
+				overlay.style.display = 'none';
+			});
+
+			document.getElementById('cl-open-modal')?.addEventListener('click', function() {
+				overlay.style.display = 'flex';
+			});
+		});
+		</script>
 		<?php
 	}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Allow the user to close the modal for Custom Layout upsell. The modal appears every time the user enters the page, and if it is closed, it reappears if the user presses on `Add New Layout`.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->


https://github.com/user-attachments/assets/cd90921f-a684-485d-8128-2dfca42a23d2



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the upsell modal close workflow.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2927
<!-- Should look like this: `Closes #1, #2, #3.` . -->
