### PR TITLE
fix: improve a11y of sortable keys

### DIFF
--- a/assets/apps/customizer-controls/src/common/useKeyboardSorting.js
+++ b/assets/apps/customizer-controls/src/common/useKeyboardSorting.js
@@ -1,0 +1,84 @@
+import { useCallback, useRef, useEffect } from '@wordpress/element';
+
+/**
+ * Custom hook for keyboard-based sorting of list items.
+ *
+ * @param {number} index - Current item index in the list
+ * @param {number} totalItems - Total number of items in the list
+ * @param {Function} onMove - Callback function to move item (receives fromIndex, toIndex)
+ * @param {boolean} isActive - External state for whether keyboard mode is active
+ * @param {Function} setIsActive - Function to set the active state
+ * @return {Object} Hook state and handlers
+ */
+const useKeyboardSorting = (
+	index,
+	totalItems,
+	onMove,
+	isActive,
+	setIsActive
+) => {
+	const handleRef = useRef(null);
+	const previousIndexRef = useRef(index);
+
+	// Handle keyboard events
+	const handleKeyDown = useCallback(
+		(e) => {
+			if (e.key === ' ' || e.key === 'Spacebar') {
+				e.preventDefault();
+				setIsActive(!isActive);
+				return;
+			}
+
+			if (!isActive) {
+				return;
+			}
+
+			if (e.key === 'ArrowUp' && index > 0) {
+				e.preventDefault();
+				const newIndex = index - 1;
+				previousIndexRef.current = index;
+				onMove(index, newIndex);
+			}
+
+			if (e.key === 'ArrowDown' && index < totalItems - 1) {
+				e.preventDefault();
+				const newIndex = index + 1;
+				previousIndexRef.current = index;
+				onMove(index, newIndex);
+			}
+			if (e.key === 'Escape') {
+				e.preventDefault();
+				setIsActive(false);
+			}
+		},
+		[isActive, index, totalItems, onMove, setIsActive]
+	);
+
+	const handleBlur = useCallback(() => {
+		setIsActive(false);
+	}, [setIsActive]);
+
+	useEffect(() => {
+		if (
+			isActive &&
+			handleRef.current &&
+			previousIndexRef.current !== index
+		) {
+			// Small delay to ensure DOM has updated
+			window.requestAnimationFrame(() => {
+				if (handleRef.current) {
+					handleRef.current.focus();
+				}
+			});
+		}
+		previousIndexRef.current = index;
+	}, [index, isActive]);
+
+	return {
+		handleRef,
+		handleKeyDown,
+		handleBlur,
+	};
+};
+
+export default useKeyboardSorting;

--- a/assets/apps/customizer-controls/src/repeater/RepeaterItem.js
+++ b/assets/apps/customizer-controls/src/repeater/RepeaterItem.js
@@ -7,21 +7,30 @@ import classnames from 'classnames';
 import PropTypes from 'prop-types';
 
 import { VisibilityIcon, HiddenIcon } from '../common';
+import useKeyboardSorting from '../common/useKeyboardSorting';
 import RepeaterItemContent from './RepeaterItemContent';
 
-const Handle = () => (
-	<Tooltip text={__('Drag to Reorder', 'neve')}>
-		<button
-			aria-label={__('Drag to Reorder', 'neve')}
-			className="handle"
-			onClick={(e) => {
-				e.preventDefault();
-			}}
-		>
-			<Icon icon={dragHandle} size={18} />
-		</button>
-	</Tooltip>
-);
+const Handle = ({ handleRef, onKeyDown, onBlur, isActive }) => {
+	return (
+		<Tooltip text={__('Drag to Reorder', 'neve')}>
+			<button
+				ref={handleRef}
+				aria-label={__('Drag to Reorder', 'neve')}
+				className={classnames('handle', {
+					'keyboard-active': isActive,
+				})}
+				onClick={(e) => {
+					e.preventDefault();
+				}}
+				onKeyDown={onKeyDown}
+				onBlur={onBlur}
+				tabIndex={0}
+			>
+				<Icon icon={dragHandle} size={18} />
+			</button>
+		</Tooltip>
+	);
+};
 
 const RepeaterItem = ({
 	fields,
@@ -31,8 +40,20 @@ const RepeaterItem = ({
 	onToggle,
 	onContentChange,
 	onRemove,
+	totalItems,
+	onMove,
+	isKeyboardActive,
+	onKeyboardActiveChange,
 }) => {
 	const [expanded, setExpanded] = useState(false);
+
+	const { handleRef, handleKeyDown, handleBlur } = useKeyboardSorting(
+		itemIndex,
+		totalItems,
+		onMove,
+		isKeyboardActive,
+		onKeyboardActiveChange
+	);
 
 	const itemLabel = () => {
 		let label = __('Item', 'neve');
@@ -60,7 +81,12 @@ const RepeaterItem = ({
 			})}
 		>
 			<div className="top-bar">
-				<Handle />
+				<Handle
+					handleRef={handleRef}
+					onKeyDown={handleKeyDown}
+					onBlur={handleBlur}
+					isActive={isKeyboardActive}
+				/>
 				{itemLabel()}
 
 				<div className="actions">
@@ -122,6 +148,10 @@ RepeaterItem.propTypes = {
 	onToggle: PropTypes.func.isRequired,
 	onContentChange: PropTypes.func.isRequired,
 	onRemove: PropTypes.func.isRequired,
+	totalItems: PropTypes.number.isRequired,
+	onMove: PropTypes.func.isRequired,
+	isKeyboardActive: PropTypes.bool.isRequired,
+	onKeyboardActiveChange: PropTypes.func.isRequired,
 };
 
 export default RepeaterItem;

--- a/assets/apps/customizer-controls/src/scss/_ordering.scss
+++ b/assets/apps/customizer-controls/src/scss/_ordering.scss
@@ -58,6 +58,16 @@ $icon-bright: #00a0d2;
 				fill: $gray-dark;
 				background-color: $gray-light;
 			}
+
+			&:focus {
+				outline: 2px solid $icon;
+				outline-offset: -2px;
+			}
+
+			&.keyboard-active {
+				background-color: $icon-bright;
+				fill: #fff;
+			}
 		}
 
 

--- a/assets/apps/customizer-controls/src/scss/_repeater.scss
+++ b/assets/apps/customizer-controls/src/scss/_repeater.scss
@@ -17,6 +17,18 @@ $text-color: #50575e;
     margin: 0;
   }
 
+  .handle {
+    &:focus {
+      outline: 2px solid #0073aa;
+      outline-offset: -2px;
+    }
+
+    &.keyboard-active {
+      background-color: #00a0d2;
+      fill: #fff;
+    }
+  }
+
   .icon-control {
     height: 30px;
     margin-bottom: 10px;

--- a/assets/apps/metabox/src/editor.scss
+++ b/assets/apps/metabox/src/editor.scss
@@ -99,14 +99,44 @@
 			flex-basis: 20%;
 			cursor: move;
 
-			.components-button {
-				color: #bfbfbf;
+			// Enhanced custom handle button styling
+			.ti-sortable-handle-btn {
+				width: 32px;
+				height: 32px;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+				border: 1px solid #d5dadf;
+				background: #f6f7f7;
+				border-radius: 4px;
+				color: #6c6c6c;
+				cursor: move;
+				padding: 0;
+				transition: background .15s ease, box-shadow .15s ease, color .15s ease;
+			}
 
-				&:hover, &:focus {
-					color: #bfbfbf;
-					box-shadow: none;
-				  	background: none;
-				}
+			.ti-sortable-handle-btn:hover {
+				background: #ebedef;
+				color: #444444;
+			}
+
+			.ti-sortable-handle-btn:focus {
+				outline: none;
+				background: #ffffff;
+				box-shadow: 0 0 0 2px #2271b1;
+				color: #1e1e1e;
+			}
+
+			&.keyboard-active .ti-sortable-handle-btn {
+				background: #2271b1;
+				color: #ffffff;
+				box-shadow: 0 0 0 2px #2271b1;
+				border-color: #2271b1;
+			}
+
+			.ti-sortable-handle-btn .dashicons {
+				font-size: 18px;
+				line-height: 1;
 			}
 		}
 


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

This makes the sortable items in Customizer and Post Editor keyboard-ready. You can take the focus to the dragger, click space and then press up/down key to move the item, and then space again to end selection.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
No

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- Make sure the items are moving properly with the keyboard.
- And then make sure they continue to work as before without any issues.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/neve-pro-addon/issues/3065.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
