### PR TITLE
Checked walker class existence

### DIFF
--- a/header-footer-grid/templates/components/component-nav-secondary.php
+++ b/header-footer-grid/templates/components/component-nav-secondary.php
@@ -36,7 +36,7 @@ $menu_id = SecondNav::COMPONENT_ID . '-' . $device_class . '-' . current_row( He
 				'fallback_cb'    => '__return_false',
 				'before'         => '<div class="wrap">',
 				'after'          => '</div>',
-				'walker'         => '\Neve\Views\Secondary_Nav_Walker',
+				'walker'         => class_exists( '\Neve\Views\Secondary_Nav_Walker' ) ? '\Neve\Views\Secondary_Nav_Walker' : '',
 			)
 		);
 		?>

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -38,8 +38,8 @@ $menu_id = Nav::NAV_MENU_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 				'component_id'   => $_id,
 				'menu_class'     => 'primary-menu-ul nav-ul' . $additional_menu_class,
 				'container'      => 'ul',
-				'walker'         => '\Neve\Views\Nav_Walker',
-				'fallback_cb'    => '\Neve\Views\Nav_Walker::fallback',
+				'walker'         => class_exists( '\Neve\Views\Nav_Walker' ) ? '\Neve\Views\Nav_Walker' : '',
+				'fallback_cb'    => class_exists( '\Neve\Views\Nav_Walker' ) ? '\Neve\Views\Nav_Walker::fallback' : '',
 				'echo'           => false,
 			]
 		);

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -31,6 +31,7 @@ $menu_id = Nav::NAV_MENU_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 			aria-label="<?php esc_attr_e( 'Primary Menu', 'neve' ); ?>">
 
 		<?php
+		$has_nav_walker = class_exists( '\Neve\Views\Nav_Walker' );
 		echo wp_nav_menu(
 			[
 				'theme_location' => 'primary',
@@ -38,8 +39,8 @@ $menu_id = Nav::NAV_MENU_ID . '-' . current_row( HeaderBuilder::BUILDER_NAME );
 				'component_id'   => $_id,
 				'menu_class'     => 'primary-menu-ul nav-ul' . $additional_menu_class,
 				'container'      => 'ul',
-				'walker'         => class_exists( '\Neve\Views\Nav_Walker' ) ? '\Neve\Views\Nav_Walker' : '',
-				'fallback_cb'    => class_exists( '\Neve\Views\Nav_Walker' ) ? '\Neve\Views\Nav_Walker::fallback' : '',
+				'walker'         => $has_nav_walker ? '\Neve\Views\Nav_Walker' : '',
+				'fallback_cb'    => $has_nav_walker ? '\Neve\Views\Nav_Walker::fallback' : 'wp_page_menu',
 				'echo'           => false,
 			]
 		);

--- a/inc/views/secondary_nav_walker.php
+++ b/inc/views/secondary_nav_walker.php
@@ -12,6 +12,9 @@ namespace Neve\Views;
 
 // Bail when the parent walker file is missing, so extending it cannot fatal.
 if ( ! class_exists( 'Neve\Views\Nav_Walker' ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( 'Secondary_Nav_Walker could not be loaded because Neve\Views\Nav_Walker is not available.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+	}
 	return;
 }
 

--- a/inc/views/secondary_nav_walker.php
+++ b/inc/views/secondary_nav_walker.php
@@ -12,9 +12,6 @@ namespace Neve\Views;
 
 // Bail when the parent walker file is missing, so extending it cannot fatal.
 if ( ! class_exists( 'Neve\Views\Nav_Walker' ) ) {
-	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-		error_log( 'Secondary_Nav_Walker could not be loaded because Neve\Views\Nav_Walker is not available.' ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
-	}
 	return;
 }
 

--- a/inc/views/secondary_nav_walker.php
+++ b/inc/views/secondary_nav_walker.php
@@ -10,6 +10,11 @@
 
 namespace Neve\Views;
 
+// Bail when the parent walker file is missing, so extending it cannot fatal.
+if ( ! class_exists( 'Neve\Views\Nav_Walker' ) ) {
+	return;
+}
+
 /**
  * Class Secondary_Nav_Walker
  *


### PR DESCRIPTION
### Summary
Added a guard to check if the walker class exists before using it in the nav components. This prevents fatal errors if the walker class is missing.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4579

## Why no test
The autoloader test case is already present and verifies that all classes are loaded correctly, returning `false` if a class does not exist. However, the Walker class is called directly from core files, so a missing class would result in a fatal error. Therefore, I added a guard to check whether the class exists before using it.
