### PR TITLE
[Fix] Fatal error edge case in WooCommerce checkout 

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -210,6 +210,11 @@ class Woocommerce {
 			return null;
 		}
 
+		// @phpstan-ignore-next-line it seems WC()->session might be null in some contexts
+		if ( empty( WC()->session ) ) {
+			return null;
+		}
+
 		$payment_method = WC()->session->get( 'chosen_payment_method' );
 		if ( ! $payment_method ) {
 			// If payment method is null, see if there is only one option;


### PR DESCRIPTION
### Summary
Fixes edge case fatal error where session was null on the return from `WC()` method.
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

Couldn't replicate so not really sure how to test.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2998.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
