### PR TITLE
[Fix] Quote block style consistency between editor & frontend

### DIFF
--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -97,17 +97,38 @@ ol {
 
 // === Quotes === //
 .wp-block-quote {
+	margin-top: $spacing-xl;
+	margin-bottom: $spacing-xl;
+	border: solid var(--nv-text-color);
+	border-width: 0 0 0 4px;
+	padding: 0 0 0 $spacing-md;
 
-	.wp-block-quote__citation {
-		font-size: $text-sm;
+
+	p {
+		margin-bottom: $spacing-xs;
+		font-size: $text-lg;
+		font-style: italic;
 	}
 
-	&.is-style-large {
+	.wp-block-quote__citation {
+		font-style: normal;
+		font-size: $text-sm !important;
+		font-weight: 600;
+	}
 
-		p {
-			font-size: $text-lg;
-			font-style: normal;
-		}
+	&.has-text-align-center {
+		border: 0;
+		padding: 0;
+	}
+
+	&.has-text-align-right {
+		border-width: 0 4px 0 0;
+		padding: 0 $spacing-md 0 0;
+	}
+
+	&.is-style-plain {
+		border: 0;
+		padding: 0;
 	}
 }
 
@@ -115,17 +136,23 @@ ol {
 .wp-block-pullquote {
 	margin-top: $spacing-lg;
 	margin-bottom: $spacing-lg;
-	border-top: 4px solid var(--nv-text-color);
-	border-bottom: 4px solid var(--nv-text-color);
+	border: solid var(--nv-text-color);
+	border-width: 4px 0;
 	padding: $spacing-lg $spacing-md;
 
 	p {
 		font-size: $text-xl !important;
 	}
 
-	&__citation {
-		font-size: $text-sm;
-		text-transform: none;
+	blockquote {
+		padding: 0;
+		border: 0;
+	}
+
+	cite {
+		font-style: normal;
+		font-size: $text-sm !important;
+		font-weight: 600;
 	}
 
 	&.is-style-solid-color {

--- a/assets/scss/components/main/_gutenberg.scss
+++ b/assets/scss/components/main/_gutenberg.scss
@@ -59,18 +59,20 @@
 // === Quotes === //
 blockquote {
 	margin: $spacing-xl 0;
-	border-color: var(--nv-text-color);
-	border-style: solid;
+	border: solid var(--nv-text-color);
 	border-width: 0 0 0 4px;
 	padding: 0 0 0 $spacing-md;
 
 	p {
 		margin-bottom: $spacing-xs;
+		font-size: $text-lg;
+		font-style: italic;
 	}
 
 	cite {
 		font-style: normal;
 		font-size: $text-sm !important;
+		font-weight: 600;
 	}
 
 	&.has-text-align-center {
@@ -83,24 +85,17 @@ blockquote {
 		padding: 0 $spacing-md 0 0;
 	}
 
-	&.is-style-large {
+	&.is-style-plain {
 		border: 0;
 		padding: 0;
-
-		&.wp-block-quote > p {
-			margin-bottom: $spacing-md;
-			font-style: normal;
-			font-size: $text-lg;
-		}
 	}
 }
 
 // === Pull Quotes === //
 .wp-block-pullquote {
-	margin-top: $spacing-lg;
-	margin-bottom: $spacing-lg;
-	border-top: $base-border-strong;
-	border-bottom: $base-border-strong;
+	margin: $spacing-lg 0;
+	border: solid var(--nv-text-color);
+	border-width: 4px 0;
 	padding: $spacing-lg $spacing-md;
 
 	p {
@@ -108,9 +103,8 @@ blockquote {
 	}
 
 	blockquote {
-		padding-left: 0;
-		border-left: 0;
-		margin: 0;
+		padding: 0;
+		border: 0;
 	}
 
 	&.alignleft {


### PR DESCRIPTION
### Summary
- Updates styles for quote block according to Codeinwp/neve-pro-addon#2945.
- Make sure that quote block styling is consistend between frontend and the editor.
- Removes deprecated block styles for the quote block - i.e. `Large` style which has been removed (it will fallback on the default quote block style).
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
<details>
<summary>Editor</summary>

![image](https://github.com/user-attachments/assets/6e578076-6040-493b-9256-1417e0be862c)

</details>

<details>
<summary>Frontend</summary>

![image](https://github.com/user-attachments/assets/0bb05d20-a247-4d07-9234-442e1e0287fd)

</details>

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Add quote blocks in a page/post
- Styling should be consistent between frontend and editor

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2945.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
