### PR TITLE
Handled WP Error responses to prevent fatal

### DIFF
--- a/inc/compatibility/elementor.php
+++ b/inc/compatibility/elementor.php
@@ -134,12 +134,16 @@ class Elementor extends Page_Builder_Base {
 	/**
 	 * Filter rest responses to add Neve Palette Colors to pages using Elementor.
 	 *
-	 * @param \WP_REST_Response $response request response.
-	 * @param array             $handler request handler.
-	 * @param \WP_REST_Request  $request rest request.
-	 * @return \WP_REST_Response
+	 * @param \WP_REST_Response|\WP_Error $response request response.
+	 * @param array                       $handler request handler.
+	 * @param \WP_REST_Request            $request rest request.
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function alter_global_colors_front_end( $response, $handler, \WP_REST_Request $request ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		$route         = $request->get_route();
 		$rest_to_slugs = [
 			'nvprimaryaccent'   => 'nv-primary-accent',
@@ -178,12 +182,16 @@ class Elementor extends Page_Builder_Base {
 	/**
 	 * Filter rest responses to add Neve Palette Colors to Elementor.
 	 *
-	 * @param \WP_REST_Response $response request response.
-	 * @param array             $handler request handler.
-	 * @param \WP_REST_Request  $request rest request.
-	 * @return \WP_REST_Response
+	 * @param \WP_REST_Response|\WP_Error $response request response.
+	 * @param array                       $handler request handler.
+	 * @param \WP_REST_Request            $request rest request.
+	 * @return \WP_REST_Response|\WP_Error
 	 */
 	public function alter_global_colors_in_picker( $response, $handler, \WP_REST_Request $request ) {
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
 		$route = $request->get_route();
 
 		if ( $route !== '/elementor/v1/globals' ) {

--- a/tests/test-elementor-compatibility.php
+++ b/tests/test-elementor-compatibility.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Description Test Elementor compatibility
+ * Tests Elementor compatibility.
  *
  * @package neve
  */
@@ -16,10 +16,33 @@ class TestElementorCompatibility extends WP_UnitTestCase {
 	const GLOBALS_ROUTE = '/elementor/v1/globals';
 
 	/**
+	 * A single global color REST route, filtered by the front end callback.
+	 */
+	const COLOR_ROUTE = self::GLOBALS_ROUTE . '/colors/nvprimaryaccent';
+
+	/**
+	 * Build a compatibility instance in a post-init state.
+	 *
+	 * Avoids ::init(), which needs ELEMENTOR_VERSION defined and would leak that
+	 * constant plus its hooks into the rest of the suite.
+	 *
+	 * @return \Neve\Compatibility\Elementor
+	 */
+	private function get_elementor_compat() {
+		$elementor = new \Neve\Compatibility\Elementor();
+
+		$custom_colors = new ReflectionProperty( $elementor, 'custom_global_colors' );
+		$custom_colors->setAccessible( true );
+		$custom_colors->setValue( null, [] );
+
+		return $elementor;
+	}
+
+	/**
 	 * Errored responses should be passed through untouched.
 	 */
 	public function test_global_colors_in_picker_passes_through_wp_error() {
-		$elementor = new \Neve\Compatibility\Elementor();
+		$elementor = $this->get_elementor_compat();
 		$request   = new WP_REST_Request( 'GET', self::GLOBALS_ROUTE );
 		$error     = new WP_Error( 'rest_forbidden', 'Sorry, you are not allowed to do that.', [ 'status' => 403 ] );
 
@@ -30,8 +53,8 @@ class TestElementorCompatibility extends WP_UnitTestCase {
 	 * Errored responses on a color route should be passed through untouched.
 	 */
 	public function test_global_colors_front_end_passes_through_wp_error() {
-		$elementor = new \Neve\Compatibility\Elementor();
-		$request   = new WP_REST_Request( 'GET', '/elementor/v1/globals/colors/nvprimaryaccent' );
+		$elementor = $this->get_elementor_compat();
+		$request   = new WP_REST_Request( 'GET', self::COLOR_ROUTE );
 		$error     = new WP_Error( 'rest_forbidden', 'Sorry, you are not allowed to do that.', [ 'status' => 403 ] );
 
 		$this->assertSame( $error, $elementor->alter_global_colors_front_end( $error, [], $request ) );
@@ -41,19 +64,29 @@ class TestElementorCompatibility extends WP_UnitTestCase {
 	 * Valid responses should still get the Neve palette colors merged in.
 	 */
 	public function test_global_colors_in_picker_adds_palette_colors() {
-		if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
-			define( 'ELEMENTOR_VERSION', '3.0.0' );
-		}
-
-		$elementor = new \Neve\Compatibility\Elementor();
-		$elementor->init();
-		$request  = new WP_REST_Request( 'GET', self::GLOBALS_ROUTE );
-		$response = new WP_REST_Response( [ 'colors' => [] ] );
+		$elementor = $this->get_elementor_compat();
+		$request   = new WP_REST_Request( 'GET', self::GLOBALS_ROUTE );
+		$response  = new WP_REST_Response( [ 'colors' => [] ] );
 
 		$filtered = $elementor->alter_global_colors_in_picker( $response, [], $request );
 		$data     = $filtered->get_data();
 
 		$this->assertArrayHasKey( 'nvprimaryaccent', $data['colors'] );
 		$this->assertArrayHasKey( 'value', $data['colors']['nvprimaryaccent'] );
+	}
+
+	/**
+	 * Valid responses on a single color route should be replaced with the Neve color.
+	 */
+	public function test_global_colors_front_end_overrides_color() {
+		$elementor = $this->get_elementor_compat();
+		$request   = new WP_REST_Request( 'GET', self::COLOR_ROUTE );
+		$response  = new WP_REST_Response( [] );
+
+		$filtered = $elementor->alter_global_colors_front_end( $response, [], $request );
+		$data     = $filtered->get_data();
+
+		$this->assertSame( 'nvprimaryaccent', $data['id'] );
+		$this->assertArrayHasKey( 'value', $data );
 	}
 }

--- a/tests/test-elementor-compatibility.php
+++ b/tests/test-elementor-compatibility.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Description Test Elementor compatibility
+ *
+ * @package neve
+ */
+
+/**
+ * Class TestElementorCompatibility
+ */
+class TestElementorCompatibility extends WP_UnitTestCase {
+
+	/**
+	 * The globals REST route filtered by the picker callback.
+	 */
+	const GLOBALS_ROUTE = '/elementor/v1/globals';
+
+	/**
+	 * Errored responses should be passed through untouched.
+	 */
+	public function test_global_colors_in_picker_passes_through_wp_error() {
+		$elementor = new \Neve\Compatibility\Elementor();
+		$request   = new WP_REST_Request( 'GET', self::GLOBALS_ROUTE );
+		$error     = new WP_Error( 'rest_forbidden', 'Sorry, you are not allowed to do that.', [ 'status' => 403 ] );
+
+		$this->assertSame( $error, $elementor->alter_global_colors_in_picker( $error, [], $request ) );
+	}
+
+	/**
+	 * Errored responses on a color route should be passed through untouched.
+	 */
+	public function test_global_colors_front_end_passes_through_wp_error() {
+		$elementor = new \Neve\Compatibility\Elementor();
+		$request   = new WP_REST_Request( 'GET', '/elementor/v1/globals/colors/nvprimaryaccent' );
+		$error     = new WP_Error( 'rest_forbidden', 'Sorry, you are not allowed to do that.', [ 'status' => 403 ] );
+
+		$this->assertSame( $error, $elementor->alter_global_colors_front_end( $error, [], $request ) );
+	}
+
+	/**
+	 * Valid responses should still get the Neve palette colors merged in.
+	 */
+	public function test_global_colors_in_picker_adds_palette_colors() {
+		if ( ! defined( 'ELEMENTOR_VERSION' ) ) {
+			define( 'ELEMENTOR_VERSION', '3.0.0' );
+		}
+
+		$elementor = new \Neve\Compatibility\Elementor();
+		$elementor->init();
+		$request  = new WP_REST_Request( 'GET', self::GLOBALS_ROUTE );
+		$response = new WP_REST_Response( [ 'colors' => [] ] );
+
+		$filtered = $elementor->alter_global_colors_in_picker( $response, [], $request );
+		$data     = $filtered->get_data();
+
+		$this->assertArrayHasKey( 'nvprimaryaccent', $data['colors'] );
+		$this->assertArrayHasKey( 'value', $data['colors']['nvprimaryaccent'] );
+	}
+}

--- a/tests/test-elementor-compatibility.php
+++ b/tests/test-elementor-compatibility.php
@@ -33,7 +33,7 @@ class TestElementorCompatibility extends WP_UnitTestCase {
 
 		$custom_colors = new ReflectionProperty( $elementor, 'custom_global_colors' );
 		$custom_colors->setAccessible( true );
-		$custom_colors->setValue( null, [] );
+		$custom_colors->setValue( $elementor, [] );
 
 		return $elementor;
 	}


### PR DESCRIPTION
### Summary
Handled WP_Error in `rest_request_after_callbacks` filter callbacks to prevent fatal errors when the response is an error. This ensures that the code only attempts to modify the response if it is a valid `WP_REST_Response` object.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4559