### PR TITLE
Handle array values in Mods::to_json()

### DIFF
--- a/inc/core/settings/mods.php
+++ b/inc/core/settings/mods.php
@@ -200,7 +200,13 @@ class Mods {
 	 * @return mixed
 	 */
 	public static function to_json( $key, $default = false, $as_array = true ) {
-		return json_decode( self::get( $key, $default ), $as_array );
+		$value = self::get( $key, $default );
+
+		if ( is_array( $value ) ) {
+			$value = wp_json_encode( $value );
+		}
+
+		return json_decode( $value, $as_array );
 	}
 
 	/**

--- a/tests/test-neve-mods-manager.php
+++ b/tests/test-neve-mods-manager.php
@@ -90,4 +90,23 @@ class TestNeveModsManager extends WP_UnitTestCase {
 		$mod_value = \Neve\Core\Settings\Mods::to_json( 'test_mod4' );
 		$this->assertEquals( $mod_value, [ 'subkey' => 3 ] );
 	}
+
+	/**
+	 * Test an already-decoded responsive value.
+	 */
+	public function test_to_json_accepts_array_value() {
+		$value = array(
+			'mobile'  => 14,
+			'tablet'  => 16,
+			'desktop' => 18,
+		);
+
+		\Neve\Core\Settings\Mods::set( 'test_mod_array', $value );
+
+		$this->assertSame( $value, \Neve\Core\Settings\Mods::to_json( 'test_mod_array' ) );
+		$this->assertEquals(
+			json_decode( wp_json_encode( $value ) ),
+			\Neve\Core\Settings\Mods::to_json( 'test_mod_array', false, false )
+		);
+	}
 }


### PR DESCRIPTION
### Summary

Serializes already-decoded array theme mods before passing them through the existing JSON decode path. This preserves both array and object return modes and prevents frontend dynamic CSS generation from failing on legacy responsive values.

### Will affect visual aspect of the product

NO

### Screenshots

Not applicable.

### Test instructions

- Store a responsive theme mod as an array.
- Call Mods::to_json() in both array and object modes.
- Confirm both representations are returned without a TypeError.
- Run the Neve PHPUnit suite.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [x] I have run all tests and they pass
* [x] The code passes PHP CodeSniffer
* [x] Code meets WordPress Coding Standards
* [x] Security and sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR

Closes #4610.