### PR TITLE
feat: make Elementor's Page Content widget available to Custom Layouts

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -572,10 +572,10 @@ class Elementor extends Page_Builder_Base {
 	/**
 	 * Allow Post Content widget to be shown in the panel for neve_custom_layouts post type.
 	 *
-	 * @param array $data The original data that needs to be saved.
-	 * @param int   $post_id The ID of the post for which the data is being saved.
+	 * @param array<string, mixed> $data The original data that needs to be saved.
+	 * @param int                  $post_id The ID of the post for which the data is being saved.
 	 *
-	 * @return array The modified data with the additional configuration.
+	 * @return array<string, mixed> The modified data with the additional configuration.
 	 */
 	public function elementor_document_config( $data, $post_id ) {
 		if ( 'neve_custom_layouts' === get_post_type( $post_id ) ) {


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This PR makes Elementor's Page Content widget available to Custom Layouts post type.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure if you create a Custom Layout using Elementor, you see the Post Content widget available when using Elementor Pro.
- Make sure it works properly.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/3058.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
