### PR TITLE
[Fix] current_single_content magic tag was over-escaped

### DIFF
--- a/header-footer-grid/Core/Magic_Tags.php
+++ b/header-footer-grid/Core/Magic_Tags.php
@@ -126,6 +126,10 @@ class Magic_Tags {
 			return '';
 		}
 
+		if ( $tag === 'current_single_content' ) {
+			return wp_kses_post( call_user_func( [ $this, $tag ] ) );
+		}
+
 		$allowed_tags = wp_kses_allowed_html();
 		if ( $tag === 'current_post_meta' || $tag === 'meta_date' ) {
 			$allowed_tags['span'] = [


### PR DESCRIPTION
### Summary
Fixes issue with `{current_single_content}` magic tag that was over-escaped, not allowing post HTML.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Please refer to the[ initial issue](https://github.com/Codeinwp/neve-pro-addon/issues/2992) for testing steps as they are defined perfectly well there as well.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2992.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
