### PR TITLE
[Feat] Adds image size options to single post thumbnail

### DIFF
--- a/inc/core/styles/frontend.php
+++ b/inc/core/styles/frontend.php
@@ -818,6 +818,19 @@ class Frontend extends Generator {
 			'selectors' => '.nv-single-post-wrap',
 			'rules'     => $spacing_rules,
 		];
+		
+		$this->_subscribers['.nv-thumb-wrap img'] = [
+			'aspect-ratio' => [
+				'key'     => 'neve_post_thumbnail_aspect_ratio',
+				'default' => 'original',
+				'filter'  => function ( $css_prop, $value, $meta, $device ) {
+					if ( $value === 'original' ) {
+						return '';
+					}
+					return sprintf( '%s: %s; object-fit: cover;', $css_prop, str_replace( '-', '/', $value ) );
+				},
+			],
+		];
 	}
 
 	/**

--- a/inc/views/post_layout.php
+++ b/inc/views/post_layout.php
@@ -104,7 +104,7 @@ class Post_Layout extends Base_View {
 					echo '<div class="nv-thumb-wrap">';
 					echo get_the_post_thumbnail(
 						null,
-						'neve-blog',
+						get_theme_mod( 'neve_post_thumbnail_size', 'neve-blog' ),
 						array( 'class' => $skip_lazy_class )
 					);
 					echo '</div>';


### PR DESCRIPTION
### Summary
Adds new settings for the single post thumbnail when using the `Normal` header layout option.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/0380e16d-b154-4911-b952-be0152293e2c)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Check the **Blog > Single Post** panel;
- Under the elements ordering, inside the thumbnail panel there should be two select settings;
- The settings should work as expected;
- The settings should only be available when using the "Normal" header layout;
- When switching from the old version to this one, the settings should not affect the frontend;

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2934.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
