### PR TITLE
fix: scope logo palette inline script to avoid global collisions

### DIFF
--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -248,8 +248,9 @@ class Logo extends Abstract_Component {
 		$variants_json = wp_json_encode( $variants );
 
 		$script = <<<JS
-	var html = document.documentElement;
-	var theme = html.getAttribute('data-neve-theme') || 'light';
+	;(function () {
+	var htmlEl = document.documentElement;
+	var theme = htmlEl.getAttribute('data-neve-theme') || 'light';
 	var variants = {$variants_json};
 
 	function setCurrentTheme( theme ) {
@@ -283,16 +284,18 @@ class Logo extends Abstract_Component {
 
 	var observer = new MutationObserver(function(mutations) {
 		mutations.forEach(function(mutation) {
-			if (mutation.type == 'attributes') {
-				theme = html.getAttribute('data-neve-theme');
+			if (mutation.type == 'attributes' && mutation.attributeName === 'data-neve-theme') {
+				theme = htmlEl.getAttribute('data-neve-theme');
 				setCurrentTheme(theme);
 			};
 		});
 	});
 
-	observer.observe(html, {
-		attributes: true
+	observer.observe(htmlEl, {
+		attributes: true,
+		attributeFilter: ['data-neve-theme']
 	});
+	})();
 JS;
 		return $script;
 	}

--- a/tests/js/logo-toggle-script.test.mjs
+++ b/tests/js/logo-toggle-script.test.mjs
@@ -1,0 +1,53 @@
+// Behavioral test for the Logo palette inline script (issue #4541).
+// Run: node tests/js/logo-toggle-script.test.mjs
+import { readFileSync } from 'fs';
+import { strict as assert } from 'assert';
+import { JSDOM, VirtualConsole } from 'jsdom';
+
+const php = readFileSync(new URL('../../header-footer-grid/Core/Components/Logo.php', import.meta.url), 'utf8');
+const js = php.match(/<<<JS\n([\s\S]*?)\nJS;/)[1].replace(
+	'{$variants_json}',
+	JSON.stringify({ logo: { same: false, light: { src: 'http://x/light.png', srcset: '', sizes: '' }, dark: { src: 'http://x/dark.png', srcset: '', sizes: '' } } })
+);
+
+function makePage() {
+	const errors = [];
+	const virtualConsole = new VirtualConsole();
+	virtualConsole.on('jsdomError', (e) => errors.push(e));
+	const dom = new JSDOM(
+		'<html><body><img class="neve-site-logo" data-variant="logo" src="http://x/light.png"></body></html>',
+		{ runScripts: 'outside-only', virtualConsole }
+	);
+	dom.window.eval(js);
+	return { window: dom.window, errors };
+}
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+// 1. No page globals leaked.
+{
+	const { window } = makePage();
+	assert.equal(window.html, undefined, 'script leaks global "html"');
+	assert.equal(window.setCurrentTheme, undefined, 'script leaks global "setCurrentTheme"');
+}
+
+// 2. Survives a clobbered window.html + unrelated root attribute change.
+{
+	const { window, errors } = makePage();
+	window.html = 'not-an-element';
+	window.document.documentElement.setAttribute('data-test', '1');
+	await tick();
+	assert.deepEqual(errors, [], `observer threw: ${errors[0]}`);
+}
+
+// 3. Still swaps the logo on data-neve-theme change (even after the clobber).
+{
+	const { window, errors } = makePage();
+	window.html = 'not-an-element';
+	window.document.documentElement.setAttribute('data-neve-theme', 'dark');
+	await tick();
+	assert.deepEqual(errors, [], `observer threw: ${errors[0]}`);
+	assert.equal(window.document.querySelector('.neve-site-logo').src, 'http://x/dark.png', 'logo did not swap to dark variant');
+}
+
+console.log('logo-toggle-script: all assertions passed');


### PR DESCRIPTION
Fixes #4541

## Summary
The logo palette inline script declared `var html` (and other variables) in the page's global scope and dereferenced it later in a MutationObserver callback. If any third-party script reassigned the global `html`, the callback threw `Uncaught TypeError: html.getAttribute is not a function` on the next attribute change on `<html>`.

## Changes
- Wrapped the inline script in an IIFE — no more page globals to collide with (`html` renamed to `htmlEl`; leading `;` guards against unsafe concatenation in `Script_Register`).
- Added `attributeFilter: ['data-neve-theme']` so the observer only fires for the attribute it cares about, instead of every mutation on the root element.

No behavior change otherwise: palette-based logo swapping works exactly as before.
