### PR TITLE
Handled empty value

### DIFF
--- a/inc/core/styles/dynamic_selector.php
+++ b/inc/core/styles/dynamic_selector.php
@@ -29,6 +29,7 @@ class Dynamic_Selector {
 	const META_DEVICE_ONLY      = 'device_only';
 	const META_FILTER           = 'filter';
 	const META_AS_JSON          = 'as_json';
+	const META_IS_EMPTY         = 'is_empty';
 
 	const KEY_SELECTOR = 'selectors';
 	const KEY_RULES    = 'rules';
@@ -174,6 +175,10 @@ class Dynamic_Selector {
 		$default = isset( $meta[ self::META_DEFAULT ] ) ? $meta[ self::META_DEFAULT ] : false;
 		$value   = Mods::get( $key, $default );
 
+		// Only check whether the value is empty when the meta has the is_empty flag set to true.
+		if ( isset( $meta[ self::META_IS_EMPTY ] ) && $meta[ self::META_IS_EMPTY ] && empty( $value ) ) {
+			return $default;
+		}
 
 		if ( $value === false || $value === null || $value === '' ) {
 			return $default;


### PR DESCRIPTION
### Summary
Added a flag `is_empty` to the dynamic selector meta, which allows us to check if a value is empty and return the default value instead of an empty value.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR (No need to add a test here. Just handle the empty value check condition.)
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Part of https://github.com/Codeinwp/neve-pro-addon/issues/3221