### PR TITLE
Improved dropdown positioning

### DIFF
--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -33,40 +33,46 @@ export const repositionDropdowns = () => {
 		'.sub-menu, .minimal .nv-nav-search'
 	);
 
-	if (dropDowns.length === 0) return;
+	if (!dropDowns.length) return;
 
 	const windowWidth = window.innerWidth;
 
+	// How far a dropdown runs past the viewport: negative past the left edge,
+	// positive past the right edge, zero when it fits.
+	const getOverflow = (bounding) => {
+		if (bounding.left < 0) {
+			return bounding.left;
+		}
+
+		return bounding.right > windowWidth ? bounding.right - windowWidth : 0;
+	};
+
 	dropDowns.forEach((dropDown) => {
 		const style = dropDown.style;
-		// Nested flyouts open sideways, first level dropdowns open under the parent item.
-		const edge = dropDown.matches('.sub-menu .sub-menu') ? '100%' : 0;
-		let bounding = dropDown.getBoundingClientRect();
 
-		if (bounding.left < 0) {
-			// Overflows the left edge, so open towards the right.
-			style.left = edge;
-			style.right = 'auto';
-		} else if (bounding.right >= windowWidth) {
-			// Overflows the right edge, so open towards the left.
-			style.right = edge;
-			style.left = 'auto';
+		// Drop what an earlier pass applied, so the dropdown is measured where
+		// the stylesheet puts it and stale offsets do not pile up.
+		style.right = style.left = style.transform = '';
+
+		let overflow = getOverflow(dropDown.getBoundingClientRect());
+
+		if (!overflow) {
+			return;
 		}
 
-		// Recalculate bounding after we've made adjustments.
-		bounding = dropDown.getBoundingClientRect();
+		const edge = dropDown.matches('.sub-menu .sub-menu') ? '100%' : '0px';
+
+		style.right = overflow < 0 ? 'auto' : edge;
+		style.left = overflow < 0 ? edge : 'auto';
 
 		// Wider than the space on the side it opens towards, offset it to fit.
-		let offset = 0;
+		overflow = getOverflow(dropDown.getBoundingClientRect());
 
-		if (bounding.left < 0) {
-			offset = 20 - bounding.left;
-		} else if (bounding.right >= windowWidth) {
-			offset = windowWidth - bounding.right - 20;
-		}
-
-		if (offset) {
-			style.transform = 'translateX(' + offset + 'px)';
+		if (overflow) {
+			style.transform =
+				'translateX(' +
+				(overflow < 0 ? 20 - overflow : -overflow - 20) +
+				'px)';
 		}
 	});
 	if (typeof menuCalcEvent !== 'undefined') {

--- a/assets/js/src/frontend/navigation.js
+++ b/assets/js/src/frontend/navigation.js
@@ -1,4 +1,4 @@
-/* global NeveProperties menuCalcEvent CustomEvent */
+/* global menuCalcEvent CustomEvent */
 /* jshint esversion: 6 */
 import {
 	toggleClass,
@@ -29,7 +29,6 @@ export const initNavigation = () => {
  * Reposition drop downs in case they go off screen.
  */
 export const repositionDropdowns = () => {
-	const { isRTL } = NeveProperties;
 	const dropDowns = document.querySelectorAll(
 		'.sub-menu, .minimal .nv-nav-search'
 	);
@@ -39,30 +38,35 @@ export const repositionDropdowns = () => {
 	const windowWidth = window.innerWidth;
 
 	dropDowns.forEach((dropDown) => {
-		let bounding = dropDown.getBoundingClientRect(),
-			rightDist = bounding.left;
+		const style = dropDown.style;
+		// Nested flyouts open sideways, first level dropdowns open under the parent item.
+		const edge = dropDown.matches('.sub-menu .sub-menu') ? '100%' : 0;
+		let bounding = dropDown.getBoundingClientRect();
 
-		if (rightDist < 0) {
-			dropDown.style.right = isRTL ? '-100%' : 'auto';
-			dropDown.style.left = isRTL ? 'auto' : 0;
-		}
-
-		if (rightDist + bounding.width >= windowWidth) {
-			dropDown.style.right = isRTL ? 0 : '100%';
-			dropDown.style.left = 'auto';
+		if (bounding.left < 0) {
+			// Overflows the left edge, so open towards the right.
+			style.left = edge;
+			style.right = 'auto';
+		} else if (bounding.right >= windowWidth) {
+			// Overflows the right edge, so open towards the left.
+			style.right = edge;
+			style.left = 'auto';
 		}
 
 		// Recalculate bounding after we've made adjustments.
 		bounding = dropDown.getBoundingClientRect();
-		rightDist = bounding.left;
 
-		if (rightDist < 0 || rightDist + bounding.width >= windowWidth) {
-			// Calculate how much should we offset the dropdown to make it fit.
-			dropDown.style.transform =
-				'translateX(' +
-				(isRTL ? '-' : '') +
-				(Math.abs(rightDist) + 20) +
-				'px)';
+		// Wider than the space on the side it opens towards, offset it to fit.
+		let offset = 0;
+
+		if (bounding.left < 0) {
+			offset = 20 - bounding.left;
+		} else if (bounding.right >= windowWidth) {
+			offset = windowWidth - bounding.right - 20;
+		}
+
+		if (offset) {
+			style.transform = 'translateX(' + offset + 'px)';
 		}
 	});
 	if (typeof menuCalcEvent !== 'undefined') {

--- a/e2e-tests/fixtures/customizer/hfg/submenu-viewport-setup.json
+++ b/e2e-tests/fixtures/customizer/hfg/submenu-viewport-setup.json
@@ -1,0 +1,7 @@
+{
+    "neve_migrated_hfg_colors": true,
+    "ti_prev_theme": "twentytwentyone",
+    "neve_ran_migrations": true,
+    "neve_container_width": "{\"mobile\":748,\"tablet\":992,\"desktop\":2000,\"suffix\":{\"mobile\":\"px\",\"tablet\":\"px\",\"desktop\":\"px\"}}",
+    "hfg_header_layout_v2": "{\"desktop\":{\"top\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"main\":{\"left\":[{\"id\":\"logo\"}],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[{\"id\":\"primary-menu\"}]},\"bottom\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]}},\"mobile\":{\"top\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"main\":{\"left\":[{\"id\":\"logo\"}],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[{\"id\":\"nav-icon\"}]},\"bottom\":{\"left\":[],\"c-left\":[],\"center\":[],\"c-right\":[],\"right\":[]},\"sidebar\":[{\"id\":\"primary-menu\"}]}}"
+}

--- a/e2e-tests/specs/customizer/hfg/hfg-submenu-viewport.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-submenu-viewport.spec.ts
@@ -48,6 +48,14 @@ const getInlineStyles = async (page: Page, selector: string) => {
 	}, selector);
 };
 
+const reposition = async (page: Page) => {
+	await page.setViewportSize({
+		width: VIEWPORT.width - 1,
+		height: VIEWPORT.height,
+	});
+	await page.setViewportSize(VIEWPORT);
+};
+
 const getBox = async (page: Page, selector: string) => {
 	return await page.evaluate((element: string) => {
 		const node = document.querySelector(element);
@@ -145,13 +153,13 @@ test.describe('Submenu viewport repositioning', function () {
 			VIEWPORT.width
 		);
 
-		// The resize handler repositions the dropdowns, debounced by 500ms.
-		await page.setViewportSize({
-			width: VIEWPORT.width - 1,
-			height: VIEWPORT.height,
-		});
-		await page.setViewportSize(VIEWPORT);
-		await page.waitForTimeout(1000);
+		await reposition(page);
+		await page.waitForFunction((selector) => {
+			const dropdown = document.querySelector(
+				selector
+			) as HTMLElement | null;
+			return dropdown !== null && dropdown.style.right !== '';
+		}, LAST_ITEM + ' > .sub-menu');
 	});
 
 	test('Keeps the hovered dropdown under its parent item', async ({

--- a/e2e-tests/specs/customizer/hfg/hfg-submenu-viewport.spec.ts
+++ b/e2e-tests/specs/customizer/hfg/hfg-submenu-viewport.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect, APIRequestContext, Page } from '@playwright/test';
+import { setCustomizeSettings } from '../../../utils';
+import data from '../../../fixtures/customizer/hfg/submenu-viewport-setup.json';
+
+const VIEWPORT = { width: 1280, height: 900 };
+const TEST_NAME = 'hfgSubmenuViewport';
+const MENU_NAME = 'Submenu Viewport Test';
+
+// Only the last item has a submenu, so the dropdown opens at the right edge of
+// the viewport.
+const ITEMS = ['Home', 'Blog', 'About', 'Team', 'Services'];
+const CHILDREN = ['Consulting', 'Support'];
+const GRANDCHILD = 'Strategy';
+
+/**
+ * Neve Pro publishes the submenu alignment control as `right: var(--alignment)`,
+ * with `auto` for the Left option. Replicated here, since the control lives in
+ * the Pro plugin.
+ */
+const LEFT_ALIGNED_DROPDOWNS = '.nav-ul > li > .sub-menu { right: auto; }';
+const LAST_ITEM = '.header--row .nv-nav-wrap .nav-ul > li:last-child';
+
+type Menu = { id: number; locations: string[] };
+
+const restURL = (baseURL: string | undefined, path: string) =>
+	`${baseURL ?? ''}/wp-json/wp/v2/${path}`;
+
+const post = async (
+	request: APIRequestContext,
+	baseURL: string | undefined,
+	path: string,
+	body: Record<string, unknown>
+) => {
+	const response = await request.post(restURL(baseURL, path), { data: body });
+	expect(response.ok()).toBeTruthy();
+	return await response.json();
+};
+
+// The inline styles the reposition logic writes on a submenu.
+const getInlineStyles = async (page: Page, selector: string) => {
+	return await page.evaluate((subMenu: string) => {
+		const element = document.querySelector(subMenu);
+		if (!(element instanceof HTMLElement)) {
+			throw new Error(`Missing element: ${subMenu}`);
+		}
+		const { right, left, transform } = element.style;
+		return { right, left, transform };
+	}, selector);
+};
+
+const getBox = async (page: Page, selector: string) => {
+	return await page.evaluate((element: string) => {
+		const node = document.querySelector(element);
+		if (!node) {
+			throw new Error(`Missing element: ${element}`);
+		}
+		const { left, right, top, bottom, width, height } =
+			node.getBoundingClientRect();
+		return { left, right, top, bottom, width, height };
+	}, selector);
+};
+
+test.describe('Submenu viewport repositioning', function () {
+	test.describe.configure({ mode: 'serial' });
+	test.use({ viewport: VIEWPORT });
+
+	let menuId = 0;
+	let previousMenuId: number | undefined;
+
+	test.beforeAll(async ({ request, baseURL }) => {
+		const menus: Menu[] = await request
+			.get(restURL(baseURL, 'menus?per_page=100'))
+			.then((response) => response.json());
+		previousMenuId = menus.find((menu) =>
+			menu.locations.includes('primary')
+		)?.id;
+
+		const menu = await post(request, baseURL, 'menus', {
+			name: MENU_NAME,
+			locations: ['primary'],
+		});
+		menuId = menu.id;
+
+		let lastItemId = 0;
+		for (const title of ITEMS) {
+			const item = await post(request, baseURL, 'menu-items', {
+				title,
+				url: '#',
+				menus: menuId,
+				status: 'publish',
+			});
+			lastItemId = item.id;
+		}
+
+		let firstChildId = 0;
+		for (const title of CHILDREN) {
+			const child = await post(request, baseURL, 'menu-items', {
+				title,
+				url: '#',
+				menus: menuId,
+				status: 'publish',
+				parent: lastItemId,
+			});
+			firstChildId = firstChildId || child.id;
+		}
+
+		await post(request, baseURL, 'menu-items', {
+			title: GRANDCHILD,
+			url: '#',
+			menus: menuId,
+			status: 'publish',
+			parent: firstChildId,
+		});
+
+		// After the menu is in place: the settings endpoint snapshots the menu
+		// locations, and serves that snapshot back for `test_name` requests.
+		await setCustomizeSettings(TEST_NAME, data, { request, baseURL });
+	});
+
+	test.afterAll(async ({ request, baseURL }) => {
+		await request.delete(restURL(baseURL, `menus/${menuId}?force=true`));
+		if (previousMenuId) {
+			await post(request, baseURL, `menus/${previousMenuId}`, {
+				locations: ['primary'],
+			});
+		}
+	});
+
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/?test_name=' + TEST_NAME);
+
+		const parent = page.locator(LAST_ITEM);
+		await expect(parent).toHaveClass(/menu-item-has-children/);
+		await expect(parent).toContainText(ITEMS[ITEMS.length - 1]);
+
+		// With the container at its maximum width and the menu on the right,
+		// the last item sits at the right edge of the viewport.
+		const parentBox = await getBox(page, LAST_ITEM);
+		expect(VIEWPORT.width - parentBox.right).toBeLessThan(60);
+
+		await page.addStyleTag({ content: LEFT_ALIGNED_DROPDOWNS });
+		// Left aligned, the dropdown does not fit next to its parent item.
+		const dropdownBox = await getBox(page, LAST_ITEM + ' > .sub-menu');
+		expect(parentBox.left + dropdownBox.width).toBeGreaterThan(
+			VIEWPORT.width
+		);
+
+		// The resize handler repositions the dropdowns, debounced by 500ms.
+		await page.setViewportSize({
+			width: VIEWPORT.width - 1,
+			height: VIEWPORT.height,
+		});
+		await page.setViewportSize(VIEWPORT);
+		await page.waitForTimeout(1000);
+	});
+
+	test('Keeps the hovered dropdown under its parent item', async ({
+		page,
+	}) => {
+		const parentItem = page.locator(LAST_ITEM);
+		const dropdown = page.locator(LAST_ITEM + ' > .sub-menu');
+
+		await parentItem.hover();
+		await expect(dropdown).toBeVisible();
+
+		const parentBox = await getBox(page, LAST_ITEM);
+		const dropdownBox = await getBox(page, LAST_ITEM + ' > .sub-menu');
+
+		// The pointer rests in the middle of the parent item, and the dropdown
+		// starts right below it - no gap to cross on the way down to it.
+		const pointer = parentBox.left + parentBox.width / 2;
+		expect(pointer).toBeGreaterThan(dropdownBox.left);
+		expect(pointer).toBeLessThan(dropdownBox.right);
+		expect(Math.abs(dropdownBox.top - parentBox.bottom)).toBeLessThan(2);
+		expect(dropdownBox.left).toBeGreaterThanOrEqual(0);
+		expect(dropdownBox.right).toBeLessThanOrEqual(VIEWPORT.width);
+
+		// Aligned to the parent item instead of moved next to it.
+		expect(await getInlineStyles(page, LAST_ITEM + ' > .sub-menu')).toEqual(
+			{
+				right: '0px',
+				left: 'auto',
+				transform: '',
+			}
+		);
+	});
+
+	test('Flips the hovered flyout to the side of its parent item', async ({
+		page,
+	}) => {
+		const flyoutParentSelector =
+			LAST_ITEM + ' > .sub-menu > li:first-child';
+		const flyoutSelector = flyoutParentSelector + ' > .sub-menu';
+		const flyoutParentItem = page.locator(flyoutParentSelector);
+		const flyout = page.locator(flyoutSelector);
+
+		await page.locator(LAST_ITEM).hover();
+		await flyoutParentItem.hover();
+		await expect(flyout).toBeVisible();
+
+		const flyoutParentBox = await getBox(page, flyoutParentSelector);
+		const flyoutBox = await getBox(page, flyoutSelector);
+
+		// The pointer rests in the middle of the flyout parent item, and the
+		// flyout touches its left edge at the same height - no gap sideways.
+		const pointer = flyoutParentBox.top + flyoutParentBox.height / 2;
+		expect(pointer).toBeGreaterThan(flyoutBox.top);
+		expect(pointer).toBeLessThan(flyoutBox.bottom);
+		expect(Math.abs(flyoutParentBox.left - flyoutBox.right)).toBeLessThan(
+			2
+		);
+		expect(flyoutBox.left).toBeGreaterThanOrEqual(0);
+		expect(flyoutBox.right).toBeLessThanOrEqual(VIEWPORT.width);
+
+		expect(await getInlineStyles(page, flyoutSelector)).toEqual({
+			right: '100%',
+			left: 'auto',
+			transform: '',
+		});
+	});
+});


### PR DESCRIPTION
### Summary
Refactored the dropdown repositioning logic to use bounding box calculations and CSS properties (`left`, `right`, and `transform`) to ensure dropdowns are always visible within the viewport, regardless of text direction. The logic now checks for left and right overflows and adjusts positioning accordingly, including handling nested flyouts.

### Test instructions
- Create a menu with a submenu, set it as the primary menu, and place it in the right-side header grid.
- Set the container width to maximum
- Align the submenu container to the left in the primary menu layout setting.
- Verify the submenu is aligned correctly without any extra gap.
- Verify the same behavior for RTL also.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4573