### PR TITLE
Ensured compatibility with Gutenberg v22.6.0

### DIFF
--- a/assets/scss/gutenberg-editor-style.scss
+++ b/assets/scss/gutenberg-editor-style.scss
@@ -5,10 +5,9 @@
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 
-  &, > * {
+  &, > *:not(.block-canvas-cover) {
 	background-color: var(--nv-site-bg);
 	color: var(--nv-text-color);
-  z-index: 99999;
   }
 
   .wp-block {

--- a/assets/scss/gutenberg-editor-style.scss
+++ b/assets/scss/gutenberg-editor-style.scss
@@ -8,6 +8,7 @@
   &, > * {
 	background-color: var(--nv-site-bg);
 	color: var(--nv-text-color);
+  z-index: 99999;
   }
 
   .wp-block {


### PR DESCRIPTION
### Summary
Override the `z-index` to make the component visible in the editor.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4479