### PR TITLE
feat: add Masteriyo as recommended plugin in dashboard

### DIFF
--- a/assets/apps/dashboard/src/utils/constants.js
+++ b/assets/apps/dashboard/src/utils/constants.js
@@ -68,6 +68,7 @@ export const NEVE_PLUGIN_ICON_MAP = {
 	'wp-cloudflare-page-cache': LucideTimer,
 	'feedzy-rss-feeds': LucideRss,
 	'hyve-lite': LucideBotMessageSquare,
+	'learning-management-system': LucideGraduationCap,
 	// 'sparks'
 };
 

--- a/inc/admin/dashboard/main.php
+++ b/inc/admin/dashboard/main.php
@@ -890,6 +890,10 @@ class Main {
 				'title'       => 'Feedzy',
 				'description' => __( 'RSS feeds aggregator and content curator', 'neve' ),
 			],
+			'learning-management-system'    => [
+				'title'       => 'Masteriyo',
+				'description' => __( 'LMS plugin to create and sell online courses', 'neve' ),
+			],
 		];
 
 		if ( is_php_version_compatible( '8.1' ) ) {

--- a/inc/admin/dashboard/plugin_helper.php
+++ b/inc/admin/dashboard/plugin_helper.php
@@ -56,6 +56,8 @@ class Plugin_Helper {
 				return $slug . '/wp-cloudflare-super-page-cache.php';
 			case 'wp-full-stripe-free':
 				return $slug . '/wp-full-stripe.php';
+			case 'learning-management-system':
+				return $slug . '/lms.php';
 			default:
 				return $slug . '/' . $slug . '.php';
 		}


### PR DESCRIPTION
Adds Masteriyo LMS (learning-management-system) to the Neve dashboard Recommended Plugins card, with a dedicated graduation-cap icon and a slug-to-path mapping since the plugin's main file is `lms.php`.

Closes #4490

### Summary
<!-- Please describe the changes you made. -->

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

- 
- 

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [ ] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [ ] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [ ] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [ ] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)

<!-- Issues that this pull request closes. -->
Closes #.
<!-- Should look like this: `Closes #1, #2, #3.` . -->
