### PR TITLE
Handle array input in the logo JSON sanitizer

### DIFF
--- a/header-footer-grid/Core/Components/Logo.php
+++ b/header-footer-grid/Core/Components/Logo.php
@@ -303,12 +303,18 @@ JS;
 	/**
 	 * Sanitize the logo json
 	 *
-	 * @param string $input A json data for the logo component.
+	 * @param mixed $input A json data for the logo component.
 	 *
 	 * @return string
 	 */
 	public static function sanitize_logo_json( $input ) {
-		$inputs = json_decode( $input, true );
+		if ( is_array( $input ) ) {
+			$inputs = $input;
+			$input  = wp_json_encode( $input );
+		} else {
+			$inputs = is_string( $input ) ? json_decode( $input, true ) : null;
+		}
+
 		if ( is_array( $inputs ) && ! empty( $inputs ) && ! empty( $input ) ) {
 			return $input;
 		}

--- a/tests/test-neve-sanitization.php
+++ b/tests/test-neve-sanitization.php
@@ -158,6 +158,22 @@ class TestSanitization extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Logo data can already be decoded when it reaches the sanitizer.
+	 */
+	public function test_logo_json_sanitizer_accepts_array_input() {
+		$input = array(
+			'light' => 12,
+			'dark'  => 34,
+			'same'  => false,
+		);
+
+		$this->assertSame(
+			wp_json_encode( $input ),
+			\HFG\Core\Components\Logo::sanitize_logo_json( $input )
+		);
+	}
+
+	/**
 	 * Test that only well formed CSS variable expressions are treated as CSS variables.
 	 */
 	public function test_is_css_var() {


### PR DESCRIPTION
### Summary

Accepts already-decoded array values in the Header Footer Grid logo sanitizer and serializes valid data before returning it. Other unexpected values continue to fall back to the current logo defaults.

### Will affect visual aspect of the product

NO

### Screenshots

Not applicable.

### Test instructions

- Pass a light, dark, and same logo array to Logo::sanitize_logo_json().
- Confirm the method returns the equivalent JSON value without a TypeError.
- Run the Neve PHPUnit suite.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [x] I have run all tests and they pass
* [x] The code passes PHP CodeSniffer
* [x] Code meets WordPress Coding Standards
* [x] Security and sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR

Closes #4607.