### PR TITLE
Fix crash when the Google Fonts filter returns a non-array

### DIFF
--- a/globals/utilities.php
+++ b/globals/utilities.php
@@ -439,7 +439,9 @@ function neve_get_google_fonts( $with_variants = false ) {
 	$fonts = neve_require_array( NEVE_MAIN_DIR . 'globals/google-fonts.php' );
 
 	if ( $with_variants ) {
-		return apply_filters( 'neve_google_fonts_with_variants_array', $fonts );
+		$fonts = apply_filters( 'neve_google_fonts_with_variants_array', $fonts );
+
+		return is_array( $fonts ) ? $fonts : array();
 	}
 
 	return apply_filters( 'neve_google_fonts_array', array_keys( $fonts ) );

--- a/tests/test-neve-file-guards.php
+++ b/tests/test-neve-file-guards.php
@@ -160,6 +160,28 @@ class TestNeveFileGuards extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A third-party filter must not replace the variant catalog with a scalar.
+	 */
+	public function testGoogleFontVariantsRejectNonArrayFilterResults() {
+		$previous_families = \Neve\Views\Font_Manager::$font_families;
+		\Neve\Views\Font_Manager::$font_families = array(
+			'Roboto' => array( '400' ),
+		);
+
+		add_filter( 'neve_google_fonts_with_variants_array', '__return_false' );
+
+		try {
+			$this->assertSame( array(), neve_get_google_fonts( true ) );
+			( new \Neve\Views\Font_Manager() )->register_google_fonts();
+			$this->assertFalse( wp_style_is( 'neve-google-font-roboto', 'enqueued' ) );
+		} finally {
+			remove_filter( 'neve_google_fonts_with_variants_array', '__return_false' );
+			\Neve\Views\Font_Manager::$font_families = $previous_families;
+			wp_dequeue_style( 'neve-google-font-roboto' );
+		}
+	}
+
+	/**
 	 * Enqueue the customizer controls with a given font list in place.
 	 *
 	 * neve_get_google_fonts() runs its result through this filter, so it can


### PR DESCRIPTION
### Summary

Normalizes the filtered Google Fonts variant catalog to an empty array when a callback returns an invalid scalar value. This prevents array_keys() from crashing font registration while preserving valid filtered catalogs.

### Will affect visual aspect of the product

NO

### Screenshots

Not applicable.

### Test instructions

- Add a callback to neve_google_fonts_with_variants_array that returns false.
- Register a Google font and run the frontend font registration callback.
- Confirm the request completes and no invalid font stylesheet is enqueued.
- Run the Neve PHPUnit suite.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [x] I have run all tests and they pass
* [x] The code passes PHP CodeSniffer
* [x] Code meets WordPress Coding Standards
* [x] Security and sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR

Closes #4604.