### PR TITLE
Feat/customizer panels

### DIFF
--- a/assets/apps/customizer-controls/src/scss/_documentation.scss
+++ b/assets/apps/customizer-controls/src/scss/_documentation.scss
@@ -1,25 +1,32 @@
 .control-section.neve-documentation {
-  display: block !important;
-  margin-bottom: 0;
-  margin-top: -1px;
-  .documentation-inner {
-	display: flex;
-  }
-  .neve-customizer-heading {
-	padding: 7px 10px 7px 14px;
-	display: flex;
-	flex-grow: 1;
-	margin: auto;
-	letter-spacing: initial;
-	font-size: 14px;
-	font-weight: 600;
+	display: block !important;
+	margin-bottom: 0;
+	margin-top: -1px;
 
-	&:hover, &:focus-within {
-	  cursor: default;
+	.documentation-inner {
+		display: flex;
+	}
+	.neve-customizer-heading {
+		padding: 5px 15px 5px 18px;
+		display: flex;
+		flex-grow: 1;
+		margin: auto;
+		align-items: center;
+		justify-content: space-between;
+		letter-spacing: initial;
+		font-size: 14px;
+		font-weight: 600;
+		gap: 10px;
+		height: unset;
+
+		&:hover,
+		&:focus-within {
+			cursor: default;
+		}
 	}
 
 	.components-button {
-	  margin-left: auto;
+		height: auto;
+		padding: 9px 15px;
 	}
-  }
 }

--- a/assets/apps/customizer-controls/src/scss/_upsell.scss
+++ b/assets/apps/customizer-controls/src/scss/_upsell.scss
@@ -1,36 +1,47 @@
-$upsell_blue: #0065A6 !default;
+$upsell_blue: #0065a6 !default;
 
 .control-section.neve-upsell {
-  	margin-bottom: 0;
-  	.upsell-inner {
-	  display: flex;
+	border-top: none !important;
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+
+	&:hover {
+		border-left-color: $upsell_blue;
+	}
+
+	margin-bottom: 0;
+	.upsell-inner {
+		display: flex;
 	}
 	.neve-customizer-heading {
-	  color: $upsell_blue;
-	  padding: 7px 10px 7px 14px;
-	  display: flex;
-	  flex-grow: 1;
-	  margin: auto;
-	  letter-spacing: initial;
-	  font-size: 14px;
-	  font-weight: 600;
+		color: $upsell_blue;
+		padding: 5px 15px 5px 18px;
+		display: flex;
+		flex-grow: 1;
+		margin: auto;
+		letter-spacing: initial;
+		font-size: 14px;
+		align-items: center;
+		gap: 10px;
+		justify-content: space-between;
+		height: auto;
 
-	  &:hover, &:focus-within {
-		background-color: $upsell_blue;
-		color: #fff;
-		cursor: default;
+		&:hover,
+		&:focus-within {
+			background-color: $upsell_blue;
+			color: #fff;
+			cursor: default;
+
+			.components-button {
+				background: #fff;
+				color: $upsell_blue;
+			}
+		}
 
 		.components-button {
-		  background: #fff;
-		  color: $upsell_blue;
+			background: $upsell_blue;
+			height: auto;
+			padding: 9px 15px;
 		}
-	  }
-
-	  .components-button {
-		margin-left: auto;
-		font-weight: 600;
-		font-size: 14px;
-		background: $upsell_blue;
-	  }
 	}
 }

--- a/assets/apps/dashboard/src/Components/App.js
+++ b/assets/apps/dashboard/src/Components/App.js
@@ -39,7 +39,7 @@ const App = () => {
 			<Header />
 
 			{/*<Deal />*/}
-			{'starter-sites' !== currentTab && <Notifications />}
+			{/* {'starter-sites' !== currentTab && <Notifications />} */}
 
 			<Container className="flex flex-col lg:flex-row gap-6 h-full grow">
 				<div className="grow">{tabs[currentTab].render(setTab)}</div>

--- a/assets/apps/dashboard/src/Components/App.js
+++ b/assets/apps/dashboard/src/Components/App.js
@@ -39,7 +39,7 @@ const App = () => {
 			<Header />
 
 			{/*<Deal />*/}
-			{/* {'starter-sites' !== currentTab && <Notifications />} */}
+			{'starter-sites' !== currentTab && <Notifications />}
 
 			<Container className="flex flex-col lg:flex-row gap-6 h-full grow">
 				<div className="grow">{tabs[currentTab].render(setTab)}</div>

--- a/assets/apps/dashboard/src/Components/Content/Welcome.js
+++ b/assets/apps/dashboard/src/Components/Content/Welcome.js
@@ -4,10 +4,11 @@ import { LucidePanelsTopLeft } from 'lucide-react';
 
 import Card from '../../Layout/Card';
 import { NEVE_HAS_PRO } from '../../utils/constants';
-import Link from '../Common/Link';
+
 import TransitionWrapper from '../Common/TransitionWrapper';
 import ModuleGrid from './ModuleGrid';
 import PluginsCard from './Sidebar/PluginsCard';
+import Button from '../Common/Button';
 
 export default () => (
 	<TransitionWrapper className="grid gap-6">
@@ -19,19 +20,35 @@ export default () => (
 
 const CustomizerShortcutsCard = () => (
 	<Card
-		title={__('Essential Settings', 'neve')}
+		title={__('Get Started', 'neve')}
 		icon={<LucidePanelsTopLeft size={18} />}
+		className="border border-blue-300"
+		afterTitle={
+			<Button isPrimary href={neveDash.customizerURL}>
+				{__('Go to Customizer', 'neve')}
+			</Button>
+		}
 	>
-		<div className="grid sm:grid-cols-2 gap-x-8 gap-y-4">
+		<div className="grid sm:grid-cols-2 gap-6">
 			{neveDash.customizerShortcuts.map(({ text, link, description }) => (
-				<div key={link} className="grid gap-1">
-					<Link text={text} url={link} />
+				<a
+					href={link}
+					key={link}
+					className="grid gap-1 p-4 bg-gray-50 rounded-lg hover:bg-gray-100 transition-colors group"
+				>
+					<span
+						className={
+							'text-base text-blue-600 group-hover:text-blue-700 group-hover:underline'
+						}
+					>
+						{text}
+					</span>
 					{description && (
 						<span className="text-gray-600 text-xs">
 							{description}
 						</span>
 					)}
-				</div>
+				</a>
 			))}
 		</div>
 	</Card>

--- a/assets/apps/dashboard/src/Components/Content/Welcome.js
+++ b/assets/apps/dashboard/src/Components/Content/Welcome.js
@@ -29,7 +29,7 @@ const CustomizerShortcutsCard = () => (
 			</Button>
 		}
 	>
-		<div className="grid sm:grid-cols-2 gap-6">
+		<div className="grid sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-6">
 			{neveDash.customizerShortcuts.map(({ text, link, description }) => (
 				<a
 					href={link}

--- a/assets/apps/dashboard/src/Components/SkeletonLoader.js
+++ b/assets/apps/dashboard/src/Components/SkeletonLoader.js
@@ -1,131 +1,103 @@
-const SkeletonLoader = () => (
-	<div className="antialiased grow flex flex-col gap-6 h-full">
-		<header className="bg-white z-50">
-			<div>
+const SkeletonLoader = () => {
+	return (
+		<div className="antialiased grow flex flex-col gap-6 h-full">
+			{/* Header Skeleton */}
+			<header className="bg-white z-50">
 				<div className="border-b border-gray-100">
 					<div className="max-w-[90vw] w-full lg:container mx-auto px-2 lg:px-6">
-						<div className="flex items-center justify-between h-14">
+						<div className="flex flex-col gap-5 py-2 sm:flex-row items-center justify-between">
 							<div className="flex items-center space-x-3">
-								<div className="size-7 bg-gray-200 rounded-sm" />
-								<div className="h-4 w-16 bg-gray-200 rounded" />
-								<div className="h-5 w-14 bg-gray-200 rounded" />
-								<div className="h-4 w-16 bg-gray-200 rounded" />
+								<div className="size-7 rounded-sm bg-gray-200 animate-pulse" />
+								<div className="w-16 h-4 bg-gray-200 animate-pulse rounded" />
 							</div>
-							<div className="flex items-center">
-								<div className="flex items-center gap-2 px-3 py-2">
-									<div className="size-5 bg-gray-200 rounded" />
-									<div className="h-4 w-24 bg-gray-200 rounded" />
-								</div>
-								<div className="w-px h-4 bg-gray-200 mx-3" />
-								<div className="flex items-center gap-2 px-3 py-2">
-									<div className="size-5 bg-gray-200 rounded" />
-									<div className="h-4 w-20 bg-gray-200 rounded" />
-								</div>
+							<div className="flex items-center gap-3">
+								<div className="w-28 h-8 bg-gray-200 animate-pulse rounded" />
+								<div className="w-px h-4 bg-gray-200" />
+								<div className="w-28 h-8 bg-gray-200 animate-pulse rounded" />
 							</div>
 						</div>
 					</div>
 				</div>
 				<div className="border-b border-gray-200">
-					<div className="max-w-[90vw] lg:container mx-auto px-2 lg:px-6">
-						<nav className="flex -mb-px">
-							{[...Array(4)].map((item, i) => (
+					<div className="max-w-[90vw] w-full lg:container mx-auto px-2 lg:px-6">
+						<nav className="flex -mb-px justify-center sm:justify-start">
+							{[1, 2, 3].map((i) => (
 								<div
 									key={i}
-									className={`px-4 py-3 ${
-										i === 0
-											? 'border-b-2 border-gray-200'
-											: ''
-									}`}
-								>
-									<div className="h-4 w-20 bg-gray-200 rounded" />
-								</div>
+									className="w-24 h-4 bg-gray-200 animate-pulse rounded m-4"
+								/>
 							))}
 						</nav>
 					</div>
 				</div>
-			</div>
-		</header>
+			</header>
 
-		<div className="max-w-[90vw] w-full lg:container mx-auto px-2 lg:px-6 flex flex-col lg:flex-row gap-6 h-full grow">
-			<div className="grow">
-				<div className="grid gap-6">
-					<div className="p-6 rounded-lg bg-white shadow-sm">
+			{/* Main Content Skeleton */}
+			<div className="max-w-[90vw] w-full lg:container mx-auto px-2 lg:px-6 flex flex-col lg:flex-row gap-6">
+				<div className="grow">
+					{/* Get Started Section */}
+					<div className="p-6 rounded-lg shadow-sm bg-white border border-gray-200">
 						<div className="flex items-center mb-6 gap-3">
-							<div className="size-5 bg-gray-200 rounded" />
-							<div className="h-5 w-40 bg-gray-200 rounded" />
+							<div className="w-5 h-5 bg-gray-200 animate-pulse rounded" />
+							<div className="w-24 h-5 bg-gray-200 animate-pulse rounded" />
+							<div className="ml-auto">
+								<div className="w-32 h-10 bg-gray-200 animate-pulse rounded" />
+							</div>
 						</div>
-						<div className="grid grid-cols-2 gap-x-8 gap-y-4">
-							{[...Array(8)].map((_, i) => (
+						<div className="grid sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-6">
+							{[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
 								<div
 									key={i}
-									className="h-4 w-32 bg-gray-200 rounded"
+									className="h-20 bg-gray-100 rounded-lg animate-pulse"
 								/>
 							))}
 						</div>
 					</div>
 
-					<div className="grid xl:grid-cols-2 gap-6">
-						<div className="xl:col-span-2 flex items-center justify-between">
-							<div className="h-6 w-40 bg-gray-200 rounded" />
-							<div className="h-4 w-24 bg-gray-200 rounded" />
+					{/* Plugins Section */}
+					<div className="mt-6 p-6 rounded-lg shadow-sm bg-white">
+						<div className="flex items-center mb-6 gap-3">
+							<div className="w-40 h-5 bg-gray-200 animate-pulse rounded" />
 						</div>
-						{[...Array(8)].map((_, i) => (
-							<div
-								key={i}
-								className="p-6 rounded-lg bg-white shadow-sm"
-							>
-								<div className="flex items-center mb-6 gap-3">
-									<div className="size-5 bg-gray-200 rounded" />
-									<div className="h-5 w-32 bg-gray-200 rounded" />
-									<div className="ml-auto">
-										<div className="h-5 w-12 bg-gray-200 rounded" />
+						<div className="grid gap-4 2xl:grid-cols-2">
+							{[1, 2, 3, 4, 5, 6].map((i) => (
+								<div
+									key={i}
+									className="flex items-start p-3 bg-white rounded-lg border border-gray-100"
+								>
+									<div className="flex-grow">
+										<div className="flex gap-4 items-center">
+											<div className="w-6 h-6 bg-gray-200 animate-pulse rounded" />
+											<div className="w-24 h-4 bg-gray-200 animate-pulse rounded" />
+											<div className="ml-auto w-24 h-4 bg-gray-200 animate-pulse rounded" />
+										</div>
+										<div className="w-48 h-4 bg-gray-200 animate-pulse rounded mt-2" />
 									</div>
 								</div>
-								<div className="h-4 w-full bg-gray-200 rounded" />
-							</div>
-						))}
+							))}
+						</div>
 					</div>
 				</div>
-			</div>
 
-			<div className="shrink-0 lg:w-[435px]">
-				<div className="grid gap-6">
-					{[...Array(2)].map((_, i) => (
-						<div
-							key={i}
-							className="p-6 rounded-lg bg-white shadow-sm"
-						>
-							<div className="flex items-center mb-6 gap-3">
-								<div className="h-5 w-32 bg-gray-200 rounded" />
-							</div>
-							<div className="h-4 w-full bg-gray-200 rounded mb-4" />
-							<div className="h-4 w-40 bg-gray-200 rounded" />
-						</div>
-					))}
-					<div className="p-6 rounded-lg bg-white shadow-sm space-y-3">
-						<div className="flex items-center mb-6 gap-3">
-							<div className="h-5 w-40 bg-gray-200 rounded" />
-						</div>
-						{[...Array(6)].map((_, i) => (
+				{/* Sidebar Skeleton */}
+				<div className="shrink-0 lg:w-[435px]">
+					<div className="grid gap-6">
+						{[1, 2, 3, 4].map((i) => (
 							<div
 								key={i}
-								className="flex items-start p-3 bg-white rounded-lg border border-gray-100"
+								className="p-6 rounded-lg shadow-sm bg-white"
 							>
-								<div className="flex-grow">
-									<div className="flex gap-4 items-center">
-										<div className="size-6 bg-gray-200 rounded" />
-										<div className="h-4 w-24 bg-gray-200 rounded" />
-										<div className="ml-auto h-4 w-32 bg-gray-200 rounded" />
-									</div>
-									<div className="h-4 w-3/4 bg-gray-200 rounded mt-1" />
+								<div className="flex items-center mb-6 gap-3">
+									<div className="w-32 h-5 bg-gray-200 animate-pulse rounded" />
 								</div>
+								<div className="w-full h-24 bg-gray-100 rounded animate-pulse" />
 							</div>
 						))}
 					</div>
 				</div>
 			</div>
 		</div>
-	</div>
-);
+	);
+};
 
 export default SkeletonLoader;

--- a/assets/customizer/css/_generic.css
+++ b/assets/customizer/css/_generic.css
@@ -95,3 +95,8 @@
 	text-align: center;
 	color: red;
 }
+
+.neve-separator-section {
+	margin: 20px auto;
+	max-width: 90%;
+}

--- a/assets/customizer/js/separator-section.js
+++ b/assets/customizer/js/separator-section.js
@@ -1,0 +1,9 @@
+wp.customize.sectionConstructor.neve_separator = wp.customize.Section.extend({
+	// No events for this type of section.
+	attachEvents() {},
+
+	// Always make the section active.
+	isContextuallyActive() {
+		return true;
+	},
+});

--- a/e2e-tests/fixtures/customizer/form-fields/form-fields-setup.json
+++ b/e2e-tests/fixtures/customizer/form-fields/form-fields-setup.json
@@ -1,4 +1,5 @@
 {
+    "neve_single_post_sidebar_layout": "right",
     "neve_migrated_hfg_colors": true,
     "nav_menu_locations": [],
     "ti_prev_theme": "twentytwentyone",

--- a/e2e-tests/specs/admin/tpc-notice-install.spec.ts
+++ b/e2e-tests/specs/admin/tpc-notice-install.spec.ts
@@ -25,7 +25,9 @@ test.describe('Dashboard Notice', () => {
 		);
 
 		// Welcome screen
-		await expect(page.locator('h1')).toContainText('Choose a design');
+		await expect(page.locator('h1')).toContainText(
+			'What type of website are you creating?'
+		);
 
 		const categories = await page.locator('.ob-cat-wrap .cat');
 		await expect(categories).toContainText([

--- a/e2e-tests/specs/admin/tpc-notice-install.spec.ts
+++ b/e2e-tests/specs/admin/tpc-notice-install.spec.ts
@@ -25,17 +25,16 @@ test.describe('Dashboard Notice', () => {
 		);
 
 		// Welcome screen
-		await expect(page.locator('h1')).toContainText(
-			'What type of website are you creating?'
-		);
+		await expect(page.locator('h1')).toContainText('Choose a design');
 
 		const categories = await page.locator('.ob-cat-wrap .cat');
 		await expect(categories).toContainText([
 			'Business',
-			'Personal',
-			'Blogging',
-			'Portfolio',
-			'E-Shop',
+			'Education',
+			'eCommerce',
+			'News',
+			'Non-Profit',
+			'Health',
 		]);
 
 		await page.goto('/wp-admin/index.php');

--- a/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
+++ b/e2e-tests/specs/customizer/general/custom-global-colors.spec.ts
@@ -32,7 +32,10 @@ test.describe('Custom Global Color Control', () => {
 			'/wp-admin/post.php?post=1&action=edit&test_name=custom-global-colors'
 		);
 		await clearWelcome(page);
-		await page.frameLocator('[name="editor-canvas"]').locator('.block-editor-rich-text__editable').first().click();
+		await page
+			.locator('.block-editor-rich-text__editable')
+			.first()
+			.click({ force: true });
 		await page.getByRole('button', { name: 'Background' }).click();
 		await page.getByRole('option', { name: 'Color: Custom 1' }).click();
 		await page

--- a/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-menu-item-description.spec.ts
@@ -28,7 +28,10 @@ test.describe('Menu item description', function () {
 		await page.getByRole('button', { name: 'Add New Category' }).click();
 		await page.goto('wp-admin/nav-menus.php');
 
-		await page.getByRole('button', { name: 'Categories' }).click();
+		await page
+			.locator('.accordion-section-title')
+			.getByText('Categories')
+			.click();
 		await page
 			.locator('#taxonomy-category-tabs')
 			.getByRole('link', { name: 'View All' })

--- a/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
@@ -208,7 +208,7 @@ test.describe('Blog/Archive 3 / Covers Layout', () => {
 			).not.toEqual(0);
 			await expect(coverPost).toHaveCSS(
 				'box-shadow',
-				'rgba(0, 0, 0, 0.12) 0px 14px 28px 0px, rgba(0, 0, 0, 0.12) 0px 10px 10px 0px'
+				'rgba(0, 0, 0, 0.15) 0px 0px 2px 0px'
 			);
 		}
 	});

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -354,6 +354,7 @@ class Main {
 			'tpcPath'                 => defined( 'TIOB_PATH' ) ? TIOB_PATH . 'template-patterns-collection.php' : 'template-patterns-collection/template-patterns-collection.php',
 			'tpcAdminURL'             => admin_url( 'admin.php?page=tiob-starter-sites' ),
 			'tpcOnboardingURL'        => admin_url( 'admin.php?page=neve-onboarding' ),
+			'customizerURL'           => admin_url( 'customize.php' ),
 			'pluginsURL'              => esc_url( admin_url( 'plugins.php' ) ),
 			'getPluginStateBaseURL'   => esc_url( rest_url( '/nv/v1/dashboard/plugin-state/' ) ),
 			'canInstallPlugins'       => current_user_can( 'install_plugins' ),

--- a/inc/compatibility/starter-content/theme-mods.php
+++ b/inc/compatibility/starter-content/theme-mods.php
@@ -218,42 +218,6 @@ return array(
 	'neve_container_width'                         => '{"mobile":748,"tablet":992,"desktop":1170}',
 	'neve_default_container_style'                 => 'contained',
 	'neve_text_color'                              => '#2b2b2b',
-	'neve_h2_typeface_general'                     =>
-	array(
-		'fontWeight'    => '600',
-		'textTransform' => 'none',
-		'letterSpacing' =>
-		array(
-			'mobile'  => 0,
-			'tablet'  => 0,
-			'desktop' => 0,
-		),
-		'lineHeight'    =>
-		array(
-			'mobile'  => '1.3',
-			'tablet'  => '1.3',
-			'desktop' => '1.3',
-			'suffix'  =>
-			array(
-				'mobile'  => 'em',
-				'tablet'  => 'em',
-				'desktop' => 'em',
-			),
-		),
-		'fontSize'      =>
-		array(
-			'mobile'  => '28',
-			'tablet'  => '34',
-			'desktop' => '46',
-			'suffix'  =>
-			array(
-				'mobile'  => 'px',
-				'tablet'  => 'px',
-				'desktop' => 'px',
-			),
-		),
-		'flag'          => false,
-	),
 	'neve_h3_typeface_general'                     =>
 	array(
 		'fontWeight'    => '600',

--- a/inc/customizer/base_customizer.php
+++ b/inc/customizer/base_customizer.php
@@ -85,6 +85,7 @@ abstract class Base_Customizer {
 	 */
 	public function init() {
 		add_action( 'customize_register', array( $this, 'register_controls_callback' ) );
+		add_action( 'customize_register', array( $this, 'after_controls_registered' ), PHP_INT_MAX );
 	}
 
 	/**
@@ -104,6 +105,11 @@ abstract class Base_Customizer {
 		$this->change_controls();
 		$this->register_partials();
 	}
+
+	/**
+	 * After all controls are registered.
+	 */
+	public function after_controls_registered() {}
 
 	/**
 	 * Function that should be extended to add customizer controls.
@@ -262,7 +268,6 @@ abstract class Base_Customizer {
 	 */
 	public function add_panel( Panel $panel ) {
 		array_push( $this->panels_to_register, $panel );
-
 	}
 
 	/**

--- a/inc/customizer/controls/separator_section.php
+++ b/inc/customizer/controls/separator_section.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Separator section.
+ *
+ * @package neve/neve-pro
+ */
+namespace Neve\Customizer\Controls;
+
+/**
+ * Customizer section.
+ */
+class Separator_Section extends \WP_Customize_Section {
+	/**
+	 * Type of this section.
+	 *
+	 * @var string
+	 */
+	public $type = 'neve_separator';
+
+	/**
+	 * Render the separator.
+	 * 
+	 * @return void
+	 */
+	public function render() {
+		$output  = '<li id="accordion-section-' . $this->id . '" class="neve-separator-section">';
+		$output .= '<hr/>';
+		$output .= '</li>';
+
+		echo wp_kses_post( $output );
+	}
+}

--- a/inc/customizer/options/buttons.php
+++ b/inc/customizer/options/buttons.php
@@ -42,6 +42,7 @@ class Buttons extends Base_Customizer {
 				array(
 					'priority' => 40,
 					'title'    => esc_html__( 'Buttons', 'neve' ),
+					'panel'    => 'neve_layout',
 				)
 			)
 		);

--- a/inc/customizer/options/colors_background.php
+++ b/inc/customizer/options/colors_background.php
@@ -44,6 +44,7 @@ class Colors_Background extends Base_Customizer {
 				array(
 					'priority' => 27,
 					'title'    => esc_html__( 'Colors & Background', 'neve' ),
+					'panel'    => 'neve_layout',
 				)
 			)
 		);

--- a/inc/customizer/options/form_fields.php
+++ b/inc/customizer/options/form_fields.php
@@ -54,6 +54,7 @@ class Form_Fields extends Base_Customizer {
 					'description_hidden' => true,
 					'description'        => __( 'Customize the general design of the form elements across the site.', 'neve' ) . ' ' . neve_external_link( 'https://docs.themeisle.com/article/1341-neve-form-fields', 'Learn More' ),
 					'title'              => esc_html__( 'Form Fields', 'neve' ),
+					'panel'              => 'neve_layout',
 				]
 			)
 		);

--- a/inc/customizer/options/main.php
+++ b/inc/customizer/options/main.php
@@ -53,7 +53,7 @@ class Main extends Base_Customizer {
 		$panels = array(
 			'neve_layout'     => array(
 				'priority' => 25,
-				'title'    => __( 'Layout', 'neve' ),
+				'title'    => __( 'Global', 'neve' ),
 			),
 			'neve_blog'       => array(
 				'priority' => 25,

--- a/inc/customizer/options/main.php
+++ b/inc/customizer/options/main.php
@@ -14,6 +14,7 @@ use Neve\Core\Settings\Mods;
 use Neve\Customizer\Controls\React\Documentation_Section;
 use Neve\Customizer\Controls\React\Instructions_Section;
 use Neve\Customizer\Base_Customizer;
+use Neve\Customizer\Controls\Separator_Section;
 use Neve\Customizer\Controls\Simple_Upsell;
 use Neve\Customizer\Types\Control;
 use Neve\Customizer\Types\Panel;
@@ -81,7 +82,7 @@ class Main extends Base_Customizer {
 				$this->wpc,
 				'neve_typography_quick_links',
 				array(
-					'priority' => - 100,
+					'priority' => -100,
 					'panel'    => 'neve_typography',
 					'type'     => 'hfg_instructions',
 					'options'  => array(
@@ -113,9 +114,19 @@ class Main extends Base_Customizer {
 				$this->wpc,
 				'neve_documentation',
 				[
-					'priority' => PHP_INT_MAX,
+					'priority' => 10000,
 					'title'    => esc_html__( 'Neve', 'neve' ),
 					'url'      => tsdk_utmify( 'https://docs.themeisle.com/article/946-neve-doc', 'docsbtn' ),
+				]
+			)
+		);
+
+		$this->wpc->add_section(
+			new Separator_Section(
+				$this->wpc,
+				'neve_separator_main_panel',
+				[
+					'priority' => 10010,
 				]
 			)
 		);
@@ -125,8 +136,30 @@ class Main extends Base_Customizer {
 	 * Change controls
 	 */
 	protected function change_controls() {
-		$this->change_customizer_object( 'section', 'static_front_page', 'panel', 'neve_layout' );
-		// Change default for shop columns WooCommerce option.
 		$this->change_customizer_object( 'setting', 'woocommerce_catalog_columns', 'default', 3 );
+	}
+
+	/**
+	 * After all controls are registered, move core root panels and sections to the end of the list.
+	 */
+	public function after_controls_registered() {
+
+		$sections = [
+			'static_front_page' => 10600,
+			'custom_css'        => 10610,
+		];
+
+		$panels = [
+			'nav_menus' => 10500,
+			'widgets'   => 10510,
+		];
+
+		foreach ( $sections as $section_id => $section_priority ) {
+			$this->change_customizer_object( 'section', $section_id, 'priority', $section_priority );
+		}
+
+		foreach ( $panels as $panel_id => $panel_priority ) {
+			$this->change_customizer_object( 'panel', $panel_id, 'priority', $panel_priority );
+		}
 	}
 }

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -89,6 +89,10 @@ class Typography extends Base_Customizer {
 	 */
 	private function sections_typography() {
 		$typography_sections = array(
+			'typography_globals_section'   => array(
+				'title'    => __( 'Global', 'neve' ),
+				'priority' => 10,
+			),
 			'typography_font_pair_section' => array(
 				'title'    => __( 'Font presets', 'neve' ),
 				'priority' => 15,

--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -387,17 +387,19 @@ class Upsells extends Base_Customizer {
 	 */
 	private function section_upsells() {
 
-		$this->add_section(
-			new Section(
-				'neve_free_pro_upsell',
-				array(
-					'priority' => -100,
-					'title'    => esc_html__( 'Neve PRO Features', 'neve' ),
-					'url'      => $this->upsell_url,
-				),
-				'Neve\Customizer\Controls\React\Upsell_Section'
-			)
-		);
+		if ( ! (bool) get_option( 'fresh_site' ) ) {
+			$this->add_section(
+				new Section(
+					'neve_free_pro_upsell',
+					array(
+						'priority' => -100,
+						'title'    => esc_html__( 'Neve PRO Features', 'neve' ),
+						'url'      => $this->upsell_url,
+					),
+					'Neve\Customizer\Controls\React\Upsell_Section'
+				)
+			);
+		}
 
 		$this->add_section(
 			new Section(


### PR DESCRIPTION
### Summary
- chore: rename Layout customizer panel to Global  
- fix: dashboard customizer section style  
- fix: dashboard responsive & skeleton loader
- chore: hide customizer promo section when starter content is displayed 
- feat: reorganize customizer panels and sections
- chore: update starter content H2 typography
- chore: compact docs and promo sections in customizer
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES (only in customizer)

### Screenshots <!-- if applicable -->

Dashboard customizer section:
![image](https://github.com/user-attachments/assets/c8ffa9c3-b784-4539-8a68-42cb273fd0f6)
Customizer panels: 
![image](https://github.com/user-attachments/assets/2edce620-9699-4601-8e16-f88e18af6ad4)


## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #2915.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
