### PR TITLE
refactor: update the black friday labels

### DIFF
--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -1301,30 +1301,38 @@ class Main {
 	 */
 	public static function get_black_friday_data( $default = array() ) {
 		$config = $default;
-
-		// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-		$message_template = __( 'Our biggest sale of the year: %1$sup to %2$s OFF%3$s on %4$s. Don\'t miss this limited-time offer.', 'neve' );
-		$product_label    = __( 'Neve', 'neve' );
-		$discount         = '70%';
-
-		$plan   = apply_filters( 'product_neve_license_plan', 0 );
+		
+		$message   = __( 'Custom layouts, WooCommerce tools, starter sites. What you\'ve been doing manually, Neve Pro handles for you. Exclusively for existing Neve users.', 'neve' );
+		$cta_label = __( 'Get Neve Pro', 'neve' );
+		
+		$plan   = apply_filters( 'product_neve_license_plan', false );
 		$is_pro = 0 < $plan;
+		
+		$license_status      = apply_filters( 'product_neve_license_status', false );
+		$has_valid_license   = 'valid' === $license_status;
+		$has_expired_license = 'expired' === $license_status || 'active_exired' === $license_status;
 
-		if ( $is_pro ) {
-			// translators: %1$s - HTML tag, %2$s - discount, %3$s - HTML tag, %4$s - product name.
-			$message_template = __( 'Get %1$sup to %2$s off%3$s when you upgrade your %4$s plan or renew early.', 'neve' );
-			$product_label    = __( 'Neve Pro', 'neve' );
-			$discount         = '30%';
+		if ( $has_valid_license ) {
+			// translators: %1$s - the discount percentage for the upgrade, %2$s - the discount percentage for the renewal.
+			$message   = sprintf( __( 'Upgrade your Neve Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'neve' ), '30%', '20%' );
+			$cta_label = __( 'See your options', 'neve' );
+		} elseif ( $has_expired_license ) {
+			$message   = __( 'Your Neve Pro features are still here, just locked. Renew at a reduced rate this week and pick up right where you left off.', 'neve' );
+			$cta_label = __( 'Reactivate now', 'neve' );
+		} else {
+			// translators: %s - the discount percentage for the upgrade.
+			$config['title'] = sprintf( __( 'Neve Pro: %s off this week', 'neve' ), '60%' );
 		}
 		
-		$product_label = sprintf( '<strong>%s</strong>', $product_label );
-		$url_params    = array(
+		$url_params = array(
 			'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 			'lkey'     => apply_filters( 'product_neve_license_key', false ),
+			'expired'  => $has_expired_license ? '1' : false,
 		);
 		
-		$config['message']  = sprintf( $message_template, '<strong>', $discount, '</strong>', $product_label );
-		$config['sale_url'] = add_query_arg(
+		$config['message']   = $message;
+		$config['cta_label'] = $cta_label;
+		$config['sale_url']  = add_query_arg(
 			$url_params,
 			tsdk_translate_link( tsdk_utmify( 'https://themeisle.link/neve-bf', 'bfcm', 'neve' ) )
 		);

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -1333,6 +1333,9 @@ class Main {
 		} else {
 			// translators: %s is the discount percentage.
 			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'neve' ), '60%' );
+
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'neve' ), '60%' );
 		}
 		
 		$url_params = array(

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -56,7 +56,7 @@ class Main {
 		add_action( 'admin_enqueue_scripts', [ $this, 'enqueue' ] );
 		add_action( 'init', array( $this, 'register_settings' ) );
 		add_action( 'init', array( $this, 'register_about_page' ), 1 );
-		
+
 		add_action( 'admin_notices', array( $this, 'render_custom_layout_header' ) );
 	}
 
@@ -999,7 +999,7 @@ class Main {
 	 */
 	public function render_custom_layout_header() {
 		$screen = get_current_screen();
-		
+
 		if ( ! $screen || ! ( $screen->id === 'edit-neve_custom_layouts' || $screen->id === 'neve_page_neve-custom-layout-upsell' ) ) {
 			return;
 		}
@@ -1255,18 +1255,18 @@ class Main {
 
 	/**
 	 * Register the survey.
-	 * 
+	 *
 	 * @param array $dash_data The dashboard data.
-	 * 
+	 *
 	 * @return void
 	 */
 	public function register_survey( $dash_data ) {
 		add_filter(
 			'themeisle-sdk/survey/neve',
 			function( $data, $page_slug ) use ( $dash_data ) {
-				
+
 				$install_days_number = intval( ( time() - get_option( 'neve_install', time() ) ) / DAY_IN_SECONDS );
-			
+
 				$data = array(
 					'environmentId' => 'clr0ply35522h8up0bay2de4y',
 					'attributes'    => array(
@@ -1288,26 +1288,26 @@ class Main {
 				return $data;
 			},
 			10,
-			2 
+			2
 		);
 	}
 
 	/**
 	 * Get the Black Friday config settings.
-	 * 
+	 *
 	 * @param array $default Optional. The default values.
-	 * 
+	 *
 	 * @return array The data.
 	 */
 	public static function get_black_friday_data( $default = array() ) {
 		$config = $default;
-		
+
 		$message   = __( 'Custom layouts, WooCommerce tools, starter sites. What you\'ve been doing manually, Neve Pro handles for you. Exclusively for existing Neve users.', 'neve' );
 		$cta_label = __( 'Get Neve Pro', 'neve' );
-		
+
 		$plan   = apply_filters( 'product_neve_license_plan', false );
 		$is_pro = 0 < $plan;
-		
+
 		$license_status      = apply_filters( 'product_neve_license_status', false );
 		$has_valid_license   = 'valid' === $license_status;
 		$has_expired_license = 'expired' === $license_status || 'active-expired' === $license_status;
@@ -1315,35 +1315,37 @@ class Main {
 		$neve_pro_product_slug = defined( 'NEVE_PRO_BASEFILE' ) ? basename( dirname( NEVE_PRO_BASEFILE ) ) : '';
 
 		if ( $has_valid_license ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'neve' ), '30%' );
 			// translators: %1$s - the discount percentage for the upgrade, %2$s - the discount percentage for the renewal.
 			$message   = sprintf( __( 'Upgrade your Neve Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'neve' ), '30%', '20%' );
 			$cta_label = __( 'See your options', 'neve' );
 		} elseif ( $has_expired_license ) {
-			$message   = __( 'Your Neve Pro features are still here, just locked. Renew at a reduced rate this week and pick up right where you left off.', 'neve' );
-			$cta_label = __( 'Reactivate now', 'neve' );
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'neve' ), '50%' );
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'neve' ), '50%' );
+			$message                     = __( 'Your Neve Pro features are still here, just locked. Renew at a reduced rate this week and pick up right where you left off.', 'neve' );
+			$cta_label                   = __( 'Reactivate now', 'neve' );
 		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'neve' ), '60%' );
+			// translators: %s is the discount percentage.
+			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'neve' ), '60%' );
 			// translators: %s - the discount percentage for the upgrade.
 			$config['title'] = sprintf( __( 'Neve Pro: %s off this week', 'neve' ), '60%' );
 		}
 
 		if ( $has_valid_license || $has_expired_license ) {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'neve' ), '30%' );
 			$config['plugin_meta_targets'] = array( $neve_pro_product_slug );
-		} else {
-			// translators: %s is the discount percentage.
-			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'neve' ), '60%' );
-
-			// translators: %s is the discount percentage.
-			$config['upgrade_menu_text'] = sprintf( __( 'BF Sale - %s off', 'neve' ), '60%' );
 		}
-		
+
 		$url_params = array(
 			'utm_term' => $is_pro ? 'plan-' . $plan : 'free',
 			'lkey'     => apply_filters( 'product_neve_license_key', false ),
 			'expired'  => $has_expired_license ? '1' : false,
 		);
-		
+
 		$config['message']   = $message;
 		$config['cta_label'] = $cta_label;
 		$config['sale_url']  = add_query_arg(
@@ -1356,9 +1358,9 @@ class Main {
 
 	/**
 	 * Add the Black Friday data.
-	 * 
+	 *
 	 * @param array $configs An array of configurations.
-	 * 
+	 *
 	 * @return array The configurations.
 	 */
 	public function add_black_friday_data( $configs ) {

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -1312,6 +1312,8 @@ class Main {
 		$has_valid_license   = 'valid' === $license_status;
 		$has_expired_license = 'expired' === $license_status || 'active-expired' === $license_status;
 
+		$neve_pro_product_slug = defined( 'NEVE_PRO_BASEFILE' ) ? basename( dirname( NEVE_PRO_BASEFILE ) ) : '';
+
 		if ( $has_valid_license ) {
 			// translators: %1$s - the discount percentage for the upgrade, %2$s - the discount percentage for the renewal.
 			$message   = sprintf( __( 'Upgrade your Neve Pro plan: %1$s off this week. Already on the plan you need? Renew early and save up to %2$s.', 'neve' ), '30%', '20%' );
@@ -1322,6 +1324,15 @@ class Main {
 		} else {
 			// translators: %s - the discount percentage for the upgrade.
 			$config['title'] = sprintf( __( 'Neve Pro: %s off this week', 'neve' ), '60%' );
+		}
+
+		if ( $has_valid_license || $has_expired_license ) {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - up to %s off', 'neve' ), '30%' );
+			$config['plugin_meta_targets'] = array( $neve_pro_product_slug );
+		} else {
+			// translators: %s is the discount percentage.
+			$config['plugin_meta_message'] = sprintf( __( 'Black Friday Sale - %s off', 'neve' ), '60%' );
 		}
 		
 		$url_params = array(

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -1310,7 +1310,7 @@ class Main {
 		
 		$license_status      = apply_filters( 'product_neve_license_status', false );
 		$has_valid_license   = 'valid' === $license_status;
-		$has_expired_license = 'expired' === $license_status || 'active_exired' === $license_status;
+		$has_expired_license = 'expired' === $license_status || 'active-expired' === $license_status;
 
 		if ( $has_valid_license ) {
 			// translators: %1$s - the discount percentage for the upgrade, %2$s - the discount percentage for the renewal.


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

Change the labels for Black Friday promotion. Based on https://github.com/Codeinwp/themeisle/issues/1854

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots <!-- if applicable -->

<img width="2212" height="1090" alt="CleanShot 2026-03-16 at 12 27 39@2x" src="https://github.com/user-attachments/assets/987512fa-2a39-4b02-9fe3-39c0718f4752" />

---

<img width="2220" height="1218" alt="CleanShot 2026-03-16 at 12 30 15@2x" src="https://github.com/user-attachments/assets/da1e2703-6ab7-44e0-90ca-01d7d092a93d" />

---

<img width="2180" height="300" alt="CleanShot 2026-03-16 at 12 31 31@2x" src="https://github.com/user-attachments/assets/8c63bade-79e8-4493-9b19-9e8503729de0" />


### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install this plugin: https://github.com/Soare-Robert-Daniel/test-black-friday
- Test:
  - If the notice appears during the Black Friday period.
  - If the labels change based on the license status (described in the spreadsheet)
  - If the notice can be dismissed.
  - If the notice appears only if the plugin is 3 days old. Warning: You will see the notice if you have another product that is older than 3 days; in this case, better to disable them.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1854
<!-- Should look like this: `Closes #1, #2, #3.` . -->
