### PR TITLE
Protected registered meta keys in block editor sidebar

### DIFF
--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -39,9 +39,9 @@ final class Manager {
 	private $control_classes;
 
 	/**
-	 * Meta keys registered for the block editor sidebar.
+	 * Meta keys registered for the block editor sidebar, keyed by meta key.
 	 *
-	 * @var array<string>
+	 * @var array<string, bool>
 	 */
 	private $registered_meta_keys = array();
 
@@ -60,7 +60,7 @@ final class Manager {
 		 */
 		add_action( 'init', array( $this, 'neve_register_meta' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'meta_sidebar_script_enqueue' ) );
-		add_filter( 'is_protected_meta', array( $this, 'protect_sidebar_meta' ), 10, 2 );
+		add_filter( 'is_protected_meta', array( $this, 'protect_post_sidebar_meta' ), 10, 3 );
 	}
 
 	/**
@@ -340,7 +340,7 @@ final class Manager {
 				$meta_settings
 			);
 
-			$this->registered_meta_keys[] = $control['id'];
+			$this->registered_meta_keys[ $control['id'] ] = true;
 		}
 	}
 
@@ -349,11 +349,16 @@ final class Manager {
 	 *
 	 * @param bool   $is_protected whether the key is protected.
 	 * @param string $meta_key the meta key.
+	 * @param string $meta_type the type of meta object this key belongs to.
 	 *
 	 * @return bool
 	 */
-	public function protect_sidebar_meta( $is_protected, $meta_key ) {
-		if ( in_array( $meta_key, $this->registered_meta_keys, true ) ) {
+	public function protect_post_sidebar_meta( $is_protected, $meta_key, $meta_type ) {
+		if (
+			$meta_type === 'post' &&
+			isset( $this->registered_meta_keys[ $meta_key ] ) &&
+			$this->registered_meta_keys[ $meta_key ]
+			) {
 			return true;
 		}
 

--- a/inc/admin/metabox/manager.php
+++ b/inc/admin/metabox/manager.php
@@ -39,6 +39,13 @@ final class Manager {
 	private $control_classes;
 
 	/**
+	 * Meta keys registered for the block editor sidebar.
+	 *
+	 * @var array<string>
+	 */
+	private $registered_meta_keys = array();
+
+	/**
 	 * Init function
 	 */
 	public function init() {
@@ -53,6 +60,7 @@ final class Manager {
 		 */
 		add_action( 'init', array( $this, 'neve_register_meta' ) );
 		add_action( 'enqueue_block_editor_assets', array( $this, 'meta_sidebar_script_enqueue' ) );
+		add_filter( 'is_protected_meta', array( $this, 'protect_sidebar_meta' ), 10, 2 );
 	}
 
 	/**
@@ -331,7 +339,25 @@ final class Manager {
 				$control['id'],
 				$meta_settings
 			);
+
+			$this->registered_meta_keys[] = $control['id'];
 		}
+	}
+
+	/**
+	 * Mark the meta data as protected.
+	 *
+	 * @param bool   $is_protected whether the key is protected.
+	 * @param string $meta_key the meta key.
+	 *
+	 * @return bool
+	 */
+	public function protect_sidebar_meta( $is_protected, $meta_key ) {
+		if ( in_array( $meta_key, $this->registered_meta_keys, true ) ) {
+			return true;
+		}
+
+		return $is_protected;
 	}
 
 	/**

--- a/tests/test-neve-metabox-meta.php
+++ b/tests/test-neve-metabox-meta.php
@@ -18,6 +18,13 @@ class TestNeveMetaboxMeta extends WP_UnitTestCase {
 	private $page_id;
 
 	/**
+	 * REST server in place before the test replaced it.
+	 *
+	 * @var WP_REST_Server|null
+	 */
+	private $previous_rest_server;
+
+	/**
 	 * Setup.
 	 */
 	public function setUp(): void {
@@ -26,6 +33,8 @@ class TestNeveMetaboxMeta extends WP_UnitTestCase {
 		global $wp_rest_server;
 
 		require_once ABSPATH . 'wp-admin/includes/post.php';
+
+		$this->previous_rest_server = $wp_rest_server;
 
 		// The test case unregisters every meta key on teardown.
 		$manager = new \Neve\Admin\Metabox\Manager();
@@ -53,7 +62,7 @@ class TestNeveMetaboxMeta extends WP_UnitTestCase {
 	public function tearDown(): void {
 		global $wp_rest_server;
 
-		$wp_rest_server = null;
+		$wp_rest_server = $this->previous_rest_server;
 		$_POST          = array();
 
 		parent::tearDown();

--- a/tests/test-neve-metabox-meta.php
+++ b/tests/test-neve-metabox-meta.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the block editor sidebar meta save flow.
+ *
+ * @package neve
+ */
+
+/**
+ * Class TestNeveMetaboxMeta
+ */
+class TestNeveMetaboxMeta extends WP_UnitTestCase {
+
+	/**
+	 * Page used in the save flow.
+	 *
+	 * @var int
+	 */
+	private $page_id;
+
+	/**
+	 * Setup.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		require_once ABSPATH . 'wp-admin/includes/post.php';
+
+		// The test case unregisters every meta key on teardown.
+		$manager = new \Neve\Admin\Metabox\Manager();
+		$manager->neve_register_meta();
+
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init', $wp_rest_server );
+
+		wp_set_current_user( self::factory()->user->create( array( 'role' => 'administrator' ) ) );
+
+		$this->page_id = self::factory()->post->create(
+			array(
+				'post_type'   => 'page',
+				'post_title'  => 'Neve meta page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$_POST = array();
+	}
+
+	/**
+	 * Teardown.
+	 */
+	public function tearDown(): void {
+		global $wp_rest_server;
+
+		$wp_rest_server = null;
+		$_POST          = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Save the sidebar meta the way the editor sidebar does, over the REST API.
+	 *
+	 * @param string $value the value to save.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function rest_save_sidebar_meta( $value ) {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/pages/' . $this->page_id );
+		$request->set_body_params( array( 'meta' => array( 'neve_meta_sidebar' => $value ) ) );
+
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * Submit the meta box form the way post.php does when the editor saves meta boxes.
+	 *
+	 * @param array $meta meta id => [ key, value ] pairs, as rendered by the Custom Fields box.
+	 */
+	private function submit_meta_boxes( $meta ) {
+		$_POST = array(
+			'post_ID'     => $this->page_id,
+			'post_type'   => 'page',
+			'post_title'  => 'Neve meta page',
+			'post_status' => 'publish',
+			'meta'        => $meta,
+		);
+
+		edit_post();
+
+		$_POST = array();
+	}
+
+	/**
+	 * The value picked in the Neve sidebar is saved over REST.
+	 */
+	public function test_sidebar_meta_is_saved_over_rest() {
+		$response = $this->rest_save_sidebar_meta( 'full-width' );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'full-width', get_post_meta( $this->page_id, 'neve_meta_sidebar', true ) );
+	}
+
+	/**
+	 * With the Custom Fields panel on, the meta box form is submitted right after the REST save.
+	 *
+	 * It carries the key/value pairs rendered when the editor was loaded, so the stale value
+	 * must not be written back over the one just saved from the sidebar.
+	 */
+	public function test_custom_fields_submit_does_not_revert_sidebar_meta() {
+		update_post_meta( $this->page_id, 'neve_meta_sidebar', 'default' );
+
+		$meta_id = $this->get_meta_id( 'neve_meta_sidebar' );
+
+		$this->rest_save_sidebar_meta( 'full-width' );
+		$this->assertEquals( 'full-width', get_post_meta( $this->page_id, 'neve_meta_sidebar', true ) );
+
+		// The Custom Fields box submits the value loaded with the page.
+		$this->submit_meta_boxes(
+			array(
+				$meta_id => array(
+					'key'   => 'neve_meta_sidebar',
+					'value' => 'default',
+				),
+			)
+		);
+
+		$this->assertEquals( 'full-width', get_post_meta( $this->page_id, 'neve_meta_sidebar', true ) );
+	}
+
+	/**
+	 * Meta that is not ours still goes through the Custom Fields panel.
+	 */
+	public function test_custom_fields_submit_still_updates_other_meta() {
+		update_post_meta( $this->page_id, 'some_other_key', 'first' );
+
+		$this->submit_meta_boxes(
+			array(
+				$this->get_meta_id( 'some_other_key' ) => array(
+					'key'   => 'some_other_key',
+					'value' => 'second',
+				),
+			)
+		);
+
+		$this->assertEquals( 'second', get_post_meta( $this->page_id, 'some_other_key', true ) );
+	}
+
+	/**
+	 * Get the meta id for a key on the test page.
+	 *
+	 * @param string $key the meta key.
+	 *
+	 * @return int
+	 */
+	private function get_meta_id( $key ) {
+		global $wpdb;
+
+		return (int) $wpdb->get_var(
+			$wpdb->prepare( "SELECT meta_id FROM $wpdb->postmeta WHERE post_id = %d AND meta_key = %s", $this->page_id, $key )
+		);
+	}
+}


### PR DESCRIPTION
### Summary
Protected meta keys are not shown in the Custom Fields panel, which would otherwise overwrite the values saved from the Neve sidebar with the ones loaded with the page.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4574