### PR TITLE
[Fix] Adds shortcut to clarify header background controls

### DIFF
--- a/assets/customizer/css/tabs.css
+++ b/assets/customizer/css/tabs.css
@@ -62,7 +62,8 @@
 
 .tab-hidden {
 	visibility: hidden !important;
-	height: 0 !important;
 	overflow: hidden !important;
+	height: 0 !important;
 	margin: 0 !important;
+	padding: 0 !important;
 }

--- a/assets/customizer/css/tabs.css
+++ b/assets/customizer/css/tabs.css
@@ -61,5 +61,8 @@
 }
 
 .tab-hidden {
-	display: none !important;
+	visibility: hidden !important;
+	height: 0 !important;
+	overflow: hidden !important;
+	margin: 0 !important;
 }

--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -532,6 +532,32 @@ abstract class Abstract_Builder implements Builder {
 			]
 		);
 
+		if ( $this->get_id() === 'header' && $row_id !== 'sidebar' ) {
+			SettingsManager::get_instance()->add(
+				[
+					'id'                => 'global_header_background_shortcut',
+					'group'             => $row_setting_id,
+					'section'           => $row_setting_id,
+					'tab'               => 'style',
+					'transport'         => 'postMessage',
+					'sanitize_callback' => 'esc_attr',
+					'type'              => '\Neve\Customizer\Controls\Button',
+					'options'           => [
+						'button_text'      => esc_html__( 'Background', 'neve' ),
+						'active_callback'  => function() {
+							return ! get_theme_mod( 'neve_pro_global_header_settings_advanced_style', true );
+						},
+						'button_class'     => 'button_background',
+						'icon_class'       => 'edit',
+						'shortcut'         => true,
+						'is_button'        => false,
+						'control_to_focus' => 'neve_pro_global_header_settings_background',
+					],
+				]
+			);
+		}
+
+
 		do_action( 'hfg_row_settings', $this->get_id(), $row_id, $row_setting_id );
 	}
 


### PR DESCRIPTION
### Summary
Adds shortcut pointing to the Global Header Background in all header rows when advanced settings are turned off
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/1ed153c6-8101-42cc-8d58-914f6ab09e5a)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to **Customizer > Header > Global Header Settings**;
- Disable the `Enable Advanced Options` setting;
- The Header Background control should appear in the section;
- If you now go to any of the Header Builder rows, under the **Style** tab, the Background control should be hidden;
- A shortcut to the Background control in the **Global Header Settings** section should be visible;

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2858.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
