### PR TITLE
[Fix] License card UI & adds action before theme modules loading

### DIFF
--- a/assets/apps/dashboard/src/Components/Content/Sidebar/LicenseCard.js
+++ b/assets/apps/dashboard/src/Components/Content/Sidebar/LicenseCard.js
@@ -17,9 +17,9 @@ const LicenseCard = () => {
 
 	const { changeLicense, setSettings } = useDispatch(NEVE_STORE);
 
-	const { license, isLicenseValid } = useLicenseData();
+	const { license } = useLicenseData();
 
-	const [key, setKey] = useState(isLicenseValid ? license.key || '' : '');
+	const [key, setKey] = useState(license.key || '');
 	const [status, setStatus] = useState(false);
 
 	const [toast, setToast] = useState('');
@@ -52,6 +52,8 @@ const LicenseCard = () => {
 		return null;
 	}
 
+	const isOrWasValid = ['valid', 'active_expired', 'expired'].includes(valid);
+
 	const getStatusLabel = () => {
 		const statusLabelMap = {
 			activating: __('Activating', 'neve'),
@@ -61,7 +63,7 @@ const LicenseCard = () => {
 		};
 
 		if (!status) {
-			return 'valid' === valid
+			return isOrWasValid
 				? __('Deactivate', 'neve')
 				: __('Activate', 'neve');
 		}
@@ -92,13 +94,13 @@ const LicenseCard = () => {
 						id="license-field"
 						name="license-field"
 						className="flex-grow rounded !border-gray-300 text-sm !py-1 !px-2"
-						disabled={'valid' === valid}
+						disabled={isOrWasValid}
 						onChange={(e) => {
 							const keyToSet = e.target.value.replace(/\s+/g, '');
 							setKey(keyToSet);
 						}}
 						value={
-							'valid' === valid
+							isOrWasValid
 								? '******************************' +
 								  key.slice(-5)
 								: key
@@ -121,42 +123,41 @@ const LicenseCard = () => {
 						message={toast}
 					/>
 				)}
-				{'expired' === valid ||
-					('valid' === valid && (
-						<div className="flex items-center gap-1">
-							<Pill
-								type={valid === 'valid' ? 'success' : 'warning'}
-								className="inline-flex items-center gap-1 px-2 py-1"
-							>
-								{valid === 'valid' ? (
-									<>
-										<LucideCircleCheck size={14} />
-										<span>{__('Valid', 'neve')}</span>
-									</>
-								) : (
-									<>
-										<LucideCircleX size={14} />
-										<span>{__('Expired', 'neve')}</span>
-									</>
-								)}
-							</Pill>
-							{expiration && (
+				{isOrWasValid && (
+					<div className="flex items-center gap-1">
+						<Pill
+							type={valid === 'valid' ? 'success' : 'warning'}
+							className="inline-flex items-center gap-1 px-2 py-1"
+						>
+							{valid === 'valid' ? (
 								<>
-									<span className="space-x-1 ml-auto">
-										<span className="text-xs">
-											{'valid' === valid
-												? __('Expires', 'neve')
-												: __('Expired', 'neve')}
-										</span>
-
-										<span className="font-semibold text-xs">
-											{expiration}
-										</span>
-									</span>
+									<LucideCircleCheck size={14} />
+									<span>{__('Valid', 'neve')}</span>
+								</>
+							) : (
+								<>
+									<LucideCircleX size={14} />
+									<span>{__('Expired', 'neve')}</span>
 								</>
 							)}
-						</div>
-					))}
+						</Pill>
+						{expiration && (
+							<>
+								<span className="space-x-1 ml-auto">
+									<span className="text-xs">
+										{'valid' === valid
+											? __('Expires', 'neve')
+											: __('Expired', 'neve')}
+									</span>
+
+									<span className="font-semibold text-xs">
+										{expiration}
+									</span>
+								</span>
+							</>
+						)}
+					</div>
+				)}
 			</div>
 		</Card>
 	);

--- a/assets/apps/dashboard/src/utils/module-observer.js
+++ b/assets/apps/dashboard/src/utils/module-observer.js
@@ -43,8 +43,10 @@ function autoHideModuleSubMenuPages() {
 		 */
 		const isModuleEnabled =
 			select('neve-dashboard').getModuleStatus('custom_layouts');
+		const isValid =
+			select('neve-dashboard').getLicense()?.valid === 'valid';
 
-		if (isModuleEnabled && !clLinkElem) {
+		if (isModuleEnabled && isValid && !clLinkElem) {
 			clLinkElem = appendNewSubMenuPage(
 				'.toplevel_page_neve-welcome .wp-submenu a[href*="customize.php"]',
 				window?.neveDash?.moduleObserver?.customLayouts

--- a/inc/core/core_loader.php
+++ b/inc/core/core_loader.php
@@ -145,6 +145,8 @@ class Core_Loader {
 	 * @access  private
 	 */
 	private function load_modules() {
+		do_action( 'neve_before_modules_load' );
+
 		$factory = new Factory( $this->features );
 		$factory->load_modules();
 	}


### PR DESCRIPTION
### Summary
Fixes license card state for `active_expired` status - previously it wasn't showing the state at all;
Adds new hook before theme modules loading: `neve_before_modules_load`;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/9aeb935b-4979-4afc-8da9-790f6d78a3f2)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Use Neve Pro with this PR.
- Refer to this comment https://github.com/Codeinwp/neve-pro-addon/issues/2994#issuecomment-2865898694.
- Switch license states, the UI should update properly for `active_expired`.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Supporting PR for Codeinwp/neve-pro-addon#2994.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
