### PR TITLE
Improved component resolution handling

### DIFF
--- a/header-footer-grid/Core/Builder/Abstract_Builder.php
+++ b/header-footer-grid/Core/Builder/Abstract_Builder.php
@@ -1710,6 +1710,10 @@ abstract class Abstract_Builder implements Builder {
 			$id = ( self::$current_component === null ) ? Abstract_Component::$current_component : self::$current_component;
 		}
 
+		if ( $id === null || ! isset( $this->builder_components[ $id ] ) ) {
+			return null;
+		}
+
 		return $this->builder_components[ $id ];
 	}
 

--- a/header-footer-grid/functions-template.php
+++ b/header-footer-grid/functions-template.php
@@ -51,7 +51,7 @@ function render_components( $builder_name = '', $device = null ) {
  * @param string $builder_name The builder id.
  * @param null   $component_id The component id.
  *
- * @return false|Core\Components\Abstract_Component
+ * @return false|null|Core\Components\Abstract_Component
  */
 function current_component( $builder_name = '', $component_id = null ) {
 	$builder = get_builder( $builder_name );

--- a/header-footer-grid/functions-template.php
+++ b/header-footer-grid/functions-template.php
@@ -48,8 +48,8 @@ function render_components( $builder_name = '', $device = null ) {
 /**
  * Returns the current component.
  *
- * @param string $builder_name The builder id.
- * @param null   $component_id The component id.
+ * @param string      $builder_name The builder id.
+ * @param string|null $component_id The component id.
  *
  * @return false|null|Core\Components\Abstract_Component
  */

--- a/header-footer-grid/templates/component-wrapper.php
+++ b/header-footer-grid/templates/component-wrapper.php
@@ -10,9 +10,16 @@
 
 namespace HFG;
 
-$_id = current_component()->get_id();
+$_component = current_component();
+
+// Bail when the current component cannot be resolved on the current builder.
+if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+	return;
+}
+
+$_id = $_component->get_id();
 if ( isset( $args ) && ! empty( $args ) ) {
-	current_component()->set_args( $args );
+	$_component->set_args( $args );
 }
 
 $item_classes   = array();
@@ -44,11 +51,11 @@ if ( is_customize_preview() ) {
 
 ?>
 <div class="<?php echo esc_attr( $item_classes ); ?>"
-		data-section="<?php echo esc_attr( current_component()->get_section_id() ); ?>"
-		data-item-id="<?php echo esc_attr( current_component()->get_id() ); ?>"<?php echo empty( $placement_context ) ? '' : ' data-customize-partial-placement-context="' . esc_attr( wp_json_encode( $placement_context ) ) . '"'; ?>>
+		data-section="<?php echo esc_attr( $_component->get_section_id() ); ?>"
+		data-item-id="<?php echo esc_attr( $_component->get_id() ); ?>"<?php echo empty( $placement_context ) ? '' : ' data-customize-partial-placement-context="' . esc_attr( wp_json_encode( $placement_context ) ) . '"'; ?>>
 	<?php
-	current_component()->render_css();
-	current_component()->render_component();
+	$_component->render_css();
+	$_component->render_component();
 	?>
 	<?php if ( is_customize_preview() ) { ?>
 		<span class="item--preview-name">

--- a/header-footer-grid/templates/components/component-footer-sidebar.php
+++ b/header-footer-grid/templates/components/component-footer-sidebar.php
@@ -10,7 +10,14 @@
 
 namespace HFG;
 
-$_id = current_component()->get_id();
+$_component = current_component();
+
+// Bail when the current component cannot be resolved on the current builder.
+if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+	return;
+}
+
+$_id = $_component->get_id();
 
 if ( is_active_sidebar( $_id ) ) {
 	?>
@@ -20,7 +27,7 @@ if ( is_active_sidebar( $_id ) ) {
 <?php } elseif ( current_user_can( 'edit_theme_options' ) ) { ?>
 	<div class="widget-area">
 		<section id="placeholder-widget-text" class="widget widget_text">
-			<h4 class="widget-title"><?php echo esc_html( current_component()->get_property( 'label' ) ); ?></h4>
+			<h4 class="widget-title"><?php echo esc_html( $_component->get_property( 'label' ) ); ?></h4>
 			<div class="textwidget">
 				<?php
 				echo sprintf(
@@ -34,7 +41,7 @@ if ( is_active_sidebar( $_id ) ) {
 							esc_url( admin_url( 'customize.php?autofocus[section]=sidebar-widgets-footer-' . $_id ) ),
 							/* translators: %1$s - &rarr; symbol %2$s - &rarr; symbol %3$s - &rarr; symbol */
 							sprintf( __( 'Appearance %1$s Customize %2$s Footer %3$s', 'neve' ), '&rarr;', '&rarr;', '&rarr;' ), //phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-							esc_attr( current_component()->get_property( 'label' ) )
+							esc_attr( $_component->get_property( 'label' ) )
 						)
 					)
 				);

--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -15,7 +15,7 @@ use HFG\Core\Components\Logo;
 $_component = current_component( HeaderBuilder::BUILDER_NAME );
 
 // Bail when the current component cannot be resolved on the current builder.
-if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+if ( ! $_component instanceof \HFG\Core\Components\Abstract_Component ) {
 	return;
 }
 

--- a/header-footer-grid/templates/components/component-logo.php
+++ b/header-footer-grid/templates/components/component-logo.php
@@ -12,7 +12,14 @@ namespace HFG;
 use HFG\Core\Builder\Header as HeaderBuilder;
 use HFG\Core\Components\Logo;
 
-$_id    = current_component( HeaderBuilder::BUILDER_NAME )->get_id();
+$_component = current_component( HeaderBuilder::BUILDER_NAME );
+
+// Bail when the current component cannot be resolved on the current builder.
+if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+	return;
+}
+
+$_id    = $_component->get_id();
 $device = current_device( HeaderBuilder::BUILDER_NAME );
 
 $show_name     = component_setting( Logo::SHOW_TITLE );

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -15,7 +15,7 @@ use HFG\Core\Builder\Header as HeaderBuilder;
 $_component = current_component( HeaderBuilder::BUILDER_NAME );
 
 // Bail when the current component cannot be resolved on the current builder.
-if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+if ( ! $_component instanceof \HFG\Core\Components\Abstract_Component ) {
 	return;
 }
 

--- a/header-footer-grid/templates/components/component-nav.php
+++ b/header-footer-grid/templates/components/component-nav.php
@@ -12,8 +12,15 @@ namespace HFG;
 use HFG\Core\Components\Nav;
 use HFG\Core\Builder\Header as HeaderBuilder;
 
+$_component = current_component( HeaderBuilder::BUILDER_NAME );
+
+// Bail when the current component cannot be resolved on the current builder.
+if ( ! $_component instanceof Core\Components\Abstract_Component ) {
+	return;
+}
+
 $device_class          = isset( $args ) && ! empty( $args ) ? $args['device'] : '';
-$_id                   = current_component( HeaderBuilder::BUILDER_NAME )->get_id();
+$_id                   = $_component->get_id();
 $style                 = component_setting( Nav::STYLE_ID, 'style-plain' );
 $additional_menu_class = apply_filters( 'neve_additional_menu_class', ' menu-' . $device_class );
 

--- a/tests/test-neve-hfg-component-guards.php
+++ b/tests/test-neve-hfg-component-guards.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Tests for the HFG component resolution guards.
+ *
+ * @package neve
+ */
+
+use HFG\Core\Builder\Abstract_Builder;
+use HFG\Core\Components\Abstract_Component;
+use HFG\Main;
+
+/**
+ * Class TestNeveHfgComponentGuards
+ */
+class TestNeveHfgComponentGuards extends WP_UnitTestCase {
+
+	/**
+	 * Previous builder static state.
+	 *
+	 * @var array
+	 */
+	private $previous_state = array();
+
+	/**
+	 * Store the static render state.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->previous_state = array(
+			'builder'            => Abstract_Builder::$current_builder,
+			'builder_component'  => Abstract_Builder::$current_component,
+			'current_component'  => Abstract_Component::$current_component,
+		);
+	}
+
+	/**
+	 * Restore the static render state.
+	 */
+	public function tear_down() {
+		Abstract_Builder::$current_builder   = $this->previous_state['builder'];
+		Abstract_Builder::$current_component = $this->previous_state['builder_component'];
+		Abstract_Component::$current_component = $this->previous_state['current_component'];
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Get the header builder instance.
+	 *
+	 * @return Abstract_Builder
+	 */
+	private function header_builder() {
+		$builder = Main::get_instance()->get_builder( 'header' );
+
+		$this->assertInstanceOf( Abstract_Builder::class, $builder );
+
+		return $builder;
+	}
+
+	/**
+	 * An unknown component id resolves to null instead of raising a warning.
+	 */
+	public function test_get_component_returns_null_for_unknown_id() {
+		$this->assertNull( $this->header_builder()->get_component( 'neve-not-a-component' ) );
+	}
+
+	/**
+	 * With no component in render context, get_component resolves to null.
+	 */
+	public function test_get_component_returns_null_without_render_context() {
+		Abstract_Builder::$current_component   = null;
+		Abstract_Component::$current_component = null;
+
+		$this->assertNull( $this->header_builder()->get_component() );
+	}
+
+	/**
+	 * A stale component id left in the render context resolves to null.
+	 */
+	public function test_get_component_returns_null_for_stale_context() {
+		Abstract_Builder::$current_component   = null;
+		Abstract_Component::$current_component = 'neve-stale-component';
+
+		$this->assertNull( $this->header_builder()->get_component() );
+	}
+
+	/**
+	 * A registered component is still returned.
+	 */
+	public function test_get_component_returns_registered_component() {
+		$builder    = $this->header_builder();
+		$components = $builder->get_components();
+
+		if ( empty( $components ) ) {
+			$this->markTestSkipped( 'No header components registered.' );
+		}
+
+		$id = key( $components );
+
+		Abstract_Builder::$current_component   = null;
+		Abstract_Component::$current_component = $id;
+
+		$component = $builder->get_component();
+
+		$this->assertInstanceOf( Abstract_Component::class, $component );
+		$this->assertSame( $id, $component->get_id() );
+	}
+
+	/**
+	 * Templates that resolve the component from the render context.
+	 *
+	 * @return array
+	 */
+	public function component_template_provider() {
+		return array(
+			'wrapper'        => array( 'component-wrapper' ),
+			'footer sidebar' => array( 'components/component-footer-sidebar' ),
+			'logo'           => array( 'components/component-logo' ),
+			'nav'            => array( 'components/component-nav' ),
+		);
+	}
+
+	/**
+	 * Component templates render nothing when the component is unresolvable.
+	 *
+	 * @param string $template Template slug.
+	 *
+	 * @dataProvider component_template_provider
+	 */
+	public function test_component_template_renders_nothing_without_component( $template ) {
+		Abstract_Builder::$current_builder     = 'header';
+		Abstract_Builder::$current_component   = null;
+		Abstract_Component::$current_component = 'neve-stale-component';
+
+		ob_start();
+		Main::get_instance()->load( $template );
+		$output = ob_get_clean();
+
+		$this->assertSame( '', trim( $output ) );
+	}
+}


### PR DESCRIPTION
### Summary
Improves the reliability and safety of component resolution in the header-footer grid system by adding guards to prevent errors when a component cannot be found. It updates several component templates to bail early if the current component is unresolvable and adds comprehensive unit tests to ensure these guards work as intended.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4565