### PR TITLE
chore: translations review

### DIFF
--- a/assets/apps/dashboard/src/Components/Common/Notification.js
+++ b/assets/apps/dashboard/src/Components/Common/Notification.js
@@ -174,8 +174,8 @@ const Notification = ({ data }) => {
 				sprintf(
 					// translators: %1$s: theme name (Neve), %2$s: plugin name (Neve Pro).
 					__('%1$s and %2$s', 'neve'),
-					__('Neve', 'neve'),
-					__('Neve Pro', 'neve')
+					'Neve',
+					'Neve Pro'
 				)
 			)}
 		>

--- a/assets/apps/dashboard/src/Components/Content/Changelog.js
+++ b/assets/apps/dashboard/src/Components/Content/Changelog.js
@@ -88,7 +88,7 @@ const ChangelogEntry = ({ data }) => {
 				<div className="flex items-center justify-between mb-4">
 					<div className="flex items-center space-x-3">
 						<h3 className="text-base font-semibold text-gray-900">
-							{__('Version', 'neve')} {version}
+							v{version}
 						</h3>
 						<Pill type="primary" className={'ml-auto'}>
 							{date}

--- a/assets/apps/dashboard/src/Components/Content/FreePro.js
+++ b/assets/apps/dashboard/src/Components/Content/FreePro.js
@@ -23,8 +23,8 @@ const FreeProCard = () => (
 				<div className="w-20 text-center text-sm font-medium">
 					{__('Free', 'neve')}
 				</div>
-				<div className="w-20 text-center text-sm font-medium">
-					{__('Pro', 'neve')}
+				<div className="w-20 text-center text-sm font-medium capitalize">
+					{__('PRO', 'neve').toLowerCase()}
 				</div>
 			</div>
 		</div>

--- a/assets/apps/dashboard/src/Components/Content/ModuleGrid.js
+++ b/assets/apps/dashboard/src/Components/Content/ModuleGrid.js
@@ -38,7 +38,7 @@ const ModuleToggle = ({ slug, moduleData }) => {
 				text={__('These features are available in Neve Pro.', 'neve')}
 			>
 				<Pill className="ml-2 !px-2 !py-1 text-xs bg-blue-100 text-blue-800 rounded">
-					{__('Pro', 'neve')}
+					{__('PRO', 'neve')}
 				</Pill>
 			</Tooltip>
 		);

--- a/assets/apps/dashboard/src/Components/Controls/ControlWrap.js
+++ b/assets/apps/dashboard/src/Components/Controls/ControlWrap.js
@@ -32,7 +32,7 @@ export default ({
 						<h3 className="text-base font-semibold">{label}</h3>
 						{locked && (
 							<Pill className="ml-2 !px-2 !py-1 text-xs bg-blue-100 text-blue-800 rounded">
-								{__('Pro', 'neve')}
+								{__('PRO', 'neve')}
 							</Pill>
 						)}
 					</div>

--- a/assets/apps/dashboard/src/Components/Header.js
+++ b/assets/apps/dashboard/src/Components/Header.js
@@ -57,7 +57,7 @@ const HeaderTopBar = ({ currentTab, setTab }) => {
 						</span>
 						<Pill type="secondary">
 							{isLicenseValid
-								? __('Pro', 'neve')
+								? __('PRO', 'neve')
 								: __('Free', 'neve')}
 						</Pill>
 						<span className="text-gray-500 font-medium">

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -71,7 +71,7 @@ class Footer extends Abstract_Builder {
 						'label'             => esc_html__( 'Change Copyright', 'neve' ),
 						'icon'              => 'dashicons-nametag',
 						'url'               => $this->has_valid_addons() ? null : $upgrade_url_copyright,
-						'badge'             => esc_html__( 'Pro', 'neve' ),
+						'badge'             => esc_html__( 'PRO', 'neve' ),
 						'upsellDescription' => sprintf(
 							/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 							__( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -521,7 +521,7 @@ class Main {
 			],
 			[
 				'text'        => __( 'Footer Options', 'neve' ),
-				'description' => __( 'Pro: Custom footer layouts', 'neve' ),
+				'description' => __( 'PRO', 'neve' ) . ': ' . __( 'Custom footer layouts', 'neve' ),
 				'link'        => add_query_arg( [ 'autofocus[panel]' => 'hfg_footer' ], admin_url( 'customize.php' ) ),
 			],
 			[
@@ -576,7 +576,7 @@ class Main {
 						'description' => __( 'Add engaging elements, protect content, and create dynamic layouts with our advanced toolkit.', 'neve' ),
 					],
 					[
-						'title'       => __( 'Otter Blocks PRO', 'neve' ),
+						'title'       => 'Otter Blocks PRO',
 						'description' => __( 'Advanced Gutenberg blocks with animations & visibility controls.', 'neve' ),
 					],
 				],
@@ -725,7 +725,7 @@ class Main {
 	private function get_recommended_plugins() {
 		$plugins = [
 			'otter-blocks'                  => [
-				'title'       => __( 'Otter Blocks', 'neve' ),
+				'title'       => 'Otter Blocks',
 				'description' => __( 'Advanced blocks for modern WordPress editing', 'neve' ),
 			],
 			'templates-patterns-collection' => [
@@ -733,27 +733,27 @@ class Main {
 				'description' => __( 'Import ready-made websites with a single click', 'neve' ),
 			],
 			'wp-full-stripe-free'           => [
-				'title'       => __( 'WP Full Pay', 'neve' ),
+				'title'       => 'WP Full Pay',
 				'description' => __( 'Simple ecommerce solution with Stripe integration', 'neve' ),
 			],
 			'optimole-wp'                   => [
-				'title'       => __( 'Optimole', 'neve' ),
+				'title'       => 'Optimole',
 				'description' => __( 'Smart image optimization and CDN', 'neve' ),
 			],
 			'wp-cloudflare-page-cache'      => [
-				'title'       => __( 'Super Page Cache', 'neve' ),
+				'title'       => 'Super Page Cache',
 				'description' => __( 'Lightning-fast caching made simple', 'neve' ),
 				'hide'        => defined( 'SPC_PRO_PATH' ),
 			],
 			'feedzy-rss-feeds'              => [
-				'title'       => __( 'Feedzy', 'neve' ),
+				'title'       => 'Feedzy',
 				'description' => __( 'RSS feeds aggregator and content curator', 'neve' ),
 			],
 		];
 
 		if ( is_php_version_compatible( '8.1' ) ) {
 			$plugins['hyve-lite'] = [
-				'title'       => __( 'Hyve', 'neve' ),
+				'title'       => 'Hyve',
 				'description' => __( 'AI chatbot for your website', 'neve' ),
 			];
 		}
@@ -1064,7 +1064,7 @@ class Main {
 				</a>
 
 				<span class="nv-admin-title"><?php esc_html_e( 'Neve', 'neve' ); ?></span>
-				<span class="nv-admin-badge"><?php echo $is_using_pro ? esc_html__( 'Pro', 'neve' ) : esc_html__( 'Free', 'neve' ); ?></span>
+				<span class="nv-admin-badge"><?php echo $is_using_pro ? esc_html__( 'PRO', 'neve' ) : esc_html__( 'Free', 'neve' ); ?></span>
 
 				<span class="nv-admin-version"><?php echo esc_html( sprintf( 'v%s', NEVE_VERSION ) ); ?></span>
 			</div>

--- a/inc/admin/hooks_upsells.php
+++ b/inc/admin/hooks_upsells.php
@@ -449,13 +449,10 @@ class Hooks_Upsells {
 
 				<div class="cl-quote">
 					<?php
-					echo esc_html__(
-						'I’ve been using Neve by Themeisle for a few years now, and it’s proven to be the best theme I’ve ever built websites on. It’s lightweight, modern, fast, customizable, and works great with Woocommerce stores too.',
-						'neve'
-					);
+					echo esc_html( 'I’ve been using Neve by Themeisle for a few years now, and it’s proven to be the best theme I’ve ever built websites on. It’s lightweight, modern, fast, customizable, and works great with Woocommerce stores too.' );
 					?>
 					<span class="cl-quote-author">
-						— <?php echo esc_html__( 'Ville Ekman', 'neve' ); ?>
+						— <?php echo esc_html( 'Ville Ekman' ); ?>
 					</span>
 				</div>
 			</div>


### PR DESCRIPTION
### Summary
Reviews some translations changes done during the 4.0.0 review.

- Ensures that when using `Pro` we use `PRO` as this was available previously and already translated;
- Removes translations from Plugin / Theme name i.e. `Neve` | `Neve Pro`;
- Removes `Version` in the Changelog dashboard tab (using just `v` instead);
- Removes translation for the testimonial itself and the author name in the Custom Layouts page;
- Removes translations for all the plugins names in the Recommended plugins section;

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES (only on the backend)

## Check before Pull Request is ready:

* ~[] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR~
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2979
<!-- Should look like this: `Closes #1, #2, #3.` . -->
