### PR TITLE
[Fix] Gallery for WooCommerce conflict & improve product layout

### DIFF
--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -4,7 +4,7 @@
 
 .nv-single-product-top {
 	display: flex;
-	flex-wrap: wrap;
+	flex-direction: column;
 	position: relative;
 }
 
@@ -224,10 +224,8 @@
 @mixin product--tablet() {
 
 	.nv-single-product-top {
-
-		.summary {
-			margin-left: 4%;
-		}
+		gap: 4%;
+		flex-direction: row;
 	}
 
 	body.single-product .neve-main > .container > .row {


### PR DESCRIPTION
### Summary
Fixes issues with Gallery for Woocommerce plugin;
Improves how we treated layout on single product page;
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO 

### Screenshots <!-- if applicable -->
![image](https://github.com/user-attachments/assets/459870b6-c9fe-4855-a44d-374fcaf28b63)

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Follow initial issue for testing steps: Codeinwp/neve-pro-addon#2943

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes Codeinwp/neve-pro-addon#2943.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
