### PR TITLE
Ensured compatibility with PPOM popup button

### DIFF
--- a/assets/scss/components/compat/woocommerce/_product.scss
+++ b/assets/scss/components/compat/woocommerce/_product.scss
@@ -84,6 +84,14 @@
 				margin: 0;
 			}
 		}
+
+		> .ppom-fieldspopup-btn-wrap {
+			width: 100%;
+
+			button {
+				width: 100%;
+			}
+		}
 	}
 
 	.group_table {


### PR DESCRIPTION
### Summary
Fixed the PPOM popup button width.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4019