### PR TITLE
[Fix] nav caret icon size not working on mobile/tablet

### DIFF
--- a/assets/scss/components/elements/navigation/_nav-menu.scss
+++ b/assets/scss/components/elements/navigation/_nav-menu.scss
@@ -136,8 +136,8 @@
 		}
 
 		.caret svg {
-			width: 1em;
-			height: 1em;
+			width: var(--smiconsize, 1em);
+			height: var(--smiconsize, 1em);
 		}
 
 		.caret-wrap {


### PR DESCRIPTION
### Summary
Fixes issue with dropdown caret icon size setting from Neve Pro not working in the sidebar menu.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this version (without pro);
- The caret icon for doropdowns should work just as before for the free version;
- Install and activate the Pro version;
- The icon size control should work for the menus in the mobile sidebar;

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2483.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
