### PR TITLE
fix: cache mega-menu-free is-active tracking beacon

### DIFF
--- a/inc/views/header.php
+++ b/inc/views/header.php
@@ -283,14 +283,26 @@ class Header extends Base_View {
 			}
 		}
 
-		Tracker::track(
-			array(
+		// Cache the active state and only send when it changes or the refresh window has elapsed.
+		// `wp_update_nav_menu` fires multiple times per save and the value is near-static per site,
+		// so sending unconditionally floods the tracking pipeline with duplicate readings.
+		$last  = get_option( 'neve_mm_active_state', null );
+		$now   = $has_mm ? 'yes' : 'no';
+		$stale = ! get_transient( 'neve_mm_tracked' );
+
+		if ( $now !== $last || $stale ) {
+			update_option( 'neve_mm_active_state', $now );
+			set_transient( 'neve_mm_tracked', 1, MONTH_IN_SECONDS );
+
+			Tracker::track(
 				array(
-					'feature'          => 'mega-menu-free',
-					'featureComponent' => 'is-active',
-					'featureValue'     => $has_mm,
-				),
-			)
-		);
+					array(
+						'feature'          => 'mega-menu-free',
+						'featureComponent' => 'is-active',
+						'featureValue'     => $has_mm,
+					),
+				)
+			);
+		}
 	}
 }


### PR DESCRIPTION
## Summary

The `mega-menu-free` / `is-active` tracking beacon in `inc/views/header.php` fired on **every** `wp_update_nav_menu` save. Because WordPress core triggers that hook multiple times per save and the value is near-static per site, the same reading (overwhelmingly `false`) was re-transmitted thousands of times — accounting for ~98% of all telemetry events, ~99% of them `false`.

This caches the active state and only sends the beacon when it actually changes or after a refresh window elapses.

## Changes

`track_mm_settings()` now:
- Stores the last reported active state in the `neve_mm_active_state` option (`'yes'`/`'no'`).
- Gates dispatch behind a `neve_mm_tracked` transient with a `MONTH_IN_SECONDS` TTL.
- Sends only when the state **changed** (`$now !== $last`) or the refresh window is **stale**.

The option is the durable value-of-record (must survive to detect changes); the transient is purely the time-based refresh gate (early eviction just means a slightly early refresh — harmless).

## Why this shape

Both `true` and `false` readings are still emitted, so free mega-menu penetration (~0.49% of sites) stays measurable — volume just drops from ~768k/yr to roughly one event per site per change/month.

## Acceptance criteria

- [x] `is-active` no longer fires on every menu save; one save ⇒ at most one tracking event.
- [x] Both `true` and `false` are still emitted, at most ~once per site per refresh window or on state change.
- [x] No same-minute bursts / per-item multiplier.
- [x] Free-mega-menu penetration is still derivable from the export.

Closes Codeinwp/neve-pro-addon#3201