### PR TITLE
[Fix] Pagination number input too wide

### DIFF
--- a/assets/scss/components/elements/blog/_pagination.scss
+++ b/assets/scss/components/elements/blog/_pagination.scss
@@ -1,36 +1,36 @@
 ul.page-numbers {
 	display: flex;
 	flex-wrap: wrap;
+	gap: $spacing-md;
+}
 
-	li {
-		margin-bottom: $spacing-sm;
-	}
+.page-numbers {
 
-	input[type="submit"] {
+	[type="submit"] {
 		all: unset;
 		cursor: pointer;
 	}
 
 	form {
 		display: flex;
+		gap: $spacing-xs;
 	}
 
 	.page-input {
 		line-height: 1;
-		margin-right: $spacing-xs;
 		padding: 8px 15px;
 		font-size: var(--bodyfontsize);
+		width: 75px;
 	}
 
 	a,
 	span,
 	input[type="submit"] {
 		line-height: 1;
-		margin-right: $spacing-md;
 		background: var(--nv-light-bg);
 		border-radius: 3px;
 		padding: 12px 15px;
-		color: var(--nv-text-color);
+		color: inherit;
 		display: block;
 	}
 


### PR DESCRIPTION
### Summary
Restricts width of pagination input to 75px.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the blog has at least a few pages so you can check this fix;
- Set **Post Pagination** to **Number & Search Field**;
- The input should be restricted to a reasonable width;

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2698.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
