### PR TITLE
feat: mobile mini-cart dropdown tap + per-unit max for responsive range

### DIFF
--- a/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
+++ b/assets/apps/customizer-controls/src/responsive-range/ResponsiveRangeComponent.js
@@ -36,7 +36,7 @@ const ResponsiveRangeComponent = ({ control }) => {
 	}, []);
 
 	const { label } = control.params;
-	const { hideResponsive, units, defaultVal, min, max } =
+	const { hideResponsive, units, defaultVal, min, max, unitsMax } =
 		control.params.input_attrs;
 
 	const suffixValue = () => {
@@ -57,6 +57,16 @@ const ResponsiveRangeComponent = ({ control }) => {
 	};
 
 	const isRelativeUnit = () => ['em', 'rem'].includes(suffixValue());
+
+	// Allow a different max per unit (e.g. 1200 for px but 100 for %).
+	const maxForUnit = (unit) => {
+		if (unitsMax && unit && unitsMax[unit] !== undefined) {
+			return unitsMax[unit];
+		}
+		return max || 100;
+	};
+
+	const currentMax = () => maxForUnit(suffixValue());
 
 	const unitButtons = () => {
 		if (!units) {
@@ -89,6 +99,12 @@ const ResponsiveRangeComponent = ({ control }) => {
 							nextValue[currentDevice] = parseInt(
 								nextValue[currentDevice]
 							);
+						}
+						// Clamp the value to the new unit's max (e.g. when
+						// switching from px to %, 600 becomes 100).
+						const unitMax = maxForUnit(unit);
+						if (nextValue[currentDevice] > unitMax) {
+							nextValue[currentDevice] = unitMax;
 						}
 						setValue(nextValue);
 						control.setting.set(JSON.stringify(nextValue));
@@ -134,7 +150,7 @@ const ResponsiveRangeComponent = ({ control }) => {
 				<RangeControl
 					value={displayValue}
 					min={min || 0}
-					max={max || 100}
+					max={currentMax()}
 					step={isRelativeUnit() ? 0.1 : 1}
 					allowReset
 					onChange={(nextValue) => {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -19,6 +19,7 @@ export const initNavigation = () => {
 	handleMobileDropdowns();
 	handleSearch();
 	handleMiniCartPosition();
+	handleMiniCartMobileToggle();
 	window.HFG.initSearch = function () {
 		handleSearch();
 		handleMobileDropdowns();
@@ -224,19 +225,95 @@ function handleSearch() {
  * Handle the mini cart position in nav.
  */
 function handleMiniCartPosition() {
-	const item = document.querySelector('.header--row .menu-item-nav-cart');
-	if (item === null) {
+	const items = document.querySelectorAll('.header--row .menu-item-nav-cart');
+	if (items.length === 0) {
 		return;
 	}
-	const miniCart = item.querySelector('.nv-nav-cart:not(.cart-off-canvas)');
 
-	if (miniCart !== null) {
-		miniCart.style.left =
-			item.getBoundingClientRect().left < 350 ? 0 : null;
-	}
+	const isMobile = window.matchMedia('(max-width: 959px)').matches;
+	const sideSpacing = 2 * 16;
+
+	items.forEach((item) => {
+		const miniCart = item.querySelector(
+			'.nv-nav-cart:not(.cart-off-canvas)'
+		);
+
+		if (miniCart === null) {
+			return;
+		}
+
+		miniCart.style.left = '';
+		miniCart.style.right = '';
+
+		if (isMobile) {
+			const cartWidth = Math.min(360, window.innerWidth - sideSpacing);
+			const itemOffset = item.getBoundingClientRect().left;
+
+			miniCart.style.width = `${cartWidth}px`;
+			miniCart.style.maxWidth = `calc(100vw - ${sideSpacing}px)`;
+			miniCart.style.left = `${
+				(window.innerWidth - cartWidth) / 2 - itemOffset
+			}px`;
+			miniCart.style.right = 'auto';
+			return;
+		}
+
+		miniCart.style.width = '';
+		miniCart.style.maxWidth = '';
+		miniCart.style.left = item.getBoundingClientRect().left < 350 ? 0 : '';
+	});
 }
 
 window.addEventListener('resize', handleMiniCartPosition);
+
+/**
+ * Toggle the dropdown mini cart on tap for mobile.
+ *
+ * On desktop the dropdown mini cart opens on hover. Touch devices have no
+ * hover, so without this the cart icon would just follow its link to the cart
+ * page. Below the laptop breakpoint we toggle a `cart-dropdown-open` class on
+ * tap instead; the dropdown's appearance is reused from the desktop styles
+ * (see the woocommerce nav-cart styles), so customers can preview the cart and
+ * keep shopping. It closes on a second tap or when tapping outside of it.
+ */
+function handleMiniCartMobileToggle() {
+	const carts = document.querySelectorAll('.responsive-nav-cart.dropdown');
+	if (carts.length === 0) {
+		return;
+	}
+
+	// Mirrors the $laptop (960px) breakpoint where the hover dropdown applies.
+	const isMobile = () => window.matchMedia('(max-width: 959px)').matches;
+
+	carts.forEach((cart) => {
+		const openButton = cart.querySelector('.cart-icon-wrapper');
+		if (openButton === null) {
+			return;
+		}
+		openButton.addEventListener('click', function (e) {
+			if (!isMobile() || cart.classList.contains('cart-is-empty')) {
+				return;
+			}
+			e.preventDefault();
+			cart.classList.toggle('cart-dropdown-open');
+		});
+	});
+
+	// Close an open dropdown when tapping outside of it.
+	document.addEventListener('click', function (e) {
+		if (!isMobile()) {
+			return;
+		}
+		carts.forEach((cart) => {
+			if (
+				cart.classList.contains('cart-dropdown-open') &&
+				!cart.contains(e.target)
+			) {
+				cart.classList.remove('cart-dropdown-open');
+			}
+		});
+	});
+}
 
 /**
  * Create an overlay to allow closing.

--- a/assets/scss/components/compat/woocommerce/_nav-cart.scss
+++ b/assets/scss/components/compat/woocommerce/_nav-cart.scss
@@ -165,6 +165,23 @@ $cart-width: 360px;
 	}
 }
 
+// Mobile: tapping the cart icon toggles `cart-dropdown-open` (see
+// navigation.js). The dropdown appearance is already defined above, so we only
+// need to reveal it here — reusing the same element and styles as the desktop.
+@media (max-width: 959px) {
+
+	.responsive-nav-cart.dropdown .nv-nav-cart:not(.cart-off-canvas) {
+		width: min(#{$cart-width}, calc(100vw - #{2 * $spacing-md}));
+		max-width: calc(100vw - #{2 * $spacing-md});
+	}
+
+	.responsive-nav-cart.dropdown.cart-dropdown-open .nv-nav-cart {
+		display: block;
+		opacity: 1;
+		visibility: visible;
+	}
+}
+
 @mixin nav-cart--laptop() {
 
 	.nv-nav-cart {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		{
 			"gzip": false,
 			"running": false,
-			"limit": "7 KB",
+			"limit": "8 KB",
 			"path": "assets/js/build/modern/frontend.js"
 		},
 		{


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

**Pro PR: https://github.com/Codeinwp/neve/pull/4512**

Addresses https://github.com/Codeinwp/neve-pro-addon/issues/3159 (mini-cart dropdown on mobile tap) and https://github.com/Codeinwp/neve-pro-addon/issues/3161(width support for the header search form).

#### Search form width (Pro + theme)
The header search form had no width control, so it always rendered at its intrinsic width and couldn't be stretched to dominate the header.

- Added a responsive Width control (field_width, px / %) on the Advanced Search Form.
- Added a Stretch to fill available space toggle (flex_grow).

#### Mobile mini-cart dropdown (theme)

On mobile the dropdown mini-cart was hidden and tapping the cart icon just navigated to the cart page. Now, below the 960px breakpoint, tapping toggles the dropdown preview so customers can review the cart and keep shopping.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES/NO

### Screenshots <!-- if applicable -->

### Test instructions
<!-- Describe how this pull request can be tested. -->

Requires Neve + Neve Pro + WooCommerce active. Hard-refresh / clear cache before testing so rebuilt assets load.

A. Search width (#3161) — Customize → Header → add Advanced Search Form → Style tab

- Controls present: new Width slider (with % / px unit buttons) and Stretch to fill available space toggle.
- Width px: switch to px, set ~600 → field widens live; slider allows up to 1200.
- Width %: switch to % → slider caps at 100; switching px→% clamps an out-of-range value (e.g. 600 → 100).
- Per-device: set different values on desktop/tablet/mobile tabs → each applies at its breakpoint.
- Stretch: toggle on (preview reloads) → field expands to fill its row.

B. Mobile mini-cart dropdown (#3159) — Cart Icon in header

- Tap to open: tap the cart icon → dropdown preview opens, page does not navigate.
- Tap to close: tap the icon again → closes.
- Outside tap: open, then tap outside the dropdown → closes.
I- nner actions: View cart / Checkout links navigate; removing a line item works via AJAX and the dropdown stays open.
- Empty cart: empty cart → tapping the icon follows the default link to the cart page (no empty popup).
- Desktop ≥960px: hover still opens the dropdown; clicking the icon still goes to the cart page (tap logic doesn't interfere).

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR (if you're not sure who to assign, we can do this step for you)
