### PR TITLE
Fix missing form label typography fallbacks

### DIFF
--- a/assets/scss/components/main/_extends.scss
+++ b/assets/scss/components/main/_extends.scss
@@ -124,9 +124,9 @@
 
 %nv-form-labels {
 	font-weight: var(--formlabelfontweight, var(--bodyfontweight));
-	text-transform: var(--formlabeltexttransform);
-	letter-spacing: var(--formlabelletterspacing);
-	line-height: var(--formlabellineheight);
+	text-transform: var(--formlabeltexttransform, none);
+	letter-spacing: var(--formlabelletterspacing, normal);
+	line-height: var(--formlabellineheight, var(--bodylineheight));
 	font-size: var(--formlabelfontsize, var(--bodyfontsize));
 }
 


### PR DESCRIPTION
## Summary

- add CSS fallbacks for every form-label typography custom property
- inherit font size, weight, and line height from body typography
- use neutral defaults for transform and letter spacing

## Testing

- yarn run lint:scss

Closes #4510