### PR TITLE
Correct alignment styles

### DIFF
--- a/assets/scss/components/main/_gutenberg.scss
+++ b/assets/scss/components/main/_gutenberg.scss
@@ -45,13 +45,17 @@
 	margin-right: calc(50% - 49vw);
 }
 
-.nv-sidebar-left :is(.alignfull, .alignwide),
-.nv-sidebar-right :is(.alignfull, .alignwide),
-.wp-block-themeisle-blocks-advanced-column :is(.alignfull, .alignwide):not(.wp-block-columns) {
-	width: 100%;
-	max-width: 100%;
-	margin-left: auto;
-	margin-right: auto;
+.nv-sidebar-left,
+.nv-sidebar-right,
+.wp-block-themeisle-blocks-advanced-columns:not(.has-1-columns),
+.wp-block-columns:has(.alignfull, .alignwide) {
+
+	:is(.alignfull, .alignwide) {
+		width: 100%;
+		max-width: 100%;
+		margin-left: auto;
+		margin-right: auto;
+	}
 }
 
 // === Quotes === //


### PR DESCRIPTION
### Summary
Fixed the alignfull and alignwide styles for sidebars and nested Otter Section column or WP column blocks.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4531