### PR TITLE
Preserved HTML markup in excerpts

### DIFF
--- a/bin/envs/cli-setup.sh
+++ b/bin/envs/cli-setup.sh
@@ -21,6 +21,13 @@ init_environment(){
 	echo "Installing Neve theme from $NEVE_LOCATION"
 	wp --allow-root theme install --activate $NEVE_LOCATION
 	wp --allow-root option update fresh_site 0
+
+	# Activating Neve remaps widgets by sidebar id, and 'blog-sidebar' does not
+	# match the previous theme's, so the default widgets can be left unassigned.
+	if [ "$(wp --allow-root widget list blog-sidebar --format=count)" = "0" ]; then
+		echo "Populating blog-sidebar"
+		wp --allow-root widget add block blog-sidebar --content='<!-- wp:search /-->'
+	fi
   echo "Installing Theme API Plugin"
   wp --allow-root plugin install https://github.com/codeinwp/wp-thememods-api/archive/refs/heads/main.zip --force --activate
 }

--- a/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
@@ -2,6 +2,16 @@ import { test, expect } from '@playwright/test';
 import { setCustomizeSettings } from '../../../utils';
 import data from '../../../fixtures/customizer/layout/blog-archive-setting-setup.json';
 
+const SEARCH_TERM = 'nvexcerpthtmlfixture';
+const LINK_HREF = 'https://example.com/neve-excerpt-link';
+const EXCERPT = `Neve <strong>keeps</strong> this <a href="${LINK_HREF}">excerpt link</a> visible while trimming the rest sentinelword away.`;
+
+const excerptHtmlSettings = {
+	neve_blog_archive_layout: 'default',
+	neve_post_excerpt_length: 8,
+	neve_post_content_ordering: '["title-meta","excerpt"]',
+};
+
 test.describe('Blog/Archive 1 / Default Layout', () => {
 	test.beforeAll(async ({ request, baseURL }) => {
 		await setCustomizeSettings('defaultLayout', data.archive1, {
@@ -281,5 +291,57 @@ test.describe('Blog/Archive 4 / Default Layout', () => {
 		expect(
 			await page.locator('article.post.has-post-thumbnail').count()
 		).toEqual(0);
+	});
+});
+
+test.describe('Blog/Archive / Excerpt markup', () => {
+	let postId: number;
+
+	test.beforeAll(async ({ request, baseURL }) => {
+		await setCustomizeSettings('excerptHtml', excerptHtmlSettings, {
+			request,
+			baseURL,
+		});
+
+		const response = await request.post(baseURL + '/wp-json/wp/v2/posts', {
+			data: {
+				title: `Excerpt markup ${SEARCH_TERM}`,
+				content: `Body copy for ${SEARCH_TERM}.`,
+				excerpt: EXCERPT,
+				status: 'publish',
+				// Dated far back so the post lands on the last archive page and
+				// leaves the other archive specs alone.
+				date: '2001-01-01T00:00:00',
+			},
+		});
+		expect(response.ok()).toBeTruthy();
+		postId = (await response.json()).id;
+	});
+
+	test.afterAll(async ({ request, baseURL }) => {
+		if (postId) {
+			await request.delete(
+				baseURL + `/wp-json/wp/v2/posts/${postId}?force=true`
+			);
+		}
+	});
+
+	test('Trimming the excerpt keeps its HTML', async ({ page }) => {
+		await page.goto(`/?s=${SEARCH_TERM}&test_name=excerptHtml`);
+
+		const excerpt = page.locator('article.post .excerpt-wrap');
+		await expect(excerpt).toHaveCount(1);
+
+		const link = excerpt.locator(`a[href="${LINK_HREF}"]`);
+		await expect(link).toBeVisible();
+		await expect(link).toHaveText('excerpt link');
+		await expect(excerpt.locator('strong')).toHaveText('keeps');
+
+		const text = await excerpt.innerText();
+		// The trim still happens: the last kept word is in, the next one is out.
+		expect(text).toContain('trimming');
+		expect(text).not.toContain('sentinelword');
+		// Markup is rendered, not printed as escaped text.
+		expect(text).not.toContain('<a ');
 	});
 });

--- a/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
@@ -12,6 +12,11 @@ const excerptHtmlSettings = {
 	neve_post_content_ordering: '["title-meta","excerpt"]',
 };
 
+const excerptHtmlCutSettings = {
+	...excerptHtmlSettings,
+	neve_post_excerpt_length: 4,
+};
+
 test.describe('Blog/Archive 1 / Default Layout', () => {
 	test.beforeAll(async ({ request, baseURL }) => {
 		await setCustomizeSettings('defaultLayout', data.archive1, {
@@ -302,6 +307,10 @@ test.describe('Blog/Archive / Excerpt markup', () => {
 			request,
 			baseURL,
 		});
+		await setCustomizeSettings('excerptHtmlCut', excerptHtmlCutSettings, {
+			request,
+			baseURL,
+		});
 
 		const response = await request.post(baseURL + '/wp-json/wp/v2/posts', {
 			data: {
@@ -342,6 +351,27 @@ test.describe('Blog/Archive / Excerpt markup', () => {
 		expect(text).toContain('trimming');
 		expect(text).not.toContain('sentinelword');
 		// Markup is rendered, not printed as escaped text.
+		expect(text).not.toContain('<a ');
+	});
+
+	test('Trimming inside a link closes the link', async ({ page }) => {
+		await page.goto(`/?s=${SEARCH_TERM}&test_name=excerptHtmlCut`);
+
+		const excerpt = page.locator('article.post .excerpt-wrap');
+		await expect(excerpt).toHaveCount(1);
+
+		// Word 4 is the first half of the link text and word 5 is past the cut, so
+		// only an anchor closed by the trim can render as a link at all.
+		const link = excerpt.locator(`a[href="${LINK_HREF}"]`);
+		await expect(link).toBeVisible();
+		await expect(link).toHaveText('excerpt');
+		// The read more marker follows the link instead of being swallowed by it.
+		await expect(link).not.toContainText('…');
+		await expect(excerpt.locator('strong')).toHaveText('keeps');
+
+		const text = await excerpt.innerText();
+		expect(text).toContain('…');
+		expect(text).not.toContain('visible');
 		expect(text).not.toContain('<a ');
 	});
 });

--- a/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
@@ -320,10 +320,12 @@ test.describe('Blog/Archive / Excerpt markup', () => {
 		const stale = await request.get(
 			baseURL + `/wp-json/wp/v2/posts?slug=${POST_SLUG}&status=any`
 		);
+		expect(stale.ok()).toBeTruthy();
 		for (const post of await stale.json()) {
-			await request.delete(
+			const staleDeleteResponse = await request.delete(
 				baseURL + `/wp-json/wp/v2/posts/${post.id}?force=true`
 			);
+			expect(staleDeleteResponse.ok()).toBeTruthy();
 		}
 
 		const response = await request.post(baseURL + '/wp-json/wp/v2/posts', {

--- a/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
+++ b/e2e-tests/specs/customizer/layout/blog-archive-settings.spec.ts
@@ -3,6 +3,7 @@ import { setCustomizeSettings } from '../../../utils';
 import data from '../../../fixtures/customizer/layout/blog-archive-setting-setup.json';
 
 const SEARCH_TERM = 'nvexcerpthtmlfixture';
+const POST_SLUG = 'nv-excerpt-html-fixture';
 const LINK_HREF = 'https://example.com/neve-excerpt-link';
 const EXCERPT = `Neve <strong>keeps</strong> this <a href="${LINK_HREF}">excerpt link</a> visible while trimming the rest sentinelword away.`;
 
@@ -300,6 +301,8 @@ test.describe('Blog/Archive 4 / Default Layout', () => {
 });
 
 test.describe('Blog/Archive / Excerpt markup', () => {
+	test.describe.configure({ mode: 'serial' });
+
 	let postId: number;
 
 	test.beforeAll(async ({ request, baseURL }) => {
@@ -312,9 +315,21 @@ test.describe('Blog/Archive / Excerpt markup', () => {
 			baseURL,
 		});
 
+		// A run killed before afterAll leaves the post behind; drop it by slug so
+		// the search page has exactly one result either way.
+		const stale = await request.get(
+			baseURL + `/wp-json/wp/v2/posts?slug=${POST_SLUG}&status=any`
+		);
+		for (const post of await stale.json()) {
+			await request.delete(
+				baseURL + `/wp-json/wp/v2/posts/${post.id}?force=true`
+			);
+		}
+
 		const response = await request.post(baseURL + '/wp-json/wp/v2/posts', {
 			data: {
 				title: `Excerpt markup ${SEARCH_TERM}`,
+				slug: POST_SLUG,
 				content: `Body copy for ${SEARCH_TERM}.`,
 				excerpt: EXCERPT,
 				status: 'publish',
@@ -329,9 +344,10 @@ test.describe('Blog/Archive / Excerpt markup', () => {
 
 	test.afterAll(async ({ request, baseURL }) => {
 		if (postId) {
-			await request.delete(
+			const deleteResponse = await request.delete(
 				baseURL + `/wp-json/wp/v2/posts/${postId}?force=true`
 			);
+			expect(deleteResponse.ok()).toBeTruthy();
 		}
 	});
 

--- a/inc/views/partials/excerpt.php
+++ b/inc/views/partials/excerpt.php
@@ -77,7 +77,7 @@ class Excerpt extends Base_View {
 
 		if ( has_excerpt( $post_id ) ) {
 			$excerpt_more = apply_filters( 'excerpt_more', ' [&hellip;]' );
-			$content      = wp_trim_words( get_the_excerpt( $post_id ), $length, $excerpt_more );
+			$content      = $this->trim_words_keep_html( get_the_excerpt( $post_id ), $length, $excerpt_more );
 
 			return apply_filters( 'the_excerpt', $content );
 		}
@@ -87,6 +87,161 @@ class Excerpt extends Base_View {
 		remove_filter( 'excerpt_length', array( $this, 'change_excerpt_length' ), 10 );
 
 		return apply_filters( 'the_excerpt', $content );
+	}
+
+	/**
+	 * Trim words while preserving HTML markup.
+	 *
+	 * Similar to wp_trim_words(), but preserves HTML tags.
+	 *
+	 * @param string $text      HTML content to trim.
+	 * @param int    $num_words Maximum number of words.
+	 * @param string $more      String to append when the content is trimmed.
+	 *
+	 * @return string
+	 */
+	private function trim_words_keep_html( $text, $num_words, $more = '...' ) {
+		$num_words = (int) $num_words;
+
+		if ( $num_words <= 0 || '' === $text ) {
+			return '';
+		}
+
+		// `wp_get_word_count_type()` is WP 6.2+; older installs read the same core string.
+		$count_type = function_exists( 'wp_get_word_count_type' )
+			? wp_get_word_count_type()
+			: _x( 'words', 'Word count type. Do not translate!', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Core string, not a theme one.
+
+		// Locales counting characters are left to core, markup and all.
+		if (
+			0 === strpos( $count_type, 'characters' )
+			&& preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) )
+		) {
+			return wp_trim_words( $text, $num_words, $more );
+		}
+
+		$tokens = preg_split(
+			'/(<[^>]*>)/',
+			$text,
+			-1,
+			PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+		);
+
+		if ( ! is_array( $tokens ) ) {
+			return wp_trim_words( $text, $num_words, $more );
+		}
+
+		$void_tags = array(
+			'area',
+			'base',
+			'br',
+			'col',
+			'embed',
+			'hr',
+			'img',
+			'input',
+			'link',
+			'meta',
+			'param',
+			'source',
+			'track',
+			'wbr',
+		);
+
+		$output    = '';
+		$open_tags = array();
+		$remaining = $num_words;
+		$trimmed   = false;
+		// Whitespace is held back until a word or tag follows it, so the cut does not
+		// leave a trailing space inside a closed tag or in front of `$more`.
+		$pending = '';
+
+		foreach ( $tokens as $token ) {
+			// Comments carry no words, and their contents must not be counted as any.
+			if ( 0 === strpos( $token, '<!--' ) ) {
+				$output .= $pending . $token;
+				$pending = '';
+
+				continue;
+			}
+
+			// If this is an HTML tag, handle it differently.
+			if ( preg_match( '#^<\s*(/?)\s*([a-zA-Z0-9]+)(?:\s[^>]*)?\s*(/?)>$#s', $token, $matches ) ) {
+				$output .= $pending . $token;
+				$pending = '';
+
+				$tag             = strtolower( $matches[2] );
+				$is_closing      = '/' === $matches[1];
+				$is_self_closing = '/' === $matches[3];
+
+				if ( in_array( $tag, $void_tags, true ) || $is_self_closing ) {
+					continue;
+				}
+
+				if ( $is_closing ) {
+					$index = array_search( $tag, $open_tags, true );
+
+					if ( false !== $index ) {
+						$open_tags = array_slice( $open_tags, $index + 1 );
+					}
+
+					continue;
+				}
+
+				array_unshift( $open_tags, $tag );
+
+				continue;
+			}
+
+			// If this is a text, split it into words and add them to the output.
+			$parts = preg_split(
+				'/(\s+)/u',
+				$token,
+				-1,
+				PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY
+			);
+
+			if ( ! is_array( $parts ) ) {
+				$output .= $pending . $token;
+				$pending = '';
+
+				continue;
+			}
+
+			foreach ( $parts as $part ) {
+				if ( '' === trim( $part ) ) {
+					$pending .= $part;
+
+					continue;
+				}
+
+				if ( $remaining <= 0 ) {
+					$trimmed = true;
+					break;
+				}
+
+				$output .= $pending . $part;
+				$pending = '';
+				$remaining--;
+			}
+
+			if ( $trimmed ) {
+				break;
+			}
+		}
+
+		if ( ! $trimmed ) {
+			return $text;
+		}
+
+		// Close any tags that are still open so the resulting HTML remains valid.
+		foreach ( $open_tags as $tag ) {
+			$output .= '</' . $tag . '>';
+		}
+
+		$output .= $more;
+
+		return $output;
 	}
 
 	/**

--- a/inc/views/partials/excerpt.php
+++ b/inc/views/partials/excerpt.php
@@ -102,15 +102,27 @@ class Excerpt extends Base_View {
 	 */
 	private function trim_words_keep_html( $text, $num_words, $more = '...' ) {
 		$num_words = (int) $num_words;
+		$trimmed   = $this->trim_markup( $text, $num_words, $more );
 
+		return apply_filters( 'wp_trim_words', $trimmed, $num_words, $more, $text );
+	}
+
+	/**
+	 * Trim a text to a number of words, leaving the markup around them in place.
+	 *
+	 * @param string $text      HTML content to trim.
+	 * @param int    $num_words Maximum number of words.
+	 * @param string $more      String to append when the content is trimmed.
+	 *
+	 * @return string
+	 */
+	private function trim_markup( $text, $num_words, $more ) {
 		if ( $num_words <= 0 || '' === $text ) {
 			return '';
 		}
 
-		// `wp_get_word_count_type()` is WP 6.2+; older installs read the same core string.
-		$count_type = function_exists( 'wp_get_word_count_type' )
-			? wp_get_word_count_type()
-			: _x( 'words', 'Word count type. Do not translate!', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Core string, not a theme one.
+		// `wp_get_word_count_type()` is WP 6.2+; older installs count words.
+		$count_type = function_exists( 'wp_get_word_count_type' ) ? wp_get_word_count_type() : 'words';
 
 		// Some locales budget characters rather than words, as `wp_trim_words()` does.
 		$count_chars = 0 === strpos( $count_type, 'characters' )
@@ -127,69 +139,23 @@ class Excerpt extends Base_View {
 			return wp_trim_words( $text, $num_words, $more );
 		}
 
-		$void_tags = array(
-			'area',
-			'base',
-			'br',
-			'col',
-			'embed',
-			'hr',
-			'img',
-			'input',
-			'link',
-			'meta',
-			'param',
-			'source',
-			'track',
-			'wbr',
-		);
-
 		$output    = '';
-		$open_tags = array();
 		$remaining = $num_words;
-		$trimmed   = false;
-		// Whitespace is held back until a word or tag follows it, so the cut does not
-		// leave a trailing space inside a closed tag or in front of `$more`.
-		$pending = '';
+		$cut       = false;
+
+		// Markup and whitespace are held back until a kept word follows them, so a
+		// tag opened right at the cut does not leave an empty element behind.
+		$pending      = '';
+		$pending_cost = 0;
 
 		foreach ( $tokens as $token ) {
-			// Comments carry no words, and their contents must not be counted as any.
-			if ( 0 === strpos( $token, '<!--' ) ) {
-				$output .= $pending . $token;
-				$pending = '';
+			// Tokens are split on this same pattern, so a match is one of the tags.
+			if ( preg_match( '#^<[^>]*>$#', $token ) ) {
+				$pending .= $token;
 
 				continue;
 			}
 
-			// If this is an HTML tag, handle it differently.
-			if ( preg_match( '#^<\s*(/?)\s*([a-zA-Z0-9]+)(?:\s[^>]*)?\s*(/?)>$#s', $token, $matches ) ) {
-				$output .= $pending . $token;
-				$pending = '';
-
-				$tag             = strtolower( $matches[2] );
-				$is_closing      = '/' === $matches[1];
-				$is_self_closing = '/' === $matches[3];
-
-				if ( in_array( $tag, $void_tags, true ) || $is_self_closing ) {
-					continue;
-				}
-
-				if ( $is_closing ) {
-					$index = array_search( $tag, $open_tags, true );
-
-					if ( false !== $index ) {
-						$open_tags = array_slice( $open_tags, $index + 1 );
-					}
-
-					continue;
-				}
-
-				array_unshift( $open_tags, $tag );
-
-				continue;
-			}
-
-			// If this is a text, split it into words and add them to the output.
 			$parts = preg_split(
 				'/(\s+)/u',
 				$token,
@@ -198,66 +164,55 @@ class Excerpt extends Base_View {
 			);
 
 			if ( ! is_array( $parts ) ) {
-				$output .= $pending . $token;
-				$pending = '';
+				$output      .= $pending . $token;
+				$pending      = '';
+				$pending_cost = 0;
 
 				continue;
 			}
 
 			foreach ( $parts as $part ) {
 				if ( '' === trim( $part ) ) {
-					$pending .= $part;
+					// Core collapses each run of whitespace to a single space.
+					$pending      .= $count_chars ? ' ' : $part;
+					$pending_cost += $count_chars ? 1 : 0;
 
 					continue;
 				}
 
+				$remaining -= $pending_cost;
+
 				if ( $remaining <= 0 ) {
-					$trimmed = true;
+					$cut = true;
 					break;
 				}
 
-				// Character locales spend the budget per character, so a single run
-				// of text can be cut part way through.
-				if ( $count_chars ) {
-					$chars = $this->split_characters( $part );
+				$chars = $count_chars ? $this->split_characters( $part ) : array( $part );
 
-					if ( count( $chars ) > $remaining ) {
-						$output   .= $pending . implode( '', array_slice( $chars, 0, $remaining ) );
-						$pending   = '';
-						$remaining = 0;
-						$trimmed   = true;
-						break;
-					}
-
-					$output    .= $pending . $part;
-					$pending    = '';
-					$remaining -= count( $chars );
-
-					continue;
+				// Character locales can cut part way through a run of text.
+				if ( count( $chars ) > $remaining ) {
+					$output .= $pending . implode( '', array_slice( $chars, 0, $remaining ) );
+					$cut     = true;
+					break;
 				}
 
-				$output .= $pending . $part;
-				$pending = '';
-				$remaining--;
+				$output      .= $pending . $part;
+				$pending      = '';
+				$pending_cost = 0;
+				$remaining   -= count( $chars );
 			}
 
-			if ( $trimmed ) {
+			if ( $cut ) {
 				break;
 			}
 		}
 
-		if ( ! $trimmed ) {
+		if ( ! $cut ) {
 			return $text;
 		}
 
 		// Close any tags that are still open so the resulting HTML remains valid.
-		foreach ( $open_tags as $tag ) {
-			$output .= '</' . $tag . '>';
-		}
-
-		$output .= $more;
-
-		return $output;
+		return force_balance_tags( $output ) . $more;
 	}
 
 	/**

--- a/inc/views/partials/excerpt.php
+++ b/inc/views/partials/excerpt.php
@@ -112,13 +112,9 @@ class Excerpt extends Base_View {
 			? wp_get_word_count_type()
 			: _x( 'words', 'Word count type. Do not translate!', 'default' ); // phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Core string, not a theme one.
 
-		// Locales counting characters are left to core, markup and all.
-		if (
-			0 === strpos( $count_type, 'characters' )
-			&& preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) )
-		) {
-			return wp_trim_words( $text, $num_words, $more );
-		}
+		// Some locales budget characters rather than words, as `wp_trim_words()` does.
+		$count_chars = 0 === strpos( $count_type, 'characters' )
+			&& 1 === preg_match( '/^utf\-?8$/i', get_option( 'blog_charset' ) );
 
 		$tokens = preg_split(
 			'/(<[^>]*>)/',
@@ -220,6 +216,26 @@ class Excerpt extends Base_View {
 					break;
 				}
 
+				// Character locales spend the budget per character, so a single run
+				// of text can be cut part way through.
+				if ( $count_chars ) {
+					$chars = $this->split_characters( $part );
+
+					if ( count( $chars ) > $remaining ) {
+						$output   .= $pending . implode( '', array_slice( $chars, 0, $remaining ) );
+						$pending   = '';
+						$remaining = 0;
+						$trimmed   = true;
+						break;
+					}
+
+					$output    .= $pending . $part;
+					$pending    = '';
+					$remaining -= count( $chars );
+
+					continue;
+				}
+
 				$output .= $pending . $part;
 				$pending = '';
 				$remaining--;
@@ -242,6 +258,21 @@ class Excerpt extends Base_View {
 		$output .= $more;
 
 		return $output;
+	}
+
+	/**
+	 * Split a string into its characters.
+	 *
+	 * @param string $text Text to split.
+	 *
+	 * @return string[]
+	 */
+	private function split_characters( $text ) {
+		if ( ! preg_match_all( '/./u', $text, $matches ) ) {
+			return array();
+		}
+
+		return $matches[0];
 	}
 
 	/**

--- a/tests/test-neve-excerpt-html.php
+++ b/tests/test-neve-excerpt-html.php
@@ -1,0 +1,342 @@
+<?php
+/**
+ * Tests for the archive excerpt trim.
+ *
+ * The trim used to run through `wp_trim_words()`, which strips every tag, so a
+ * hand-written excerpt lost its links and formatting on blog and archive pages.
+ * `Excerpt::trim_markup()` is a pure string function, so the tokenizer cases
+ * live here rather than in the Playwright specs.
+ *
+ * @package neve
+ */
+
+/**
+ * Class TestNeveExcerptHtml
+ */
+class TestNeveExcerptHtml extends WP_UnitTestCase {
+
+	/**
+	 * The read more marker the partial passes to the trim.
+	 *
+	 * @var string
+	 */
+	private $more = ' [&hellip;]';
+
+	/**
+	 * Trim a text through the partial's private helper.
+	 *
+	 * @param string $text      Text to trim.
+	 * @param int    $num_words Number of words to keep.
+	 *
+	 * @return string
+	 */
+	private function trim( $text, $num_words ) {
+		$excerpt = new \Neve\Views\Partials\Excerpt();
+		$method  = new ReflectionMethod( $excerpt, 'trim_words_keep_html' );
+		$method->setAccessible( true );
+
+		return $method->invoke( $excerpt, $text, $num_words, $this->more );
+	}
+
+	/**
+	 * Trim a text with the locale counting characters, as CJK locales do.
+	 *
+	 * @param string $text  Text to trim.
+	 * @param int    $limit Number of characters to keep.
+	 *
+	 * @return string
+	 */
+	private function trim_by_characters( $text, $limit ) {
+		global $wp_locale;
+
+		$previous                   = $wp_locale->word_count_type;
+		$wp_locale->word_count_type = 'characters_including_spaces';
+
+		$output = $this->trim( $text, $limit );
+
+		$wp_locale->word_count_type = $previous;
+
+		return $output;
+	}
+
+	/**
+	 * A link before the cut keeps both its markup and its text.
+	 */
+	public function test_keeps_link_when_cut_falls_after_it() {
+		$text = 'Read the <a href="https://example.com">full announcement</a> and then a long tail of words';
+
+		$this->assertSame(
+			'Read the <a href="https://example.com">full announcement</a> and then a long' . $this->more,
+			$this->trim( $text, 8 )
+		);
+	}
+
+	/**
+	 * A cut inside a link closes it and leaves the marker outside.
+	 */
+	public function test_closes_inline_tag_left_open_by_the_cut() {
+		$text = 'Read the <a href="https://example.com">full release announcement</a> tail words';
+
+		$this->assertSame(
+			'Read the <a href="https://example.com">full release</a>' . $this->more,
+			$this->trim( $text, 4 )
+		);
+	}
+
+	/**
+	 * A text shorter than the limit is returned untouched, marker included.
+	 */
+	public function test_returns_short_text_unchanged() {
+		$text = 'Short <strong>bold</strong> excerpt';
+
+		$this->assertSame( $text, $this->trim( $text, 25 ) );
+		$this->assertSame( $text, $this->trim( $text, 3 ) );
+	}
+
+	/**
+	 * A tag opened right at the cut must not leave an empty element behind.
+	 */
+	public function test_drops_element_opened_at_the_cut() {
+		$this->assertSame(
+			'<p>one</p><p>two</p>' . $this->more,
+			$this->trim( '<p>one</p><p>two</p><p>three</p>', 2 )
+		);
+	}
+
+	/**
+	 * The same, for a list: an empty `li` would render as a stray bullet.
+	 */
+	public function test_drops_list_item_opened_at_the_cut() {
+		$this->assertSame(
+			'<ul><li>a b</li></ul>' . $this->more,
+			$this->trim( '<ul><li>a b</li><li>c d</li></ul>', 2 )
+		);
+	}
+
+	/**
+	 * Nested tags are closed at the cut.
+	 */
+	public function test_closes_nested_tags() {
+		$this->assertSame(
+			'One <em>two <strong>three</strong></em>' . $this->more,
+			$this->trim( 'One <em>two <strong>three</strong> four</em> five six', 3 )
+		);
+	}
+
+	/**
+	 * A tag nested in itself is unwound rather than left doubled.
+	 */
+	public function test_unwinds_a_tag_nested_in_itself() {
+		$this->assertSame(
+			'Nested <b>one </b><b>two</b>' . $this->more,
+			$this->trim( 'Nested <b>one <b>two</b> three</b> four five', 3 )
+		);
+	}
+
+	/**
+	 * Markup the author never closed is closed at the cut anyway.
+	 */
+	public function test_closes_unbalanced_author_markup() {
+		$this->assertSame(
+			'Unclosed <a href="#">link never closed</a>' . $this->more,
+			$this->trim( 'Unclosed <a href="#">link never closed and more words', 4 )
+		);
+	}
+
+	/**
+	 * A closing tag with nothing to close is dropped.
+	 */
+	public function test_drops_orphan_closing_tag() {
+		$this->assertSame(
+			'Stray  closing tag here' . $this->more,
+			$this->trim( 'Stray </b> closing tag here and more', 4 )
+		);
+	}
+
+	/**
+	 * Void elements are neither counted as words nor closed.
+	 */
+	public function test_leaves_void_elements_alone() {
+		$this->assertSame(
+			'Image <img src="a.png" /> after<br /> text words' . $this->more,
+			$this->trim( 'Image <img src="a.png" /> after<br> text words more', 4 )
+		);
+	}
+
+	/**
+	 * A hyphenated custom element is a tag, not three words of text.
+	 */
+	public function test_treats_custom_elements_as_markup() {
+		$this->assertSame(
+			'Custom <my-widget>element text</my-widget>' . $this->more,
+			$this->trim( 'Custom <my-widget>element text</my-widget> here more words', 3 )
+		);
+
+		$this->assertSame(
+			'Cut <my-component>inside</my-component>' . $this->more,
+			$this->trim( 'Cut <my-component>inside element</my-component> tail', 2 )
+		);
+	}
+
+	/**
+	 * A tag name carrying a colon is markup too, and is closed at the cut.
+	 */
+	public function test_treats_namespaced_elements_as_markup() {
+		$this->assertSame(
+			'Vector <svg:use href="#i">icon label</svg:use>' . $this->more,
+			$this->trim( 'Vector <svg:use href="#i">icon label</svg:use> here more words', 3 )
+		);
+
+		$this->assertSame(
+			'Cut <svg:use href="#i">inside</svg:use>' . $this->more,
+			$this->trim( 'Cut <svg:use href="#i">inside icon</svg:use> tail', 2 )
+		);
+	}
+
+	/**
+	 * Comments carry no words, so their contents must not spend the budget.
+	 */
+	public function test_does_not_count_comments_as_words() {
+		$this->assertSame(
+			'<!-- note --><b>bold text</b> more' . $this->more,
+			$this->trim( '<!-- note --><b>bold text</b> more words here', 3 )
+		);
+	}
+
+	/**
+	 * Whitespace between kept words is preserved rather than normalised.
+	 */
+	public function test_preserves_whitespace_between_kept_words() {
+		$this->assertSame(
+			"Line\nbreaks  and\ttabs" . $this->more,
+			$this->trim( "Line\nbreaks  and\ttabs here plus more", 4 )
+		);
+	}
+
+	/**
+	 * A zero length keeps nothing.
+	 */
+	public function test_zero_length_returns_empty_string() {
+		$this->assertSame( '', $this->trim( 'a <b>b</b> c', 0 ) );
+		$this->assertSame( '', $this->trim( '', 8 ) );
+	}
+
+	/**
+	 * Text without markup is trimmed exactly as `wp_trim_words()` would.
+	 */
+	public function test_matches_core_for_text_without_markup() {
+		$text = 'one two three four five six';
+
+		foreach ( array( 1, 3, 5, 6, 25 ) as $limit ) {
+			$this->assertSame(
+				wp_trim_words( $text, $limit, $this->more ),
+				$this->trim( $text, $limit ),
+				'Diverged from wp_trim_words() at length ' . $limit
+			);
+		}
+	}
+
+	/**
+	 * Character locales keep their markup rather than falling back to core.
+	 */
+	public function test_keeps_link_in_character_counting_locales() {
+		$text = '你好世界<a href="https://example.com">链接文字</a>更多内容';
+
+		$this->assertSame(
+			'你好世界<a href="https://example.com">链接</a>' . $this->more,
+			$this->trim_by_characters( $text, 6 )
+		);
+	}
+
+	/**
+	 * Character locales spend the budget per character, whitespace included.
+	 */
+	public function test_matches_core_in_character_counting_locales() {
+		$cases = array(
+			array( 'ab cd efgh', 5 ),
+			array( 'aa bb cc dd', 4 ),
+			array( 'a b c d e f', 3 ),
+			array( '你好世界链接文字', 6 ),
+		);
+
+		foreach ( $cases as list( $text, $limit ) ) {
+			global $wp_locale;
+
+			$previous                   = $wp_locale->word_count_type;
+			$wp_locale->word_count_type = 'characters_including_spaces';
+			$core                       = wp_trim_words( $text, $limit, $this->more );
+			$wp_locale->word_count_type = $previous;
+
+			$this->assertSame(
+				$core,
+				$this->trim_by_characters( $text, $limit ),
+				'Diverged from wp_trim_words() for "' . $text . '" at length ' . $limit
+			);
+		}
+	}
+
+	/**
+	 * A text within the character budget is returned untouched.
+	 */
+	public function test_character_locales_return_short_text_unchanged() {
+		$text = '短<strong>文</strong>字';
+
+		$this->assertSame( $text, $this->trim_by_characters( $text, 25 ) );
+	}
+
+	/**
+	 * The `wp_trim_words` filter runs on the result, as it does in core.
+	 */
+	public function test_applies_the_wp_trim_words_filter() {
+		$calls = array();
+
+		$capture = function ( $trimmed, $num_words, $more, $original ) use ( &$calls ) {
+			$calls[] = compact( 'num_words', 'more', 'original' );
+
+			return strtoupper( $trimmed );
+		};
+
+		add_filter( 'wp_trim_words', $capture, 10, 4 );
+
+		$text = 'one <b>two</b> three four five';
+
+		// Both the trimmed and the untrimmed return paths go through the filter.
+		$this->assertSame( 'ONE <B>TWO</B> THREE' . strtoupper( $this->more ), $this->trim( $text, 3 ) );
+		$this->assertSame( strtoupper( $text ), $this->trim( $text, 25 ) );
+
+		remove_filter( 'wp_trim_words', $capture, 10 );
+
+		$this->assertCount( 2, $calls );
+		$this->assertSame( 3, $calls[0]['num_words'] );
+		$this->assertSame( $this->more, $calls[0]['more'] );
+		$this->assertSame( $text, $calls[0]['original'] );
+	}
+
+	/**
+	 * The rendered archive excerpt keeps the link of a hand-written excerpt.
+	 */
+	public function test_rendered_excerpt_keeps_the_link() {
+		$post_id = self::factory()->post->create(
+			array(
+				'post_content' => 'Body content, not used by this assertion.',
+				'post_excerpt' => 'Read the <a href="https://example.com">full announcement</a> and then a long tail of words to drop',
+			)
+		);
+
+		$GLOBALS['post'] = get_post( $post_id );
+		setup_postdata( $GLOBALS['post'] );
+		set_theme_mod( 'neve_post_excerpt_length', 8 );
+
+		$partial = new \Neve\Views\Partials\Excerpt();
+
+		ob_start();
+		$partial->render_post_excerpt( 'index', $post_id );
+		$output = (string) ob_get_clean();
+
+		remove_theme_mod( 'neve_post_excerpt_length' );
+		wp_reset_postdata();
+
+		$this->assertStringContainsString( '<a href="https://example.com">full announcement</a>', $output );
+		$this->assertStringNotContainsString( 'to drop', $output );
+	}
+}


### PR DESCRIPTION
### Summary
Preserves HTML markup when excerpts are trimmed, and adds corresponding end-to-end tests to ensure the new behavior works as expected.

## Check before Pull Request is ready:

* [x] I have [written a test](CONTRIBUTING.md#writing-an-acceptance-test) and included it in this PR
* [x] I have [run all tests](CONTRIBUTING.md#run-tests) and they pass
* [x] The code passes when [running the PHP CodeSniffer](CONTRIBUTING.md#run-php-codesniffer)
* [x] Code meets [WordPress Coding Standards](CONTRIBUTING.md#coding-standards) for PHP, HTML, CSS and JS
* [x] [Security and Sanitization](CONTRIBUTING.md#security-and-sanitization) requirements have been followed
* [x] I have assigned a reviewer or two to review this PR

Closes https://github.com/Codeinwp/neve/issues/4598