### PR TITLE
Improved keyboard navigation between posts

### DIFF
--- a/inc/views/partials/excerpt.php
+++ b/inc/views/partials/excerpt.php
@@ -48,7 +48,7 @@ class Excerpt extends Base_View {
 		$length = $this->get_excerpt_length();
 
 		$output  = '';
-		$output .= '<div class="excerpt-wrap entry-summary">';
+		$output .= '<div class="excerpt-wrap entry-summary" tabindex="0">';
 		$output .= $this->get_excerpt( $length, $post_id );
 		$output .= '</div>';
 

--- a/inc/views/template_parts.php
+++ b/inc/views/template_parts.php
@@ -473,7 +473,7 @@ class Template_Parts extends Base_View {
 		);
 
 		// Return $new_moretag if 'text' key is not set in $read_more_args.
-		if ( ! isset( $read_more_args['text'] ) ) {
+		if ( ! isset( $read_more_args['text'] ) || empty( $read_more_args['text'] ) ) {
 			return $new_moretag;
 		}
 


### PR DESCRIPTION
### Summary
Added `tabindex` attribute to the excerpt to navigate through keyboard.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve-pro-addon/issues/3132