### PR TITLE
fix: php deprecated notice

### DIFF
--- a/inc/compatibility/woocommerce.php
+++ b/inc/compatibility/woocommerce.php
@@ -907,7 +907,7 @@ class Woocommerce {
 	 * Move the coupon field and message info after the order table.
 	 */
 	public function move_coupon() {
-		wc_enqueue_js( '$( $( ".woocommerce-checkout div.woocommerce-info, .checkout_coupon, .woocommerce-form-login" ).detach() ).appendTo( "#neve-checkout-coupon" );' );
+		wp_add_inline_script( 'neve-script', 'jQuery( jQuery( ".woocommerce-checkout div.woocommerce-info, .checkout_coupon, .woocommerce-form-login" ).detach() ).appendTo( "#neve-checkout-coupon" );' );
 	}
 
 	/**


### PR DESCRIPTION
### Summary
Add the inline script using the 'wp_add_inline_script' function to fix the deprecated notices.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4474