### PR TITLE
[Feat] Adds color setting for headings

### DIFF
--- a/assets/apps/customizer-controls/src/color/ColorComponent.js
+++ b/assets/apps/customizer-controls/src/color/ColorComponent.js
@@ -4,7 +4,7 @@ import { ColorControl } from '@neve-wp/components';
 
 import { useState, useEffect } from '@wordpress/element';
 
-const ColorComponent = ({ control, children }) => {
+const ColorComponent = ({ control, children, isCompound = false }) => {
 	const [value, setValue] = useState(control.setting.get());
 
 	const updateValues = (newVal) => {
@@ -20,8 +20,13 @@ const ColorComponent = ({ control, children }) => {
 		});
 	}, []);
 
+	const wrapClasses = [
+		isCompound ? '' : 'neve-white-background-control',
+		'neve-color-control',
+	];
+
 	return (
-		<div className="neve-white-background-control neve-color-control">
+		<div className={wrapClasses.join(' ')}>
 			<ColorControl
 				label={control.params.label}
 				selectedColor={value}

--- a/assets/apps/customizer-controls/src/font-family/FontFamilyComponent.js
+++ b/assets/apps/customizer-controls/src/font-family/FontFamilyComponent.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { lazy, Suspense, useEffect, useState } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { VariantSelector } from './VariantSelector';
+import ColorComponent from '../color/ColorComponent';
 
 const FontFamilySelector = lazy(() => import('./FontFamilySelector'));
 
@@ -100,6 +101,10 @@ const TypefaceComponent = ({ control }) => {
 		}
 	};
 
+	const hasColorControl =
+		!!control.params.color_setting &&
+		wp.customize.control(control.params.color_setting);
+
 	return (
 		<>
 			{control.params.label && (
@@ -122,7 +127,16 @@ const TypefaceComponent = ({ control }) => {
 								}
 								systemFonts={controlParams.system}
 								maybeGetTypekit={maybeGetTypekitFont}
-							/>
+							>
+								{hasColorControl && (
+									<ColorComponent
+										isCompound
+										control={wp.customize.control(
+											control.params.color_setting
+										)}
+									/>
+								)}
+							</FontFamilySelector>
 							{variants && (
 								<VariantSelector
 									setting={variants}

--- a/assets/apps/customizer-controls/src/font-family/FontFamilySelector.js
+++ b/assets/apps/customizer-controls/src/font-family/FontFamilySelector.js
@@ -14,6 +14,7 @@ const FontFamilySelector = ({
 	inheritDefault,
 	maybeGetTypekit,
 	systemFonts,
+	children,
 }) => {
 	const [visible, setVisible] = useState(false);
 	const [search, setSearch] = useState('');
@@ -169,40 +170,47 @@ const FontFamilySelector = ({
 			<span className="customize-control-title">
 				{__('Font Family', 'neve')}
 			</span>
-			<Button
-				className="font-family-selector-toggle"
-				isSecondary
-				onClick={() => {
-					setVisible(true);
-				}}
-			>
-				<span className="ff-name">
-					{selected ||
-						(inheritDefault
-							? __('Inherit', 'neve')
-							: __('Default', 'neve'))}
-				</span>
-				<span
-					className="ff-preview"
-					style={{
-						fontFamily: font || defaultFontface,
+			<div className="font-family-selector-content-wrap">
+				<Button
+					className="font-family-selector-toggle"
+					isSecondary
+					onClick={() => {
+						setVisible(true);
 					}}
 				>
-					Abc
-				</span>
-				{visible && (
-					<Popover
-						position="bottom left"
-						onFocusOutside={() => {
-							setVisible(false);
-							setSearch('');
+					<span className="ff-name">
+						{selected ||
+							(inheritDefault
+								? __('Inherit', 'neve')
+								: __('Default', 'neve'))}
+					</span>
+					<span
+						className="ff-preview"
+						style={{
+							fontFamily: font || defaultFontface,
 						}}
-						inline={true}
 					>
-						{fonts ? getFontList() : __('In Progress', 'neve')}
-					</Popover>
+						Abc
+					</span>
+					{visible && (
+						<Popover
+							position="bottom left"
+							className="neve-font-family-selector-popover"
+							onFocusOutside={() => {
+								setVisible(false);
+								setSearch('');
+							}}
+						>
+							{fonts ? getFontList() : __('In Progress', 'neve')}
+						</Popover>
+					)}
+				</Button>
+				{children && (
+					<div className="font-family-selector-children">
+						{children}
+					</div>
 				)}
-			</Button>
+			</div>
 		</div>
 	);
 };

--- a/assets/apps/customizer-controls/src/scss/_typeface.scss
+++ b/assets/apps/customizer-controls/src/scss/_typeface.scss
@@ -1,4 +1,4 @@
-.neve-font-family-control {
+.neve-font-family-control, .neve-font-family-selector-popover {
 
 	.font-family-selector-toggle {
 		width: 100%;
@@ -87,6 +87,8 @@
 
 		.load-more {
 			padding: 10px 0;
+			display: flex;
+			justify-content: center;
 
 			svg {
 				fill: #0073aa;
@@ -147,5 +149,15 @@
 				}
 			}
 		}
+	}
+
+	.font-family-selector-content-wrap {
+		display: flex;
+		gap: 10px;
+		align-items: center;
+	}
+
+	.neve-control-header {
+		margin: 0;
 	}
 }

--- a/assets/scss/components/compat/woocommerce/single/_reviews.scss
+++ b/assets/scss/components/compat/woocommerce/single/_reviews.scss
@@ -54,6 +54,7 @@
 		line-height: var(--h2lineheight);
 		letter-spacing: var(--h2letterspacing);
 		text-transform: var(--h2texttransform);
+		color: var(--headingcolor, var(--nv-text-color));
 		margin-bottom: $spacing-lg;
 		display: block;
 	}

--- a/assets/scss/components/editor/_typography.scss
+++ b/assets/scss/components/editor/_typography.scss
@@ -56,6 +56,7 @@ h6 {
 	&.wp-block,
 	& {
 		font-family: var(--headingsfontfamily, var(--bodyfontfamily));
+		color: var(--headingcolor, var(--nv-text-color));
 	}
 }
 

--- a/assets/scss/components/elements/navigation/_nav-brand.scss
+++ b/assets/scss/components/elements/navigation/_nav-brand.scss
@@ -31,6 +31,7 @@
 		line-height: var(--bodylineheight);
 		letter-spacing: var(--bodyletterspacing);
 		text-transform: var(--texttransform, var(--bodytexttransform));
+		color: inherit;
 		margin: 0;
 	}
 

--- a/assets/scss/components/main/_typography.scss
+++ b/assets/scss/components/main/_typography.scss
@@ -27,6 +27,7 @@ h5,
 h6 {
 	margin-bottom: $spacing-lg;
 	font-family: var(--headingsfontfamily), var(--nv-fallback-ff);
+	color: var(--headingcolor, var(--nv-text-color));
 }
 
 p {

--- a/inc/core/settings/config.php
+++ b/inc/core/settings/config.php
@@ -56,6 +56,7 @@ class Config {
 	const MODS_FONT_GENERAL                = 'neve_body_font_family';
 	const MODS_FONT_GENERAL_VARIANTS       = 'neve_body_font_family_variants';
 	const MODS_FONT_HEADINGS               = 'neve_headings_font_family';
+	const MODS_COLOR_HEADINGS              = 'neve_headings_color';
 	const MODS_DEFAULT_CONTAINER_STYLE     = 'neve_default_container_style';
 	const MODS_SINGLE_POST_CONTAINER_STYLE = 'neve_single_post_container_style';
 

--- a/inc/core/styles/css_vars.php
+++ b/inc/core/styles/css_vars.php
@@ -282,6 +282,9 @@ trait Css_Vars {
 			'--headingsfontfamily' => [
 				Dynamic_Selector::META_KEY => Config::MODS_FONT_HEADINGS,
 			],
+			'--headingcolor' => [
+				Dynamic_Selector::META_KEY => Config::MODS_COLOR_HEADINGS,
+			]
 		];
 		foreach ( neve_get_headings_selectors() as $id => $heading_selector ) {
 

--- a/inc/customizer/controls/react/font_family.php
+++ b/inc/customizer/controls/react/font_family.php
@@ -19,6 +19,14 @@ class Font_Family extends \WP_Customize_Control {
 	 * @var string
 	 */
 	public $type = 'neve_font_family_control';
+
+	/**
+	 * The theme mod to be used for color.
+	 * 
+	 * @var string
+	 */
+	public $color_setting = '';
+
 	/**
 	 * Additional arguments passed to JS.
 	 *
@@ -29,8 +37,9 @@ class Font_Family extends \WP_Customize_Control {
 	 * Send to JS.
 	 */
 	public function json() {
-		$json                = parent::json();
-		$json['input_attrs'] = $this->input_attrs;
+		$json                  = parent::json();
+		$json['input_attrs']   = $this->input_attrs;
+		$json['color_setting'] = $this->color_setting;
 		return $json;
 	}
 

--- a/inc/customizer/options/typography.php
+++ b/inc/customizer/options/typography.php
@@ -292,10 +292,35 @@ class Typography extends Base_Customizer {
 					'input_attrs'           => [
 						'default_is_inherit' => true,
 					],
+					'color_setting'         => Config::MODS_COLOR_HEADINGS,
 				),
 				'\Neve\Customizer\Controls\React\Font_Family'
 			)
 		);
+
+		$this->add_control(
+			new Control(
+				Config::MODS_COLOR_HEADINGS,
+				array(
+					'transport'         => $this->selective_refresh,
+					'sanitize_callback' => 'neve_sanitize_colors',
+					'default'           => 'var(--nv-text-color)',
+				),
+				array(
+					'section'               => 'neve_typography_headings',
+					'type'                  => 'hidden',
+					'live_refresh_selector' => true,
+					'live_refresh_css_prop' => [
+						'cssVar' => [
+							'vars'     => '--headingcolor',
+							'selector' => 'body',
+						],
+					],
+				)
+			)
+		);
+
+		
 
 		$selectors = neve_get_headings_selectors();
 		$priority  = 20;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
 			"gzip": false,
 			"running": false,
 			"webpack": false,
-			"limit": "38.90 KB",
+			"limit": "39 KB",
 			"path": "style-main-new.min.css"
 		}
 	],


### PR DESCRIPTION
### Summary
Adds color control for the headings color in Typography > Headings;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/5c300e6a-5adc-42f1-b0ce-32f5af8ba2d0)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Go to the Headings panel under Typography;
- The color control should be visible next to the font family selector;
- The control should change headings color;

> [!IMPORTANT]
> It will not affect the blog post card title as this has its own color control on the card color control.
> To keep this consistent I didn't affect product titles on the Shop either.

To be discussed in the future if we need to add a separate control for it inheriting this one. 

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2936.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
