### PR TITLE
feat: add option to preload fonts

### DIFF
--- a/assets/apps/customizer-controls/src/typography-extra/LocalGoogleFonts.js
+++ b/assets/apps/customizer-controls/src/typography-extra/LocalGoogleFonts.js
@@ -20,7 +20,7 @@ const initLocalGoogleFonts = () => {
 		return;
 	}
 
-	const toggleControl =
+	const localFontsToggle =
 		new wp.customize.controlConstructor.neve_toggle_control(
 			NeveReactCustomize.localGoogleFonts.key,
 			{
@@ -32,7 +32,24 @@ const initLocalGoogleFonts = () => {
 			}
 		);
 
-	render(<ToggleComponent control={toggleControl} />, section.container[0]);
+	const preloadFontsToggle =
+		new wp.customize.controlConstructor.neve_toggle_control(
+			NeveReactCustomize.preloadFonts.key,
+			{
+				section: section.id,
+				label: __('Preload fonts', 'neve'),
+				setting: NeveReactCustomize.preloadFonts.key,
+				priority: 6,
+			}
+		);
+
+	render(
+		<>
+			<ToggleComponent control={preloadFontsToggle} />
+			<ToggleComponent control={localFontsToggle} />
+		</>,
+		section.container[0]
+	);
 };
 
 export { initLocalGoogleFonts };

--- a/inc/core/settings/config.php
+++ b/inc/core/settings/config.php
@@ -94,6 +94,7 @@ class Config {
 	const MODS_POST_TYPE_VSPACING         = 'content_vspacing';
 
 	const OPTION_LOCAL_GOOGLE_FONTS_HOSTING = 'nv_pro_enable_local_fonts';
+	const MODS_PRELOAD_FONTS                = 'neve_preload_fonts';
 	const OPTION_POSTS_PER_PAGE             = 'posts_per_page';
 
 	const MODS_TPOGRAPHY_FONT_PAIRS = 'neve_font_pairs';

--- a/inc/customizer/loader.php
+++ b/inc/customizer/loader.php
@@ -144,6 +144,9 @@ class Loader {
 						'learnMore' => apply_filters( 'neve_external_link', 'https://docs.themeisle.com/article/1349-how-to-load-neve-fonts-locally', esc_html__( 'Learn more', 'neve' ) ),
 						'key'       => Config::OPTION_LOCAL_GOOGLE_FONTS_HOSTING,
 					),
+					'preloadFonts'                  => array(
+						'key' => Config::MODS_PRELOAD_FONTS,
+					),
 					'fontPairs'                     => get_theme_mod( Config::MODS_TPOGRAPHY_FONT_PAIRS, Config::$typography_default_pairs ),
 					'allowedGlobalCustomColor'      => Colors_Background::CUSTOM_COLOR_LIMIT,
 					'constants'                     => [
@@ -288,6 +291,14 @@ class Loader {
 			[
 				'type'              => 'option',
 				'sanitize_callback' => 'rest_sanitize_boolean',
+				'default'           => false,
+			]
+		);
+
+		$wp_customize->add_setting(
+			Config::MODS_PRELOAD_FONTS,
+			[
+				'sanitize_callback' => 'neve_sanitize_checkbox',
 				'default'           => false,
 			]
 		);


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This pull request adds a new feature to the Neve theme that allows users to preload Google Fonts for improved performance, alongside existing local font hosting options. The changes introduce a new Customizer toggle for font preloading, update theme configuration and settings, and implement logic to modify font stylesheet loading behavior.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
No

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure you see the option in Customizer > Typography
- The fonts in the front respect the behavior for fonts set in Customzier.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/3060.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
