### PR TITLE
[Feat] Footer enhancements

### DIFF
--- a/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
+++ b/assets/apps/customizer-controls/src/builder-instructions/Instructions.tsx
@@ -77,7 +77,7 @@ const Instructions: React.FC<Props> = ({ control }) => {
 											</span>
 										)}
 									</Button>
-									{url && upsellDescription && (
+									{upsellDescription && (
 										<div className="quick-links-upsell">
 											<p className="quick-links-description">
 												<div

--- a/assets/apps/customizer-controls/src/builder/scss/_customizer-adjustments.scss
+++ b/assets/apps/customizer-controls/src/builder/scss/_customizer-adjustments.scss
@@ -11,7 +11,8 @@ ul[id^="sub-accordion-panel-hfg_"] {
 	  display: block !important;
   }
 
-  #accordion-section-neve_header_presets {
+  #accordion-section-neve_header_presets,
+  #accordion-section-neve_footer_copyright_section {
 	  margin-top: 20px;
   }
 }

--- a/assets/apps/customizer-controls/src/builder/scss/_instructional-section.scss
+++ b/assets/apps/customizer-controls/src/builder/scss/_instructional-section.scss
@@ -28,7 +28,7 @@
 
 	.quick-links-upsell {
 		background-color: #f9fafb;
-		padding: 20px 15px;
+		padding: 10px 15px;
 
 		p {
 			margin: 0;

--- a/assets/apps/customizer-controls/src/builder/scss/_rows.scss
+++ b/assets/apps/customizer-controls/src/builder/scss/_rows.scss
@@ -2,6 +2,27 @@
 
 .rows-wrapper {
   display: flex;
+	position: relative;
+
+	.mobile-overlay {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		width: 100%;
+		backdrop-filter: blur(5px);
+		background-color: rgba(237, 237, 237, .5);
+		z-index: 1000;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+
+		p {
+			font-size: 16px;
+			max-width: 500px;
+			text-align: center;
+		}
+	}
 
   .vertical-rows {
 	margin-right: 10px;

--- a/assets/apps/customizer-controls/src/scss/_general.scss
+++ b/assets/apps/customizer-controls/src/scss/_general.scss
@@ -73,7 +73,8 @@
 }
 
 
-#sub-accordion-panel-hfg_header #accordion-section-neve_header_presets {
+#sub-accordion-panel-hfg_header #accordion-section-neve_header_presets,
+#sub-accordion-panel-hfg_footer #accordion-section-neve_footer_copyright_section {
   display: list-item !important;
 }
 
@@ -83,7 +84,7 @@
 
 #customize-control-neve_pro_global_header_settings_top_shortcut p,
 #customize-control-neve_pro_global_header_settings_main_shortcut p,
-#customize-control-neve_pro_global_header_settings_bottom_shortcut p, {
+#customize-control-neve_pro_global_header_settings_bottom_shortcut p {
   margin: 0;
 
   a {

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -12,7 +12,9 @@
 namespace HFG\Core\Builder;
 
 use HFG\Main;
+use Neve\Core\Migration_Flags;
 use Neve\Core\Theme_Info;
+use WP_Customize_Manager;
 
 /**
  * Class Footer
@@ -55,7 +57,8 @@ class Footer extends Abstract_Builder {
 			)
 		);
 
-		$upgrade_url_copyright = tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', 'copyright' ), 'query' );
+		$user_after_v41        = Migration_Flags::is_new_user_after_v41();
+		$upgrade_url_copyright = tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', $user_after_v41 ? 'copyright_dynamiclinks' : 'copyright' ), 'query' );
 
 		$this->set_property(
 			'instructions_array',
@@ -68,16 +71,19 @@ class Footer extends Abstract_Builder {
 				),
 				'quickLinks'  => array(
 					'footer_copyright_content'            => array(
-						'label'             => esc_html__( 'Change Copyright', 'neve' ),
+						'label'             => $this->has_valid_addons() ? esc_html__( 'Change Copyright', 'neve' ) : esc_html__( 'Dynamic Copyright', 'neve' ),
 						'icon'              => 'dashicons-nametag',
 						'url'               => $this->has_valid_addons() ? null : $upgrade_url_copyright,
 						'badge'             => esc_html__( 'PRO', 'neve' ),
 						'upsellDescription' => sprintf(
+							$user_after_v41 
 							/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
-							__( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
+							? __( 'Personalize your site\'s footer text! Many users choose to keep our small "Powered by Neve" credit — thank you! %1$sUpgrade to Pro%2$s for dynamic tags, HTML formatting, and advanced styling controls.', 'neve' )
+							/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+							: __( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
 							'<a href="' . esc_url_raw( $upgrade_url_copyright ) . '" target="_blank" rel="noopener noreferrer">',
 							'</a>'
-						),
+						), 
 					),
 					'hfg_footer_layout_bottom_background' => array(
 						'label' => esc_html__( 'Change Footer Color', 'neve' ),
@@ -136,6 +142,51 @@ class Footer extends Abstract_Builder {
 		add_action( 'neve_after_slot_component', [ $this, 'add_footer_component' ], 10, 3 );
 	}
 
+
+	/**
+	 * Called to register component controls.
+	 *
+	 * @param WP_Customize_Manager $wp_customize The Customize Manager.
+	 *
+	 * @return WP_Customize_Manager
+	 * @since   4.0.1
+	 * @access  public
+	 */
+	public function customize_register( WP_Customize_Manager $wp_customize ) {
+		if ( $this->has_valid_addons() || ! Migration_Flags::is_new_user_after_v41() ) {
+			return parent::customize_register( $wp_customize );
+		}
+
+		$wp_customize->add_section(
+			'neve_footer_copyright_section',
+			[
+				'title'    => __( 'Change Copyright', 'neve' ),
+				'priority' => 200,
+				'panel'    => 'hfg_footer',
+			]
+		);
+
+		$wp_customize->add_setting(
+			'footer_copyright_content',
+			[
+				'default'           => $this->get_copyright_default(),
+				'sanitize_callback' => 'wp_kses_post',
+			]
+		);
+
+		$wp_customize->add_control(
+			'footer_copyright_content',
+			[
+				'label'    => __( 'Text', 'neve' ),
+				'section'  => 'neve_footer_copyright_section',
+				'type'     => 'textarea',
+				'settings' => 'footer_copyright_content',
+			]
+		);
+		
+		return parent::customize_register( $wp_customize );
+	}
+
 	/**
 	 * Add footer component.
 	 *
@@ -162,15 +213,11 @@ class Footer extends Abstract_Builder {
 			return;
 		}
 
-		$output  = '<div class="builder-item cr"><div class="item--inner"><div class="component-wrap"><div>';
-		$output .= sprintf(
-		/* translators: %1$s is Theme Name ( Neve ), %2$s is WordPress */
-			esc_html__( '%1$s | Powered by %2$s', 'neve' ),
-			wp_kses_post( '<p><a href="' . tsdk_translate_link( 'https://themeisle.com/themes/neve/', 'path' ) . '" rel="nofollow">Neve</a>' ),
-			wp_kses_post( '<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>' )
-		);
-		$output .= '</div></div></div></div>';
+		$value = get_theme_mod( 'footer_copyright_content', $this->get_copyright_default() );
 
+		$output  = '<div class="builder-item cr"><div class="item--inner"><div class="component-wrap"><div>';
+		$output .= wp_kses_post( $value );
+		$output .= '</div></div></div></div>';
 
 		echo wp_kses_post( $output );
 	}
@@ -267,5 +314,19 @@ class Footer extends Abstract_Builder {
 				'name' => __( 'Social Icons', 'neve' ),
 			],
 		];
+	}
+
+	/**
+	 * Get the default copyright text.
+	 * 
+	 * @return string
+	 */
+	private function get_copyright_default() {
+		return sprintf(
+		/* translators: %1$s is Theme Name ( Neve ), %2$s is WordPress */
+			__( '%1$s | Powered by %2$s', 'neve' ),
+			'<p><a href="' . tsdk_translate_link( 'https://themeisle.com/themes/neve/', 'path' ) . '" rel="nofollow">Neve</a>',
+			'<a href="https://wordpress.org" rel="nofollow">WordPress</a></p>'
+		);
 	}
 }

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -60,6 +60,25 @@ class Footer extends Abstract_Builder {
 		$user_after_v41        = Migration_Flags::is_new_user_after_v41();
 		$upgrade_url_copyright = tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', $user_after_v41 ? 'copyright_dynamiclinks' : 'copyright' ), 'query' );
 
+		$copyright_quicklink_config = [
+			'label'             => esc_html__( 'Change Copyright', 'neve' ),
+			'icon'              => 'dashicons-nametag',
+			'upsellDescription' => sprintf(
+				$user_after_v41 
+				/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+				? __( 'Personalize your site\'s footer text! Many users choose to keep our small "Powered by Neve" credit — thank you! %1$sUpgrade to Pro%2$s for dynamic tags, HTML formatting, and advanced styling controls.', 'neve' )
+				/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
+				: __( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
+				'<a href="' . esc_url_raw( $upgrade_url_copyright ) . '" target="_blank" rel="noopener noreferrer">',
+				'</a>'
+			),
+		];
+
+		if ( ! $user_after_v41 ) {
+			$copyright_quicklink_config['url']   = $this->has_valid_addons() ? null : $upgrade_url_copyright;
+			$copyright_quicklink_config['badge'] = esc_html__( 'PRO', 'neve' );
+		}
+
 		$this->set_property(
 			'instructions_array',
 			array(
@@ -70,21 +89,7 @@ class Footer extends Abstract_Builder {
 					'+'
 				),
 				'quickLinks'  => array(
-					'footer_copyright_content'            => array(
-						'label'             => $this->has_valid_addons() ? esc_html__( 'Change Copyright', 'neve' ) : esc_html__( 'Dynamic Copyright', 'neve' ),
-						'icon'              => 'dashicons-nametag',
-						'url'               => $this->has_valid_addons() ? null : $upgrade_url_copyright,
-						'badge'             => esc_html__( 'PRO', 'neve' ),
-						'upsellDescription' => sprintf(
-							$user_after_v41 
-							/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
-							? __( 'Personalize your site\'s footer text! Many users choose to keep our small "Powered by Neve" credit — thank you! %1$sUpgrade to Pro%2$s for dynamic tags, HTML formatting, and advanced styling controls.', 'neve' )
-							/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
-							: __( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
-							'<a href="' . esc_url_raw( $upgrade_url_copyright ) . '" target="_blank" rel="noopener noreferrer">',
-							'</a>'
-						), 
-					),
+					'footer_copyright_content'            => $copyright_quicklink_config,
 					'hfg_footer_layout_bottom_background' => array(
 						'label' => esc_html__( 'Change Footer Color', 'neve' ),
 						'icon'  => 'dashicons-admin-appearance',

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -162,7 +162,7 @@ class Footer extends Abstract_Builder {
 			return;
 		}
 
-		$output  = '<div class="builder-item"><div class="item--inner"><div class="component-wrap"><div>';
+		$output  = '<div class="builder-item cr"><div class="item--inner"><div class="component-wrap"><div>';
 		$output .= sprintf(
 		/* translators: %1$s is Theme Name ( Neve ), %2$s is WordPress */
 			esc_html__( '%1$s | Powered by %2$s', 'neve' ),

--- a/header-footer-grid/Core/Builder/Footer.php
+++ b/header-footer-grid/Core/Builder/Footer.php
@@ -61,9 +61,18 @@ class Footer extends Abstract_Builder {
 		$upgrade_url_copyright = tsdk_translate_link( tsdk_utmify( 'https://themeisle.com/themes/neve/upgrade/', $user_after_v41 ? 'copyright_dynamiclinks' : 'copyright' ), 'query' );
 
 		$copyright_quicklink_config = [
-			'label'             => esc_html__( 'Change Copyright', 'neve' ),
-			'icon'              => 'dashicons-nametag',
-			'upsellDescription' => sprintf(
+			'label' => esc_html__( 'Change Copyright', 'neve' ),
+			'icon'  => 'dashicons-nametag',
+		];
+
+		if ( ! $user_after_v41 ) {
+			$copyright_quicklink_config['url']   = $this->has_valid_addons() ? null : $upgrade_url_copyright;
+			$copyright_quicklink_config['badge'] = esc_html__( 'PRO', 'neve' );
+
+		}
+
+		if ( ! $this->has_valid_addons() ) {
+			$copyright_quicklink_config['upsellDescription'] = sprintf(
 				$user_after_v41 
 				/* translators: %1$s: opening anchor tag, %2$s: closing anchor tag */
 				? __( 'Personalize your site\'s footer text! Many users choose to keep our small "Powered by Neve" credit — thank you! %1$sUpgrade to Pro%2$s for dynamic tags, HTML formatting, and advanced styling controls.', 'neve' )
@@ -71,12 +80,7 @@ class Footer extends Abstract_Builder {
 				: __( 'The Neve theme free version doesn\'t support copyright edits. Pro unlocks this and more—%1$sexplore%2$s it when you\'re ready!', 'neve' ),
 				'<a href="' . esc_url_raw( $upgrade_url_copyright ) . '" target="_blank" rel="noopener noreferrer">',
 				'</a>'
-			),
-		];
-
-		if ( ! $user_after_v41 ) {
-			$copyright_quicklink_config['url']   = $this->has_valid_addons() ? null : $upgrade_url_copyright;
-			$copyright_quicklink_config['badge'] = esc_html__( 'PRO', 'neve' );
+			);
 		}
 
 		$this->set_property(

--- a/header-footer-grid/functions-template.php
+++ b/header-footer-grid/functions-template.php
@@ -257,3 +257,53 @@ function parse_dynamic_tags( $string ) {
 }
 
 
+/**
+ * Check if the footer builder is empty.
+ * 
+ * @param string $device The device type (mobile or desktop).
+ * @return bool
+ */
+function is_footer_builder_empty( $device = 'mobile' ) {
+	if ( ! in_array( $device, [ 'mobile', 'desktop' ] ) ) {
+		return false;
+	}
+
+	$data = get_theme_mod( 'hfg_footer_layout_v2', wp_json_encode( neve_hfg_footer_settings() ['builder'] ) );
+
+	if ( empty( $data ) ) {
+		return true;
+	}
+
+	return is_builder_empty_for_device( $data, $device );
+}
+
+/**
+ * Check if the builder data is empty.
+ * 
+ * @param string $data The builder data.
+ * @param string $device The device type (mobile or desktop).
+ * @return bool
+ */
+function is_builder_empty_for_device( $data, $device ) {
+	$decoded = json_decode( $data, true );
+
+	if ( ! is_array( $decoded ) ) {
+		return true;
+	}
+
+	if ( empty( $decoded[ $device ] ) ) {
+		return true;
+	}
+
+	foreach ( $decoded[ $device ] as $row => $slots ) {
+		foreach ( $slots as $slot => $components ) {
+			if ( ! empty( $components ) ) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+

--- a/header-footer-grid/templates/footer-row-wrapper.php
+++ b/header-footer-grid/templates/footer-row-wrapper.php
@@ -16,16 +16,25 @@ $row_index  = current_row();
 $device     = current_device();
 $section_id = get_builder()->get_property( 'control_id' ) . '_' . $row_index;
 
-$row_visibility = 'hide-on-desktop';
-if ( $device === 'desktop' ) {
-	$row_visibility = 'hide-on-mobile hide-on-tablet';
-}
-
 $row_classes = [
 	'footer--row',
 	'footer-' . $row_index,
-	$row_visibility,
 ];
+
+$mobile_empty = is_footer_builder_empty( 'mobile' );
+
+if ( $device === 'mobile' && $mobile_empty ) {
+	return;
+}
+
+if ( $device === 'desktop' && ! $mobile_empty ) { 
+	$row_classes[] = 'hide-on-mobile hide-on-tablet';
+}
+
+if ( $device === 'mobile' ) {
+	$row_classes[] = 'hide-on-desktop';
+}
+	
 
 $row_classes[] = row_setting( Abstract_Builder::LAYOUT_SETTING );
 $row_classes   = apply_filters( 'hfg_footer_row_classes', $row_classes, $row_index );

--- a/inc/core/front_end.php
+++ b/inc/core/front_end.php
@@ -349,6 +349,7 @@ class Front_End {
 		}
 
 		$style .= $this->get_mobile_menu_styles();
+		$style .= $this->get_static_footer_styles();
 
 		wp_add_inline_style( 'neve-style', Dynamic_Css::minify_css( $style ) );
 	}
@@ -370,6 +371,24 @@ class Front_End {
 		$sidebar_animation_css .= '.header-menu-sidebar .menu-item-nav-search .is-menu-sidebar { pointer-events: unset; }';
 
 		return $sidebar_animation_css;
+	}
+
+	/**
+	 * Get static footer styles.
+	 * 
+	 * @return string
+	 */
+	private function get_static_footer_styles() {
+		if ( defined( 'NEVE_PRO_VERSION' ) ) {
+			return '';
+		}
+		
+		return '@media screen and (max-width: 960px) {
+			.builder-item.cr .item--inner {
+				--textalign: center;
+    		--justify: center;
+			}
+		}';
 	}
 
 	/**

--- a/inc/customizer/options/upsells.php
+++ b/inc/customizer/options/upsells.php
@@ -555,7 +555,7 @@ class Upsells extends Base_Customizer {
 					'priority'         => 10000,
 					'link'             => $this->get_upgrade_url( 'panel-' . $hfg_footer ),
 					'features_list'    => array(
-						__( 'Copyright edits', 'neve' ),
+						__( 'Dynamic copyright', 'neve' ),
 						__( 'Divider element', 'neve' ),
 						__( 'Payments & social icons', 'neve' ),
 						__( 'Custom layouts', 'neve' ),

--- a/tests/test-neve-migration-flags.php
+++ b/tests/test-neve-migration-flags.php
@@ -44,7 +44,7 @@ class TestNeveMigrationFlags extends WP_UnitTestCase {
 		remove_theme_mods();
 		$migration_flags = new Migration_Flags('4.0.0' );
 		$reflection = new ReflectionClass($migration_flags);
-		$method = $reflection->getMethod('is_new_user_on_v4');
+		$method = $reflection->getMethod('is_new_user');
 		$method->setAccessible(true);
 		$migration_flags->run();
 		$this->assertTrue( $method->invoke($migration_flags) );
@@ -54,7 +54,7 @@ class TestNeveMigrationFlags extends WP_UnitTestCase {
 		set_theme_mod( 'hfg_header_layout', 'layout' );
 		$migration_flags = new Migration_Flags('4.0.0' );
 		$reflection = new ReflectionClass($migration_flags);
-		$method = $reflection->getMethod('is_new_user_on_v4');
+		$method = $reflection->getMethod('is_new_user');
 		$method->setAccessible(true);
 		$migration_flags->run();
 		$this->assertFalse( $method->invoke($migration_flags) );


### PR DESCRIPTION
### Summary
1. Make mobile footer inherit components from desktop if empty;
2. Center copyright on mobile;
3. Copyright footer enhancements;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Test instructions
<!-- Describe how this pull request can be tested. -->

#### 1. Codeinwp/neve-pro-addon#2969
- Install this version of the theme;
- Make sure all components are removed on the mobile version of the footer;
- An overlay should appear, informing the user that the mobile footer inherits the desktop;
- If you dismiss it (click enable), it will not appear again for the current page load;
- The footer components from desktop should be inherited on mobile screen-size on the frontend;
- If there are components in the mobile version of the footer, these will be displayed instead;

<details><summary>Overlay Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/9f6f9fff-641e-4a0a-8b2e-989c32903b71)

</p>
</details> 

---

#### 2. Codeinwp/neve-pro-addon#2947
- Install this version of the theme;
- On the frontend, the copyright should be centered on mobile screen sizes;

---

#### 3. Codeinwp/neve-pro-addon#2993

> [!NOTE]
> **For testing this particular issue:**
> After you download the zip file of this version, change the `NEVE_VERSION` constant to `4.1.0` inside `functions.php` - this is the upcoming release version.
> You can zip it back up for further use during testing of this issue. It will be used during all variants of this issue.


A. New users after the 4.1 release:
   - On a fresh instance, without changing anything in the customizer install the version mentioned above;
   - Go into the **Customizer > Footer**;
   - There will be a new section called **Change Copyright** ;
   - The control inside is a textarea and should work as expected;
   - The upsell in the **Footer** section should have a new text, upsell link in the description should have the`utm_campaign` param `copyright_dynamiclinks`
   - Quick link should focus the new control;
   - When activating Pro, the Copyright component should inherit the value from the new control;

<details><summary>Screenshot</summary>
<p>

![image](https://github.com/user-attachments/assets/af23217d-881f-41da-9c6b-5adc692f8b17)

</p>
</details> 

B. Old users before the upcoming release:
   - On a fresh instance, install the production version of the theme --`4.0.1`;
   - Go into the customizer and change the header builder layout;
   - Replace the theme with the zip file with the `4.1.0` version;
   - Go into the **Customizer > Footer** panel;
   - The customizer panel should be the same as on the `4.0.1` version;

C. Old users before 4.0.0 (just to be sure - we had a bug in the migration mechanism which should be fixed now):
   - Install `3.8.16` version of the theme;
   - Change the header builder layout in the customizer;
   - Update the theme to `4.0.0` (last PRF);
   - Update again to `4.0.1` (last PRF hotfix patch);
   - Replace the theme with the zip file with the `4.1.0` version;
   - Go into the **Customizer > Footer** panel;
   - The customizer panel should be the same as on the `4.0.1` version;

---

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2969
Closes Codeinwp/neve-pro-addon#2947
Closes Codeinwp/neve-pro-addon#2993

<!-- Should look like this: `Closes #1, #2, #3.` . -->
