### PR TITLE
[Chore] Supporting changes for component styles

### DIFF
--- a/header-footer-grid/Core/Components/Abstract_Component.php
+++ b/header-footer-grid/Core/Components/Abstract_Component.php
@@ -745,6 +745,8 @@ abstract class Abstract_Component implements Component {
 			Dynamic_Selector::KEY_RULES    => $rules,
 		];
 
+		$css_array = apply_filters( 'neve_hfg_component_style', $css_array, $this->get_id() );
+
 		return $css_array;
 	}
 

--- a/header-footer-grid/Main.php
+++ b/header-footer-grid/Main.php
@@ -211,9 +211,6 @@ class Main {
 	 * @access  public
 	 */
 	public function inline_styles( $subscribers ) {
-		if ( is_customize_preview() ) {
-			return $subscribers;
-		}
 		$css_array = [];
 		/**
 		 * An instance of Abstract_Builder.

--- a/start.php
+++ b/start.php
@@ -38,6 +38,7 @@ function neve_run() {
 			'menu_icon_svg'             => true,
 			'custom_payment_icons'      => true,
 			'nested_ordering_control'   => true,
+			'component_style_filter'    => true, // @see Abstract_Component->add_style() method.
 		]
 	);
 	$vendor_file = trailingslashit( get_template_directory() ) . 'vendor/autoload.php';


### PR DESCRIPTION
### Summary
Supporting changes for https://github.com/Codeinwp/neve-pro-addon/pull/3019.

Also fixes a bug where some font families were not properly added in the customizer preview. 

You can see the bug if you change the submenu font family and use a setting that does a customizer refresh, or run this code in the browser console: 

`window.top.wp.customize.previewer.refresh();`

The font family will be broken for the submenu items.

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

- This pull request should break nothing by itself; 
- It contains supporting changes for https://github.com/Codeinwp/neve-pro-addon/pull/3019

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Ref: Codeinwp/neve-pro-addon#2937.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
