### PR TITLE
Fixed broken notice layout

### DIFF
--- a/assets/scss/components/compat/woocommerce/_notices.scss
+++ b/assets/scss/components/compat/woocommerce/_notices.scss
@@ -13,10 +13,10 @@
 .woocommerce-error,
 .woocommerce-message {
 	display: flex;
-	align-items: center;
-	flex-direction: column-reverse;
-	text-align: center;
-	padding: 15px;
+	align-items: start;
+	flex-direction: column;
+	text-align: start;
+	padding: 15px 15px 15px 45px;
 	--btnfs: $text-sm;
 	--primarybtnpadding: 10px 15px;
 	--primarybtnborderwidth: 3px;
@@ -36,6 +36,7 @@
 		margin-top: $spacing-sm;
 		white-space: normal;
 		margin-left: auto;
+		text-align: center;
 	}
 }
 
@@ -144,10 +145,9 @@ $blockNotices: (
 	.woocommerce-info,
 	.woocommerce-error,
 	.woocommerce-message {
-		flex-direction: row-reverse;
-		justify-content: flex-end;
 		text-align: left;
 		padding-left: $spacing-aired;
+		align-items: center;
 
 		a,
 		.button {
@@ -160,9 +160,27 @@ $blockNotices: (
 		&::before {
 			display: flex;
 			top: 0;
-			align-items: center;
 			height: 100%;
 			color: #fff;
+		}
+	}
+
+	.woocommerce-info,
+	.woocommerce-message {
+		flex-direction: row-reverse;
+		justify-content: flex-end;
+
+		&::before {
+			align-items: center;
+		}
+	}
+
+	.woocommerce-error {
+		flex-direction: column-reverse;
+
+		&::before {
+			align-items: start;
+			padding-top: 15px;
 		}
 	}
 }


### PR DESCRIPTION
### Summary
Fixed broken notice layout on cart and checkout pages.

### Screenshots
<img width="1631" height="417" alt="image" src="https://github.com/user-attachments/assets/403538e4-6f42-4305-b09d-be8ded4c9482" />

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

Closes https://github.com/Codeinwp/neve-pro-addon/issues/3034