### PR TITLE
Guard scroll-to-top callbacks when the options class is unavailable

### DIFF
--- a/inc/views/scroll_to_top.php
+++ b/inc/views/scroll_to_top.php
@@ -31,7 +31,7 @@ class Scroll_To_Top extends Base_View {
 	 * @return void
 	 */
 	public function scroll_to_top_amp() {
-		if ( ! Scroll_To_Top_Options::is_enabled() ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
@@ -91,7 +91,7 @@ class Scroll_To_Top extends Base_View {
 	 * @return void
 	 */
 	public function enqueue_scripts() {
-		if ( ! Scroll_To_Top_Options::is_enabled() ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
@@ -131,7 +131,7 @@ class Scroll_To_Top extends Base_View {
 	 * @return void
 	 */
 	public function render_button() {
-		if ( ! Scroll_To_Top_Options::is_enabled() ) {
+		if ( ! $this->is_enabled() ) {
 			return;
 		}
 
@@ -166,6 +166,26 @@ class Scroll_To_Top extends Base_View {
 		}
 		
 		echo '</button>';
+	}
+
+	/**
+	 * Check whether the scroll-to-top feature is available and enabled.
+	 *
+	 * @return bool
+	 */
+	private function is_enabled() {
+		$options_class = $this->get_options_class();
+
+		return class_exists( $options_class ) && $options_class::is_enabled();
+	}
+
+	/**
+	 * Get the scroll-to-top options class.
+	 *
+	 * @return class-string
+	 */
+	protected function get_options_class() {
+		return Scroll_To_Top_Options::class;
 	}
 
 	/**

--- a/tests/test-neve-scroll-to-top-guards.php
+++ b/tests/test-neve-scroll-to-top-guards.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Tests for scroll-to-top dependency guards.
+ *
+ * @package neve
+ */
+
+/**
+ * Scroll-to-top view whose options dependency cannot be resolved.
+ */
+class NeveMissingScrollToTopOptionsView extends \Neve\Views\Scroll_To_Top {
+
+	/**
+	 * Return a deliberately unavailable dependency.
+	 *
+	 * @return string
+	 */
+	protected function get_options_class() {
+		return 'Neve\\Tests\\Missing_Scroll_To_Top_Options';
+	}
+}
+
+/**
+ * Class TestNeveScrollToTopGuards
+ */
+class TestNeveScrollToTopGuards extends WP_UnitTestCase {
+
+	/**
+	 * Every public callback must be a no-op when the options class is missing.
+	 */
+	public function test_callbacks_survive_missing_options_class() {
+		$view = new NeveMissingScrollToTopOptionsView();
+
+		$view->enqueue_scripts();
+		$this->assertFalse( wp_script_is( 'neve-scroll-to-top', 'enqueued' ) );
+
+		ob_start();
+		$view->scroll_to_top_amp();
+		$view->render_button();
+		$output = ob_get_clean();
+
+		$this->assertSame( '', $output );
+	}
+}


### PR DESCRIPTION
### Summary

Routes all scroll-to-top callbacks through a shared availability check. When the Customizer options class cannot be loaded, script enqueueing, AMP markup, and button rendering now return safely instead of terminating the frontend request.

### Will affect visual aspect of the product

NO

### Screenshots

Not applicable.

### Test instructions

- Make the scroll-to-top options class unavailable while keeping the frontend view loadable.
- Invoke the enqueue, AMP, and render callbacks.
- Confirm they produce no output or enqueued script and do not throw.
- Run the Neve PHPUnit suite.

## Check before Pull Request is ready:

* [x] I have written a test and included it in this PR
* [x] I have run all tests and they pass
* [x] The code passes PHP CodeSniffer
* [x] Code meets WordPress Coding Standards
* [x] Security and sanitization requirements have been followed
* [ ] I have assigned a reviewer or two to review this PR

Closes #4606.