### PR TITLE
Restored mobile cart after AJAX updates

### DIFF
--- a/header-footer-grid/Core/Components/CartIcon.php
+++ b/header-footer-grid/Core/Components/CartIcon.php
@@ -108,9 +108,11 @@ class CartIcon extends Abstract_Component {
 		return '
 			(function($){
 				$(\'body\').on( \'added_to_cart\', function(){
-					var responsiveCart = document.querySelector( \'.responsive-nav-cart\' );
-					if ( responsiveCart ) {
-						responsiveCart.classList.remove(\'cart-is-empty\');
+					var responsiveCart = document.querySelectorAll( \'.responsive-nav-cart\' );
+					if ( responsiveCart.length ) {
+						responsiveCart.forEach(function(cart) {
+							cart.classList.remove(\'cart-is-empty\');
+						});
 					}
 				});
 			})(jQuery);


### PR DESCRIPTION
### Summary
Selected all the responsive nav cart elements and removed the `cart-is-empty` class from all of them when an item is added to the cart.

## Check before Pull Request is ready:

* [ ] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve-pro-addon/issues/3242

## Why no test was added
The change removes a class from the responsive nav cart when an item is added to the cart. Since Neve Pro triggers the add-to-cart AJAX event, it is not possible to test this in the Neve theme repository.