### PR TITLE
Fixed transparent header retaining a shadow line

### DIFF
--- a/assets/scss/components/hfg/frontend/layout/_general.scss
+++ b/assets/scss/components/hfg/frontend/layout/_general.scss
@@ -140,6 +140,6 @@ $desktop: map-get($gl-devices-list, desktop);
 	grid-template-columns: 1fr auto 1fr;
 }
 
-.hfg_header.site-header {
+.hfg_header.site-header:not(.neve-transparent-header) {
 	box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.1);
 }


### PR DESCRIPTION
## Summary
- Transparent headers still showed a faint shadow line along the bottom edge, even with all row border widths set to 0.
- `.hfg_header.site-header { box-shadow: 0 -1px 3px rgba(0,0,0,.1); }` in `_general.scss` had no exception for the transparent header state, unlike the sibling `background`/`::before` overlay rules on `#header-grid.global-styled`, which already skip themselves via `:not(.neve-transparent-header)`.
- Added the same `:not(.neve-transparent-header)` guard to the box-shadow rule.

## Related issue
Codeinwp/neve-pro-addon#3254 — that issue's diagnosis pointed at the Pro addon's `_transparent-header.scss` sticky/non-sticky branches, but on a live repro the Pro `header_footer_grid` stylesheet wasn't loaded at all (only its JS was enqueued). The shadow is applied unconditionally by this free-theme rule instead.

## Test plan
- [ ] Enable transparent header (Customize > Header > Global Header Settings > Style > Enable Transparent Header).
- [ ] Set all active row border widths to 0.
- [ ] Confirm no shadow/line is visible along the header's bottom edge, with a background color behind it that would make a faint line visible.
- [ ] Confirm non-transparent headers still show the shadow as before.