### PR TITLE
[Fix] Various fixes

### DIFF
--- a/header-footer-grid/Core/Settings/Manager.php
+++ b/header-footer-grid/Core/Settings/Manager.php
@@ -104,12 +104,12 @@ class Manager {
 	/**
 	 * Load settings/control group in customizer.
 	 *
-	 * @param string|null                $group Group to load.
-	 * @param \WP_Customize_Manager|null $customize_manager Manager object.
+	 * @param string|null           $group Group to load.
+	 * @param \WP_Customize_Manager $customize_manager Manager object.
 	 *
 	 * @return \WP_Customize_Manager Customizer object.
 	 */
-	public function load( $group = null, \WP_Customize_Manager $customize_manager = null ) {
+	public function load( $group = null, \WP_Customize_Manager $customize_manager ) {
 		static $core_transports = [
 			'refresh'     => true,
 			'postMessage' => true,

--- a/inc/admin/hooks_upsells.php
+++ b/inc/admin/hooks_upsells.php
@@ -245,7 +245,7 @@ class Hooks_Upsells {
 
 			/* ----- OVERLAY ----- */
 			.cl-overlay {
-				position: absolute;
+				position: fixed;
 				top: 0;
 				left: 0;
 				width: 100%;

--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -210,6 +210,31 @@ class Elementor extends Page_Builder_Base {
 			return;
 		}
 
+		// Latest Elementor versions changed how they treat the theme locations.
+		// We need to rebuild the markup so we don't break the layout.
+		// @since 4.1
+		if ( ! $this->is_elementor_editor() ) {
+				add_action(
+					'elementor/theme/after_do_header',
+					function () {
+						do_action( 'neve_before_primary' );
+						echo '<main id="content" class="neve-main">';
+						do_action( 'neve_after_primary_start' );
+					},
+					PHP_INT_MAX
+				);
+			
+				add_action(
+					'elementor/theme/before_do_footer',
+					function () {
+						do_action( 'neve_before_primary_end' );
+						echo '</main><!--/.neve-main-->';
+						do_action( 'neve_after_primary' );
+					},
+					PHP_INT_MIN
+				);
+		}
+
 		// Override theme templates.
 		add_action( 'neve_do_top_bar', array( $this, 'do_header' ), 0 );
 		add_action( 'neve_do_header', array( $this, 'do_header' ), 0 );
@@ -539,5 +564,20 @@ class Elementor extends Page_Builder_Base {
 		$elementor_overrides = self::is_elementor_template( $elementor_template_type );
 
 		return ! $elementor_overrides;
+	}
+
+	/**
+	 * Check if Elementor Editor.
+	 *
+	 * @since  4.1
+	 *
+	 * @return bool
+	 */
+	private function is_elementor_editor() {
+		if ( ( isset( $_REQUEST['action'] ) && 'elementor' === $_REQUEST['action'] ) || isset( $_REQUEST['elementor-preview'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return true;
+		}
+
+		return false;
 	}
 }


### PR DESCRIPTION
### Summary
1. Fixes issue with Elementor Pro Header & Footer builder breaking theme markup - closes #4349 
2. Fixes deprecation notice on nullable parameter - closes #4393;
3. Fixes issue with custom layouts notice going off-screen - closes #4391;

<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

### 1. https://github.com/Codeinwp/neve/issues/4349
- Install Elementor, Elementor Pro & Woocommerce;
- Make sure you have a basic shop set up;
- Go to **Templates > Theme Builder**;
- Create a Header (maybe test with footer as well) - you can set it to display sitewide, or any other way to accomodate testing;
- Layout on Shop should work as expected;
- Layout on Blog Archive when using a sidebar;

### 2. https://github.com/Codeinwp/neve/issues/4393
- Use an instance with PHP v8.4 and WP_DEBUG enabled;
- No notice should be displayed;
- Customizer should work fine - especially the Header/Footer builder components settings (you can check 1-2 components);

### 3. https://github.com/Codeinwp/neve/issues/4349
- Install this plugin and activate it: [loads-of-menu-pages.zip](https://github.com/user-attachments/files/20217047/loads-of-menu-pages.zip)
- Go into the **Dashboard > Loads of Menu Pages** page - here you can set up to 100 dummy dashboard pages;
- Set an arbitrary number (enough to be able to scroll the dashboard);
- Go to the custom layouts page (the one with the upsell);
- The modal should stay into view when scrolling


## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [X] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #4349.
Closes #4393;
Closes #4391;
<!-- Should look like this: `Closes #1, #2, #3.` . -->
