### PR TITLE
feat: add filter for Scroll to Top display

### DIFF
--- a/inc/customizer/options/scroll_to_top.php
+++ b/inc/customizer/options/scroll_to_top.php
@@ -712,20 +712,26 @@ class Scroll_To_Top extends Base_Customizer {
 	 */
 	public static function is_enabled() {
 		// Check old option first for backward compatibility.
-		$old_value = get_option( 'nv_pro_scroll_to_top_status', null );
+		$old_value  = get_option( 'nv_pro_scroll_to_top_status', null );
+		$is_enabled = false;
 
 		if ( null !== $old_value ) {
 			// Option exists — use it and migrate to the new theme_mod for future.
-			$value = $old_value === '1';
+			$is_enabled = $old_value === '1';
 
 			set_theme_mod( 'neve_scroll_to_top_status', $old_value );
 			delete_option( 'nv_pro_scroll_to_top_status' );
-
-			return $value;
+		} else {
+			// Otherwise, use the new theme_mod.
+			$is_enabled = get_theme_mod( 'neve_scroll_to_top_status', '1' ) === '1';
 		}
 
-		// Otherwise, use the new theme_mod.
-		return get_theme_mod( 'neve_scroll_to_top_status', '1' ) === '1';
+		/**
+		 * Filter to allow conditional loading of the scroll to top feature.
+		 *
+		 * @param bool $is_enabled Whether the scroll to top feature is enabled.
+		 */
+		return apply_filters( 'neve_scroll_to_top_is_enabled', $is_enabled );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Adds `neve_scroll_to_top_is_enabled`filter to the plugin that allows users to control Scroll to Top display.

Important: The PR is made against https://github.com/Codeinwp/neve/pull/4445

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Try some condition like:

```
add_action( 'init', function() {
	/**
	 * Filter scroll to top to only show on pages, not archives or posts.
	 */
	add_filter(
		'neve_scroll_to_top_is_enabled',
		function( $is_enabled ) {
			// Only enable on pages, disable on archives, posts, and other content types
			if ( ! is_page() ) {
				return false;
			}
			return $is_enabled;
		}
	);
} );
```

And make sure it works properly.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/2582.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
